### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
   - stable
   - beta
@@ -17,7 +18,7 @@ addons:
 env:
   - PATH=$HOME/.cargo/bin:$PATH
 before_script:
-  - cargo install cargo-travis
+  - cargo install cargo-travis -f
 script:
   - cargo test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,22 @@ rust:
   - stable
   - beta
   - nightly
+# necessary for travis-cargo coveralls
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev
+env:
+  - PATH=$HOME/.local/bin:$PATH
+before_script:
+  - pip install 'travis-cargo<0.2' --user
+script:
+  - travis-cargo test
+after_success:
+  - travis-cargo coveralls --no-sudo --verify
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-# necessary for travis-cargo coveralls
+# dependencies of kcov, used by coverage
 addons:
   apt:
     packages:
@@ -11,14 +11,17 @@ addons:
       - libelf-dev
       - libdw-dev
       - binutils-dev
+      - cmake
+    sources:
+      - kalakris-cmake
 env:
-  - PATH=$HOME/.local/bin:$PATH
+  - PATH=$HOME/.cargo/bin:$PATH
 before_script:
-  - pip install 'travis-cargo<0.2' --user
+  - cargo install cargo-travis
 script:
-  - travis-cargo test
+  - cargo test
 after_success:
-  - travis-cargo coveralls --no-sudo --verify
+  - cargo coveralls
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ linked-hash-map = "0.4"
 
 [dev-dependencies]
 gotham_derive = { version = "0.1.0", path = "gotham_derive" }
+
+[badges]
+travis-ci = { repository = "gotham-rs/gotham", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gotham
 
+[![Linux build status](https://travis-ci.org/gotham-rs/gotham.svg?branch=master)](https://travis-ci.org/gotham-rs/gotham)
+
 A flexible web framework that does not sacrifice safety, security or speed.
 
 The Gotham core team loves many of the elegant concepts that are found in dynamically typed web application frameworks, such as Rails, Phoenix and Django and aspire to achieve them with the type and memory safety guarantees provided by Rust.


### PR DESCRIPTION
You'll need to enable Travis for the repository. I'd recommend doing that *before* this PR gets merged, so we can check that the `.travis.yml` works (note: turn off the "build without .travis.yml" option so it doesn't try to use the default ruby build on master).

Fixes #1 

From that issue:

> If possible the two releases prior to the current stable Rust also.

Unfortunately that's rather hard to do without hard coding the versions 🙁 . Maybe in a future PR (or if you really want it I guess I could try with this PR).

Edit: now also fixes #4 with coveralls integration through travis-cargo. You'll need to use enable coveralls for the repository to activate that (through their website).