### PR TITLE
Make src/test/mod.rs appear only in test config

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -4,6 +4,9 @@
 //!
 //! [TestServer::new]: struct.TestServer.html#method.new
 
+// Workaround for std::os::unix stuff below. Would allow Gotham to be at least used on Windows
+#![cfg(test)]
+
 use std::{cell, io, net, time};
 // TODO: Cross platform
 use std::os::unix::net::UnixStream;


### PR DESCRIPTION
The file named uses some Unix-only features for testing. This prevents Gotham to be used on non-Unix systems, event if people don't run tests there. Adding module-wide configuration gate should prevent it from compiling in non-test configurations.