### PR TITLE
Fix the blog URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ These policies are in effect for any environment or tool that supports the Gotha
 ## News
 You can keep up with Gotham at:
 
-* [Our blog](https://staging.gotham.rs/blog)
+* [Our blog](https://gotham.rs/blog)
 * [On Twitter](https://twitter.com/gotham_rs)


### PR DESCRIPTION
It looks like the [current blog URL](https://staging.gotham.rs/blog) is not working and is pointing to a staging environment — this should point to the [regular blog URL](https://gotham.rs/blog) instead.