### PR TITLE
Improve concurrency by removing CpuPool from NewHandlerService

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.4"
 rand = "0.3"
 linked-hash-map = "0.4"
 num_cpus = "1"
+crossbeam = "0.3"
 
 [dev-dependencies]
 gotham_derive = { version = "0.1.0", path = "gotham_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ chrono = "0.3"
 base64 = "0.4"
 rand = "0.3"
 linked-hash-map = "0.4"
+num_cpus = "1"
 
 [dev-dependencies]
 gotham_derive = { version = "0.1.0", path = "gotham_derive" }

--- a/examples/kitchen-sink/src/main.rs
+++ b/examples/kitchen-sink/src/main.rs
@@ -15,7 +15,6 @@ mod middleware;
 use futures::{future, Future, Stream};
 
 use hyper::{Request, Response, Method, StatusCode};
-use hyper::server::Http;
 
 use log::LogLevelFilter;
 
@@ -30,7 +29,7 @@ use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, P
 use gotham::router::route::matcher::MethodOnlyRouteMatcher;
 use gotham::router::tree::TreeBuilder;
 use gotham::router::tree::node::{NodeBuilder, SegmentType};
-use gotham::handler::{NewHandler, HandlerFuture, NewHandlerService, IntoHandlerError};
+use gotham::handler::{NewHandler, HandlerFuture, IntoHandlerError};
 use gotham::middleware::pipeline::new_pipeline;
 use gotham::state::{State, FromState};
 use gotham::http::response::create_response;
@@ -294,6 +293,7 @@ fn main() {
         .level(LogLevelFilter::Error)
         .level_for("gotham", log::LogLevelFilter::Error)
         .level_for("gotham::state", log::LogLevelFilter::Error)
+        .level_for("gotham::start", log::LogLevelFilter::Info)
         .level_for("kitchen_sink", log::LogLevelFilter::Error)
         .chain(std::io::stdout())
         .format(|out, message, record| {
@@ -309,14 +309,5 @@ fn main() {
         .unwrap();
 
     let addr = "127.0.0.1:7878".parse().unwrap();
-
-    let server = Http::new()
-        .bind(&addr, NewHandlerService::new(build_router()))
-        .unwrap();
-
-    println!(
-        "Listening on http://{} with 1 thread.",
-        server.local_addr().unwrap()
-    );
-    server.run().unwrap();
+    gotham::start(addr, build_router());
 }

--- a/examples/kitchen-sink/src/main.rs
+++ b/examples/kitchen-sink/src/main.rs
@@ -308,6 +308,5 @@ fn main() {
         .apply()
         .unwrap();
 
-    let addr = "127.0.0.1:7878".parse().unwrap();
-    gotham::start(addr, build_router());
+    gotham::start("127.0.0.1:7878", build_router());
 }

--- a/examples/kitchen-sink/src/middleware.rs
+++ b/examples/kitchen-sink/src/middleware.rs
@@ -36,17 +36,17 @@ impl Middleware for KitchenSinkMiddleware {
         let result = chain(state, request);
         let header_name = self.header_name;
 
-        result
-            .and_then(move |(state, mut response)| {
-                {
-                    let data = state.borrow::<KitchenSinkData>().unwrap();
-                    let headers = response.headers_mut();
-                    headers.set_raw(header_name, data.header_value.to_owned());
-                    headers.set_raw("X-Request-ID", request_id(&state));
-                }
+        let f = result.and_then(move |(state, mut response)| {
+            {
+                let data = state.borrow::<KitchenSinkData>().unwrap();
+                let headers = response.headers_mut();
+                headers.set_raw(header_name, data.header_value.to_owned());
+                headers.set_raw("X-Request-ID", request_id(&state));
+            }
 
-                future::ok((state, response))
-            })
-            .boxed()
+            future::ok((state, response))
+        });
+
+        Box::new(f)
     }
 }

--- a/src/clone_sockets.rs
+++ b/src/clone_sockets.rs
@@ -1,0 +1,60 @@
+use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
+use std::thread;
+use std::sync::Arc;
+
+use hyper::server::{Http, NewService};
+use tokio_core;
+use tokio_core::reactor::Core;
+use futures::Stream;
+
+use handler::{NewHandler, NewHandlerService};
+
+pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
+where
+    NH: NewHandler + 'static,
+    A: ToSocketAddrs,
+{
+    let (listener, addr) = super::tcp_listener(addr);
+
+    let protocol = Arc::new(Http::new());
+    let service = NewHandlerService::new(new_handler);
+
+    info!(
+        target: "gotham::start",
+        " Gotham listening on http://{} with {} threads",
+        addr,
+        threads,
+    );
+
+    for _ in 0..threads - 1 {
+        let listener = listener.try_clone().expect("unable to clone TCP listener");
+        let protocol = protocol.clone();
+        let service = service.clone();
+        thread::spawn(move || serve(listener, &addr, &protocol, &service));
+    }
+
+    serve(listener, &addr, &protocol, &service);
+}
+
+fn serve<NH>(
+    listener: TcpListener,
+    addr: &SocketAddr,
+    protocol: &Http,
+    new_service: &NewHandlerService<NH>,
+) where
+    NH: NewHandler + 'static,
+{
+    let mut core = Core::new().expect("unable to spawn tokio reactor");
+    let handle = core.handle();
+
+    let listener = tokio_core::net::TcpListener::from_listener(listener, addr, &handle)
+        .expect("unable to convert TCP listener to tokio listener");
+
+    core.run(listener.incoming().for_each(|(socket, addr)| {
+        match new_service.new_service() {
+            Ok(service) => protocol.bind_connection(&handle, socket, addr, service),
+            Err(e) => error!(" unable to spawn service: {:?}", e),
+        }
+        Ok(())
+    })).expect("unable to run reactor over listener");
+}

--- a/src/clone_sockets.rs
+++ b/src/clone_sockets.rs
@@ -9,6 +9,7 @@ use futures::Stream;
 
 use handler::{NewHandler, NewHandlerService};
 
+/// Starts a Gotham application, with the given number of threads.
 pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
 where
     NH: NewHandler + 'static,

--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -11,7 +11,7 @@ use http::response::create_response;
 /// `Response`.
 pub struct HandlerError {
     status_code: StatusCode,
-    cause: Box<Error + Send>,
+    cause: Box<Error>,
 }
 
 /// Allows conversion into a HandlerError from an implementing type.
@@ -50,7 +50,7 @@ pub trait IntoHandlerError {
 
 impl<E> IntoHandlerError for E
 where
-    E: Error + Send + 'static,
+    E: Error + 'static,
 {
     fn into_handler_error(self) -> HandlerError {
         HandlerError {

--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -33,7 +33,7 @@ pub struct HandlerError {
 /// # #[allow(dead_code)]
 /// fn my_handler(state: State, _request: Request) -> Box<HandlerFuture> {
 ///     match File::open("config.toml") {
-///         Err(e) => future::err((state, e.into_handler_error())).boxed(),
+///         Err(e) => Box::new(future::err((state, e.into_handler_error()))),
 ///         Ok(_) => // Create and return a response
 /// #                unimplemented!(),
 ///     }

--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -28,7 +28,7 @@ pub struct HandlerError {
 /// # use gotham::state::State;
 /// # use gotham::handler::{IntoHandlerError, HandlerFuture};
 /// # use hyper::Request;
-/// # use futures::{future, Future};
+/// # use futures::future;
 /// #
 /// # #[allow(dead_code)]
 /// fn my_handler(state: State, _request: Request) -> Box<HandlerFuture> {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -28,7 +28,7 @@ pub use self::error::{HandlerError, IntoHandlerError};
 ///
 /// When the `Future` resolves to an error, the `(State, HandlerError)` value is used to generate
 /// an appropriate HTTP error response.
-pub type HandlerFuture = Future<Item = (State, Response), Error = (State, HandlerError)> + Send;
+pub type HandlerFuture = Future<Item = (State, Response), Error = (State, HandlerError)>;
 
 /// Wraps a `NewHandler` to provide a `hyper::server::NewService` implementation for Gotham
 /// handlers.
@@ -264,13 +264,13 @@ where
 /// `Service`][tokio-simple-server]
 ///
 /// [tokio-simple-server]: https://tokio.rs/docs/getting-started/simple-server/
-pub trait Handler: Send {
+pub trait Handler {
     /// Handles the request, returning a boxed future which resolves to a response.
     fn handle(self, state: State, request: Request) -> Box<HandlerFuture>;
 }
 
 /// Creates new `Handler` values.
-pub trait NewHandler: Send + Sync {
+pub trait NewHandler {
     /// The type of `Handler` created by the implementor.
     type Instance: Handler;
 
@@ -280,7 +280,7 @@ pub trait NewHandler: Send + Sync {
 
 impl<F, H> NewHandler for F
 where
-    F: Fn() -> io::Result<H> + Send + Sync,
+    F: Fn() -> io::Result<H>,
     H: Handler,
 {
     type Instance = H;
@@ -397,7 +397,7 @@ impl IntoResponse for Response {
 
 impl<F, R> Handler for F
 where
-    F: FnOnce(State, Request) -> R + Send,
+    F: FnOnce(State, Request) -> R,
     R: IntoHandlerFuture,
 {
     fn handle(self, state: State, req: Request) -> Box<HandlerFuture> {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -14,7 +14,6 @@ use hyper;
 use hyper::server::{NewService, Service};
 use hyper::{Request, Response};
 use futures::{future, Future};
-use futures_cpupool::{CpuPool, CpuFuture};
 
 use state::{State, set_request_id, request_id};
 use http::request::path::RequestPathSegments;
@@ -37,7 +36,6 @@ where
     T: NewHandler + 'static,
 {
     t: Arc<T>,
-    pool: Arc<CpuPool>,
 }
 
 impl<T> Clone for NewHandlerService<T>
@@ -45,10 +43,7 @@ where
     T: NewHandler + 'static,
 {
     fn clone(&self) -> Self {
-        NewHandlerService {
-            t: self.t.clone(),
-            pool: self.pool.clone(),
-        }
+        NewHandlerService { t: self.t.clone() }
     }
 }
 
@@ -126,10 +121,7 @@ where
     /// # }
     /// ```
     pub fn new(t: T) -> NewHandlerService<T> {
-        NewHandlerService {
-            t: Arc::new(t),
-            pool: Arc::new(CpuPool::new_num_cpus()),
-        }
+        NewHandlerService { t: Arc::new(t) }
     }
 }
 
@@ -154,7 +146,7 @@ where
     type Request = Request;
     type Response = Response;
     type Error = hyper::Error;
-    type Future = CpuFuture<Self::Response, Self::Error>;
+    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
         let s = chrono::UTC::now();
@@ -183,72 +175,71 @@ where
         // immediately consuming it.
         match self.t.new_handler() {
             Ok(handler) => {
-                self.pool.spawn_fn(move || {
-                    handler
-                        .handle(state, req)
-                        .and_then(move |(state, res)| {
-                            let f = chrono::UTC::now();
+                let f = handler
+                    .handle(state, req)
+                    .and_then(move |(state, res)| {
+                        let f = chrono::UTC::now();
+                        match f.signed_duration_since(s).num_microseconds() {
+                            Some(dur) => {
+                                info!(
+                                    "[RESPONSE][{}][{}][{}][{}µs]",
+                                    request_id(&state),
+                                    res.version(),
+                                    res.status(),
+                                    dur
+                                );
+
+                                future::ok(res.with_header(XRuntimeMicroseconds(dur)))
+                            }
+                            None => {
+                                // Valid response is still sent to client in this case but
+                                // timing has failed and should be looked into.
+                                error!(
+                                    "[RESPONSE][{}][{}][{}][invalid]",
+                                    request_id(&state),
+                                    res.version(),
+                                    res.status()
+                                );
+                                future::ok(res)
+                            }
+                        }
+                    })
+                    .or_else(move |(state, err)| {
+                        let f = chrono::UTC::now();
+
+                        {
+                            // HandlerError::cause() is far more interesting for logging,
+                            // but the API doesn't guarantee its presence (even though it
+                            // always is).
+                            let err_description = err.cause().map(Error::description).unwrap_or(
+                                err.description(),
+                            );
+
                             match f.signed_duration_since(s).num_microseconds() {
                                 Some(dur) => {
-                                    info!(
-                                        "[RESPONSE][{}][{}][{}][{}µs]",
+                                    error!(
+                                        "[ERROR][{}][Error: {}][{}]",
                                         request_id(&state),
-                                        res.version(),
-                                        res.status(),
+                                        err_description,
                                         dur
                                     );
-
-                                    future::ok(res.with_header(XRuntimeMicroseconds(dur)))
                                 }
                                 None => {
-                                    // Valid response is still sent to client in this case but
-                                    // timing has failed and should be looked into.
                                     error!(
-                                        "[RESPONSE][{}][{}][{}][invalid]",
+                                        "[ERROR][{}][Error: {}][invalid]",
                                         request_id(&state),
-                                        res.version(),
-                                        res.status()
+                                        err_description
                                     );
-                                    future::ok(res)
                                 }
                             }
-                        })
-                        .or_else(move |(state, err)| {
-                            let f = chrono::UTC::now();
+                        }
 
-                            {
-                                // HandlerError::cause() is far more interesting for logging,
-                                // but the API doesn't guarantee its presence (even though it
-                                // always is).
-                                let err_description = err.cause()
-                                    .map(Error::description)
-                                    .unwrap_or(err.description());
+                        future::ok(err.into_response(&state))
+                    });
 
-                                match f.signed_duration_since(s).num_microseconds() {
-                                    Some(dur) => {
-                                        error!(
-                                            "[ERROR][{}][Error: {}][{}]",
-                                            request_id(&state),
-                                            err_description,
-                                            dur
-                                        );
-                                    }
-                                    None => {
-                                        error!(
-                                            "[ERROR][{}][Error: {}][invalid]",
-                                            request_id(&state),
-                                            err_description
-                                        );
-                                    }
-                                }
-                            }
-
-                            future::ok(err.into_response(&state))
-                        })
-                        .boxed()
-                })
+                Box::new(f)
             }
-            Err(e) => self.pool.spawn(future::err(e.into())),
+            Err(e) => Box::new(future::err(e.into())),
         }
     }
 }
@@ -306,7 +297,7 @@ where
     fn into_handler_future(self) -> Box<HandlerFuture> {
         let (state, t) = self;
         let response = t.into_response(&state);
-        future::ok((state, response)).boxed()
+        Box::new(future::ok((state, response)))
     }
 }
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -261,7 +261,7 @@ pub trait Handler {
 }
 
 /// Creates new `Handler` values.
-pub trait NewHandler {
+pub trait NewHandler: Send + Sync {
     /// The type of `Handler` created by the implementor.
     type Instance: Handler;
 
@@ -271,7 +271,7 @@ pub trait NewHandler {
 
 impl<F, H> NewHandler for F
 where
-    F: Fn() -> io::Result<H>,
+    F: Fn() -> io::Result<H> + Send + Sync,
     H: Handler,
 {
     type Instance = H;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate base64;
 extern crate rmp_serde;
 extern crate linked_hash_map;
 extern crate num_cpus;
+extern crate crossbeam;
 
 #[cfg(test)]
 #[macro_use]
@@ -42,15 +43,18 @@ pub mod router;
 pub mod state;
 pub mod test;
 
+#[cfg(not(windows))]
+mod clone_sockets;
+#[cfg(not(windows))]
+pub use clone_sockets::start_with_num_threads;
+
+#[cfg(windows)]
+mod socket_queue;
+#[cfg(windows)]
+pub use socket_queue::start_with_num_threads;
+
 use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
-use std::thread;
-use std::sync::Arc;
-
-use hyper::server::{Http, NewService};
-use tokio_core::reactor::Core;
-use futures::Stream;
-
-use handler::{NewHandler, NewHandlerService};
+use handler::NewHandler;
 
 pub fn start<NH, A>(addr: A, new_handler: NH)
 where
@@ -61,9 +65,8 @@ where
     start_with_num_threads(addr, threads, new_handler)
 }
 
-pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
+fn tcp_listener<A>(addr: A) -> (TcpListener, SocketAddr)
 where
-    NH: NewHandler + 'static,
     A: ToSocketAddrs,
 {
     let addr = match addr.to_socket_addrs().map(|ref mut i| i.next()) {
@@ -73,45 +76,6 @@ where
     };
 
     let listener = TcpListener::bind(addr).expect("unable to open TCP listener");
-    let protocol = Arc::new(Http::new());
-    let service = NewHandlerService::new(new_handler);
 
-    info!(
-        target: "gotham::start",
-        " Gotham listening on http://{} with {} threads",
-        server.local_addr().unwrap(),
-        threads,
-    );
-
-    for _ in 0..threads - 1 {
-        let listener = listener.try_clone().expect("unable to clone TCP listener");
-        let protocol = protocol.clone();
-        let service = service.clone();
-        thread::spawn(move || serve(listener, &addr, &protocol, &service));
-    }
-
-    serve(listener, &addr, &protocol, &service);
-}
-
-fn serve<NH>(
-    listener: TcpListener,
-    addr: &SocketAddr,
-    protocol: &Http,
-    new_service: &NewHandlerService<NH>,
-) where
-    NH: NewHandler + 'static,
-{
-    let mut core = Core::new().expect("unable to spawn tokio reactor");
-    let handle = core.handle();
-
-    let listener = tokio_core::net::TcpListener::from_listener(listener, addr, &handle)
-        .expect("unable to convert TCP listener to tokio listener");
-
-    core.run(listener.incoming().for_each(|(socket, addr)| {
-        match new_service.new_service() {
-            Ok(service) => protocol.bind_connection(&handle, socket, addr, service),
-            Err(e) => error!(" unable to spawn service: {:?}", e),
-        }
-        Ok(())
-    })).expect("unable to run reactor over listener");
+    (listener, addr)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,11 @@ pub use socket_queue::start_with_num_threads;
 use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
 use handler::NewHandler;
 
+/// Starts a Gotham application, with the default number of threads (equal to the number of CPUs).
+///
+/// ## Windows
+///
+/// An additional thread is used on Windows to accept connections.
 pub fn start<NH, A>(addr: A, new_handler: NH)
 where
     NH: NewHandler + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,25 +42,39 @@ pub mod router;
 pub mod state;
 pub mod test;
 
-use std::net::SocketAddr;
-use hyper::server::Http;
+use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
+use std::thread;
+use std::sync::Arc;
+
+use hyper::server::{Http, NewService};
+use tokio_core::reactor::Core;
+use futures::Stream;
+
 use handler::{NewHandler, NewHandlerService};
 
-pub fn start<NH>(addr: SocketAddr, new_handler: NH)
+pub fn start<NH, A>(addr: A, new_handler: NH)
 where
     NH: NewHandler + 'static,
+    A: ToSocketAddrs,
 {
     let threads = num_cpus::get();
     start_with_num_threads(addr, threads, new_handler)
 }
 
-pub fn start_with_num_threads<NH>(addr: SocketAddr, threads: usize, new_handler: NH)
+pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
 where
     NH: NewHandler + 'static,
+    A: ToSocketAddrs,
 {
-    let server = Http::new()
-        .bind(&addr, NewHandlerService::new(new_handler))
-        .unwrap();
+    let addr = match addr.to_socket_addrs().map(|ref mut i| i.next()) {
+        Ok(Some(a)) => a,
+        Ok(_) => panic!("unable to resolve listener address"),
+        Err(_) => panic!("unable to parse listener address"),
+    };
+
+    let listener = TcpListener::bind(addr).expect("unable to open TCP listener");
+    let protocol = Arc::new(Http::new());
+    let service = NewHandlerService::new(new_handler);
 
     info!(
         target: "gotham::start",
@@ -69,5 +83,35 @@ where
         threads,
     );
 
-    server.run().unwrap();
+    for _ in 0..threads - 1 {
+        let listener = listener.try_clone().expect("unable to clone TCP listener");
+        let protocol = protocol.clone();
+        let service = service.clone();
+        thread::spawn(move || serve(listener, &addr, &protocol, &service));
+    }
+
+    serve(listener, &addr, &protocol, &service);
+}
+
+fn serve<NH>(
+    listener: TcpListener,
+    addr: &SocketAddr,
+    protocol: &Http,
+    new_service: &NewHandlerService<NH>,
+) where
+    NH: NewHandler + 'static,
+{
+    let mut core = Core::new().expect("unable to spawn tokio reactor");
+    let handle = core.handle();
+
+    let listener = tokio_core::net::TcpListener::from_listener(listener, addr, &handle)
+        .expect("unable to convert TCP listener to tokio listener");
+
+    core.run(listener.incoming().for_each(|(socket, addr)| {
+        match new_service.new_service() {
+            Ok(service) => protocol.bind_connection(&handle, socket, addr, service),
+            Err(e) => error!(" unable to spawn service: {:?}", e),
+        }
+        Ok(())
+    })).expect("unable to run reactor over listener");
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -101,7 +101,7 @@ pub mod session;
 ///             chain(state, req)
 ///         } else {
 ///             let response = create_response(&state, StatusCode::MethodNotAllowed, None);
-///             future::ok((state, response)).boxed()
+///             Box::new(future::ok((state, response)))
 ///         }
 ///     }
 /// }
@@ -133,7 +133,7 @@ pub mod session;
 ///         // This could be any asynchronous action. `future::lazy(_)` defers a function
 ///         // until the next cycle of tokio's event loop.
 ///         let f = future::lazy(|| future::ok(()));
-///         f.and_then(move |_| chain(state, req)).boxed()
+///         Box::new(f.and_then(move |_| chain(state, req)))
 ///     }
 /// }
 /// #

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -89,7 +89,7 @@ pub mod session;
 /// # use gotham::state::{State};
 /// # use hyper::Request;
 /// # use hyper::{Method, StatusCode};
-/// # use futures::{future, Future};
+/// # use futures::future;
 /// #
 /// struct ConditionalMiddleware;
 ///

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -30,7 +30,7 @@ pub mod session;
 ///
 /// impl Middleware for NoopMiddleware {
 ///     fn call<Chain>(self, state: State, req: Request, chain: Chain) -> Box<HandlerFuture>
-///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + Send + 'static
+///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + 'static
 ///     {
 ///         chain(state, req)
 ///     }
@@ -64,7 +64,7 @@ pub mod session;
 ///
 /// impl Middleware for MiddlewareWithStateData {
 ///     fn call<Chain>(self, mut state: State, req: Request, chain: Chain) -> Box<HandlerFuture>
-///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + Send + 'static
+///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + 'static
 ///     {
 ///         state.put(MiddlewareStateData { i: 10 });
 ///         chain(state, req)
@@ -95,7 +95,7 @@ pub mod session;
 ///
 /// impl Middleware for ConditionalMiddleware {
 ///     fn call<Chain>(self, state: State, req: Request, chain: Chain) -> Box<HandlerFuture>
-///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + Send + 'static
+///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + 'static
 ///     {
 ///         if *req.method() == Method::Get {
 ///             chain(state, req)
@@ -128,7 +128,7 @@ pub mod session;
 ///
 /// impl Middleware for AsyncMiddleware {
 ///     fn call<Chain>(self, state: State, req: Request, chain: Chain) -> Box<HandlerFuture>
-///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + Send + 'static
+///         where Chain: FnOnce(State, Request) -> Box<HandlerFuture> + 'static
 ///     {
 ///         // This could be any asynchronous action. `future::lazy(_)` defers a function
 ///         // until the next cycle of tokio's event loop.
@@ -152,7 +152,7 @@ pub trait Middleware {
     /// * Ensure to pass the same `State` to `chain`, rather than creating a new `State`.
     fn call<Chain>(self, state: State, request: Request, chain: Chain) -> Box<HandlerFuture>
     where
-        Chain: FnOnce(State, Request) -> Box<HandlerFuture> + Send + 'static,
+        Chain: FnOnce(State, Request) -> Box<HandlerFuture> + 'static,
         Self: Sized;
 }
 

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -542,7 +542,7 @@ mod tests {
 
             Ok(move |state, req| match pipeline.construct() {
                 Ok(p) => p.call(state, req, |state, req| handler.handle(state, req)),
-                Err(e) => future::err((state, e.into_handler_error())).boxed(),
+                Err(e) => Box::new(future::err((state, e.into_handler_error()))),
             })
         });
 

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -440,7 +440,7 @@ mod tests {
     use state::StateData;
     use hyper::Response;
     use hyper::StatusCode;
-    use futures::{future, Future};
+    use futures::future;
 
     fn handler(state: State, _req: Request) -> (State, Response) {
         let number = state.borrow::<Number>().unwrap().value;

--- a/src/middleware/session/backend/memory.rs
+++ b/src/middleware/session/backend/memory.rs
@@ -95,9 +95,9 @@ impl Backend for MemoryBackend {
                 match storage.get_refresh(&identifier.value) {
                     Some(&mut (ref mut instant, ref value)) => {
                         *instant = Instant::now();
-                        future::ok(Some(value.clone())).boxed()
+                        Box::new(future::ok(Some(value.clone())))
                     }
-                    None => future::ok(None).boxed(),
+                    None => Box::new(future::ok(None)),
                 }
             }
             Err(PoisonError { .. }) => {

--- a/src/middleware/session/backend/memory.rs
+++ b/src/middleware/session/backend/memory.rs
@@ -3,7 +3,7 @@ use std::time::{Instant, Duration};
 use std::{io, thread};
 
 use linked_hash_map::LinkedHashMap;
-use futures::{future, Future};
+use futures::future;
 
 use middleware::session::{SessionError, SessionIdentifier};
 use middleware::session::backend::{NewBackend, Backend, SessionFuture};
@@ -190,6 +190,7 @@ fn cleanup_once(
 mod tests {
     use super::*;
 
+    use futures::Future;
     use rand;
 
     #[test]

--- a/src/middleware/session/backend/mod.rs
+++ b/src/middleware/session/backend/mod.rs
@@ -9,20 +9,20 @@ use middleware::session::{SessionError, SessionIdentifier};
 /// Creates new `Backend` values.
 pub trait NewBackend: Sync {
     /// The type of `Backend` created by the implementor.
-    type Instance: Backend + Send + 'static;
+    type Instance: Backend + 'static;
 
     /// Create and return a new `Backend` value.
     fn new_backend(&self) -> io::Result<Self::Instance>;
 }
 
 /// Type alias for the trait objects returned by `Backend`.
-pub type SessionFuture = Future<Item = Option<Vec<u8>>, Error = SessionError> + Send;
+pub type SessionFuture = Future<Item = Option<Vec<u8>>, Error = SessionError>;
 
 /// A `Backend` receives session data and stores it, and recalls the session data subsequently.
 ///
 /// All session data is serialized into a `Vec<u8>` which is treated as opaque by the backend. The
 /// serialization format is subject to change and must not be relied upon by the `Backend`.
-pub trait Backend: Send {
+pub trait Backend {
     /// Persists a session, either creating a new session or updating an existing session.
     fn persist_session(
         &self,

--- a/src/middleware/session/mod.rs
+++ b/src/middleware/session/mod.rs
@@ -191,13 +191,13 @@ pub struct SessionCookieConfig {
 /// ```
 pub struct SessionData<T>
 where
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     value: T,
     cookie_state: SessionCookieState,
     state: SessionDataState,
     identifier: SessionIdentifier,
-    backend: Box<Backend + Send>,
+    backend: Box<Backend>,
     cookie_config: Arc<SessionCookieConfig>,
 }
 
@@ -207,7 +207,7 @@ struct SessionDropData {
 
 impl<T> SessionData<T>
 where
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     /// Discards the session, invalidating it for future use and removing the data from the
     /// `Backend`.
@@ -293,7 +293,8 @@ where
 }
 
 impl<T> StateData for SessionData<T>
-    where T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static
+where
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
 }
 
@@ -302,7 +303,6 @@ where
     T: Default
         + Serialize
         + for<'de> Deserialize<'de>
-        + Send
         + 'static,
 {
     fn take_from(s: &mut State) -> SessionData<T> {
@@ -339,7 +339,7 @@ where
 
 impl<T> Deref for SessionData<T>
 where
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     type Target = T;
 
@@ -349,7 +349,8 @@ where
 }
 
 impl<T> DerefMut for SessionData<T>
-    where T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static
+where
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     fn deref_mut(&mut self) -> &mut T {
         self.state = SessionDataState::Dirty;
@@ -418,12 +419,12 @@ where
 pub struct NewSessionMiddleware<B, T>
 where
     B: NewBackend,
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     new_backend: B,
     identifier_rng: Arc<Mutex<rng::SessionIdentifierRng>>,
     cookie_config: Arc<SessionCookieConfig>,
-    phantom: PhantomData<SessionTypePhantom<T>>,
+    phantom: PhantomData<T>,
 }
 
 /// The per-request value which deals with sessions
@@ -432,7 +433,7 @@ where
 pub struct SessionMiddleware<B, T>
 where
     B: Backend,
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     backend: B,
     identifier_rng: Arc<Mutex<rng::SessionIdentifierRng>>,
@@ -446,7 +447,6 @@ where
     T: Default
         + Serialize
         + for<'de> Deserialize<'de>
-        + Send
         + 'static,
 {
     type Instance = SessionMiddleware<B::Instance, T>;
@@ -499,11 +499,7 @@ fn default_cookie_options() -> Vec<CookieOption> {
 impl<B, T> NewSessionMiddleware<B, T>
 where
     B: NewBackend,
-    T: Default
-        + Serialize
-        + for<'de> Deserialize<'de>
-        + Send
-        + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     fn add_cookie_option(self, opt: CookieOption) -> NewSessionMiddleware<B, T> {
         let mut cookie_config = (*self.cookie_config).clone();
@@ -700,7 +696,7 @@ where
     /// ```
     pub fn with_session_type<U>(self) -> NewSessionMiddleware<B, U>
     where
-        U: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+        U: Default + Serialize + for<'de> Deserialize<'de> + 'static,
     {
         NewSessionMiddleware {
             new_backend: self.new_backend,
@@ -713,16 +709,15 @@ where
 
 impl<B, T> Middleware for SessionMiddleware<B, T>
 where
-    B: Backend + Send + 'static,
+    B: Backend + 'static,
     T: Default
         + Serialize
         + for<'de> Deserialize<'de>
-        + Send
         + 'static,
 {
     fn call<Chain>(self, state: State, request: Request, chain: Chain) -> Box<HandlerFuture>
     where
-        Chain: FnOnce(State, Request) -> Box<HandlerFuture> + Send + 'static,
+        Chain: FnOnce(State, Request) -> Box<HandlerFuture> + 'static,
         Self: Sized,
     {
         let session_identifier = request
@@ -751,8 +746,9 @@ where
 }
 
 impl<B, T> SessionMiddleware<B, T>
-    where B: Backend + Send + 'static,
-          T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static
+where
+    B: Backend + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     fn random_identifier(&self) -> SessionIdentifier {
         let mut bytes: Vec<u8> = Vec::with_capacity(64);
@@ -770,7 +766,7 @@ fn persist_session<T>(
     (mut state, mut response): (State, Response),
 ) -> future::FutureResult<(State, Response), (State, HandlerError)>
 where
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     match state.take::<SessionDropData>() {
         Some(ref session_drop_data) => {
@@ -818,7 +814,7 @@ fn cookie_string(cookie_config: &SessionCookieConfig, value: &str) -> String {
 
 fn send_cookie<T>(response: &mut Response, session_data: &SessionData<T>)
 where
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     let cookie_string = cookie_string(&*session_data.cookie_config, &session_data.identifier.value);
 
@@ -843,7 +839,7 @@ fn write_session<T>(
     session_data: SessionData<T>,
 ) -> future::FutureResult<(State, Response), (State, HandlerError)>
 where
-    T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
     let mut bytes = Vec::new();
 
@@ -885,19 +881,23 @@ where
 }
 
 impl<B, T> SessionMiddleware<B, T>
-    where B: Backend + Send + 'static,
-          T: Default + Serialize + for<'de> Deserialize<'de> + Send + 'static
+where
+    B: Backend + 'static,
+    T: Default + Serialize + for<'de> Deserialize<'de> + 'static,
 {
-    fn load_session_into_state(self,
-                               mut state: State,
-                               identifier: SessionIdentifier,
-                               result: Result<Option<Vec<u8>>, SessionError>)
-                               -> future::FutureResult<State, (State, HandlerError)> {
+    fn load_session_into_state(
+        self,
+        mut state: State,
+        identifier: SessionIdentifier,
+        result: Result<Option<Vec<u8>>, SessionError>,
+    ) -> future::FutureResult<State, (State, HandlerError)> {
         match result {
             Ok(v) => {
-                trace!("[{}] retrieved session ({}) from backend successfully",
-                       state::request_id(&state),
-                       identifier.value);
+                trace!(
+                    "[{}] retrieved session ({}) from backend successfully",
+                    state::request_id(&state),
+                    identifier.value
+                );
 
                 let session_data = SessionData::<T>::construct(self, identifier, v);
 
@@ -905,13 +905,17 @@ impl<B, T> SessionMiddleware<B, T>
                 future::ok(state)
             }
             Err(e) => {
-                error!("[{}] failed to retrieve session ({}) from backend: {:?}",
-                       state::request_id(&state),
-                       identifier.value,
-                       e);
+                error!(
+                    "[{}] failed to retrieve session ({}) from backend: {:?}",
+                    state::request_id(&state),
+                    identifier.value,
+                    e
+                );
 
-                let e = io::Error::new(io::ErrorKind::Other,
-                                       format!("backend failed to return session: {:?}", e));
+                let e = io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("backend failed to return session: {:?}", e),
+                );
 
                 future::err((state, e.into_handler_error()))
             }
@@ -921,9 +925,11 @@ impl<B, T> SessionMiddleware<B, T>
     fn new_session(self, mut state: State) -> future::FutureResult<State, (State, HandlerError)> {
         let session_data = SessionData::<T>::new(self);
 
-        trace!("[{}] created new session ({})",
-               state::request_id(&state),
-               session_data.identifier.value);
+        trace!(
+            "[{}] created new session ({})",
+            state::request_id(&state),
+            session_data.identifier.value
+        );
 
         state.put(session_data);
 

--- a/src/router/response/finalizer.rs
+++ b/src/router/response/finalizer.rs
@@ -66,6 +66,6 @@ impl ResponseFinalizer {
             }
         }
 
-        future::ok((state, res)).boxed()
+        Box::new(future::ok((state, res)))
     }
 }

--- a/src/router/response/finalizer.rs
+++ b/src/router/response/finalizer.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 use std::collections::HashMap;
 
-use futures::{future, Future};
+use futures::future;
 use hyper::{StatusCode, Response};
 
 use handler::HandlerFuture;

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use borrow_bag::{new_borrow_bag, BorrowBag, Handle, Lookup};
 use hyper::Request;
-use futures::{future, Future};
+use futures::future;
 
 use handler::{Handler, NewHandler, HandlerFuture, IntoHandlerError};
 use middleware::pipeline::{NewMiddlewareChain, Pipeline};

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -87,7 +87,7 @@ where
             }
             Err(e) => {
                 trace!("[{}] error cloning handler", request_id(&state));
-                future::err((state, e.into_handler_error())).boxed()
+                Box::new(future::err((state, e.into_handler_error())))
             }
         }
     }
@@ -150,7 +150,7 @@ where
             }
             Err(e) => {
                 trace!("[{}] error borrowing pipeline", request_id(&state));
-                future::err((state, e.into_handler_error())).boxed()
+                Box::new(future::err((state, e.into_handler_error())))
             }
         }
     }

--- a/src/socket_queue.rs
+++ b/src/socket_queue.rs
@@ -38,6 +38,11 @@ impl Stream for SocketQueue {
     }
 }
 
+/// Starts a Gotham application, with the given number of threads.
+///
+/// ## Windows
+///
+/// An additional thread is used on Windows to accept connections.
 pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
 where
     NH: NewHandler + 'static,

--- a/src/socket_queue.rs
+++ b/src/socket_queue.rs
@@ -1,0 +1,121 @@
+use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
+use std::thread;
+use std::sync::{Arc, Mutex};
+
+use hyper::server::{Http, NewService};
+use tokio_core;
+use tokio_core::net::TcpStream;
+use tokio_core::reactor::Core;
+use futures::{future, task, Future, Stream, Poll, Async};
+
+use handler::{NewHandler, NewHandlerService};
+
+use crossbeam::sync::SegQueue;
+
+#[derive(Clone)]
+struct SocketQueue {
+    queue: Arc<SegQueue<(TcpStream, SocketAddr)>>,
+    notify: Arc<Mutex<Vec<task::Task>>>,
+}
+
+impl SocketQueue {
+    fn new() -> SocketQueue {
+        let queue = Arc::new(SegQueue::new());
+        let notify = Arc::new(Mutex::new(Vec::new()));
+        SocketQueue { queue, notify }
+    }
+}
+
+impl Stream for SocketQueue {
+    type Item = (TcpStream, SocketAddr);
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.queue.try_pop() {
+            Some(t) => Ok(Async::Ready(Some(t))),
+            None => Ok(Async::NotReady),
+        }
+    }
+}
+
+pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
+where
+    NH: NewHandler + 'static,
+    A: ToSocketAddrs,
+{
+    let (listener, addr) = super::tcp_listener(addr);
+
+    let protocol = Arc::new(Http::new());
+    let service = NewHandlerService::new(new_handler);
+
+    let queue = SocketQueue::new();
+
+    {
+        let queue = queue.clone();
+        thread::spawn(move || listen(listener, addr, queue));
+    }
+
+    info!(
+        target: "gotham::start",
+        " Gotham listening on http://{} with {} threads",
+        addr,
+        threads,
+    );
+
+    for _ in 0..threads - 1 {
+        let protocol = protocol.clone();
+        let service = service.clone();
+        let queue = queue.clone();
+        thread::spawn(move || serve(queue, &protocol, &service));
+    }
+
+    serve(queue, &protocol, &service);
+}
+
+fn listen(listener: TcpListener, addr: SocketAddr, queue: SocketQueue) {
+    let mut core = Core::new().expect("unable to spawn tokio reactor");
+    let handle = core.handle();
+
+    let listener = tokio_core::net::TcpListener::from_listener(listener, &addr, &handle)
+        .expect("unable to convert TCP listener to tokio listener");
+
+    let mut n: usize = 0;
+
+    core.run(listener.incoming().for_each(|conn| {
+        queue.queue.push(conn);
+        let tasks = queue.notify.lock().expect(
+            "mutex poisoned, futures::task::Task::notify panicked?",
+        );
+
+        n = (n + 1) % tasks.len();
+        tasks[n].notify();
+        Ok(())
+    })).expect("unable to run reactor over listener");
+}
+
+fn serve<NH>(queue: SocketQueue, protocol: &Http, new_service: &NewHandlerService<NH>)
+where
+    NH: NewHandler + 'static,
+{
+    let mut core = Core::new().expect("unable to spawn tokio reactor");
+    let handle = core.handle();
+    let tasks_m = queue.notify.clone();
+
+    core.run(
+        future::lazy(move || {
+            let mut tasks = tasks_m.lock().expect(
+                "mutex poisoned, futures::task::Task::notify panicked?",
+            );
+            tasks.push(task::current());
+            future::ok(())
+        }).and_then(|_| {
+            queue.for_each(|(socket, addr)| {
+                match new_service.new_service() {
+                    Ok(service) => protocol.bind_connection(&handle, socket, addr, service),
+                    Err(e) => error!(" unable to spawn service: {:?}", e),
+                }
+                Ok(())
+            })
+        }),
+    ).expect("unable to run reactor for work stealing");
+}

--- a/src/state/data.rs
+++ b/src/state/data.rs
@@ -9,7 +9,7 @@ use state::request_id::RequestId;
 ///
 /// Typically implemented using `#[derive(StateData)]`, which is provided by the `gotham_derive`
 /// crate.
-pub trait StateData: Any + Send {}
+pub trait StateData: Any {}
 
 impl StateData for Method {}
 impl StateData for Uri {}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -39,7 +39,7 @@ pub use state::request_id::set_request_id;
 /// # }
 /// ```
 pub struct State {
-    data: HashMap<TypeId, Box<Any + Send>>,
+    data: HashMap<TypeId, Box<Any>>,
 }
 
 impl State {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -34,7 +34,7 @@ use mio;
 /// #     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
 /// #
 /// #     fn call(&self, _req: Self::Request) -> Self::Future {
-/// #         future::ok(server::Response::new().with_status(StatusCode::Accepted)).boxed()
+/// #         Box::new(future::ok(server::Response::new().with_status(StatusCode::Accepted)))
 /// #     }
 /// # }
 /// #
@@ -225,15 +225,15 @@ mod tests {
                         .with_status(StatusCode::Ok)
                         .with_body(self.response.clone());
 
-                    future::ok(response).boxed()
+                    Box::new(future::ok(response))
                 }
-                "/timeout" => future::empty().boxed(),
+                "/timeout" => Box::new(future::empty()),
                 "/myaddr" => {
                     let response = server::Response::new()
                         .with_status(StatusCode::Ok)
                         .with_body(format!("{}", req.remote_addr().unwrap()));
 
-                    future::ok(response).boxed()
+                    Box::new(future::ok(response))
                 }
                 _ => unreachable!(),
             }


### PR DESCRIPTION
Since 032249ac we've been using a `CpuPool` in `NewHandlerService` for concurrency, however there are a couple of downsides to this:

* We're bound by the single-thread performance of `hyper`
* We've got `Send` and `Sync` trait bounds in a lot of places where they wouldn't be otherwise necessary

This change moves the concurrency to the top level, starting a Tokio reactor per thread (defaulting to one thread for each CPU), and removes unnecessary `Send` / `Sync` trait bounds. I'm seeing about a 25% performance boost from this approach, just based on some very unscientific benchmarking.

Concept is based on [this gist from Alex Crichton](https://gist.github.com/alexcrichton/7b97beda66d5e9b10321207cd69afbbc), but some refactoring was needed first to attempt to support Windows, and then to ultimately use a different code path when apparently unable to share the same server socket across threads in Windows.