### PR TITLE
Add Appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+# Originally based on:
+# https://raw.githubusercontent.com/hyperium/hyper/207fca63ce/.appveyor.yml
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+  - TARGET: i686-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-gnu
+  - TARGET: i686-pc-windows-gnu
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -vV
+  - cargo -vV
+build: false
+test_script:
+  - cargo build
+  - cargo test

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -7,9 +7,8 @@
 use std::{cell, io, net, time};
 use std::net::{TcpListener, TcpStream};
 use hyper::{self, client, server};
-use futures::{future, Future, Async, Stream};
+use futures::{future, Future, Stream};
 use tokio_core::reactor;
-use tokio_io::{AsyncRead, AsyncWrite};
 use mio;
 
 /// The `TestServer` type, which is used as a harness when writing test cases for Hyper services


### PR DESCRIPTION
Enabled CI for Windows, to ensure we retain compatibility there.

Also includes a sneaky fix for a couple of unused imports that snuck in with #30.