### PR TITLE
Implement regex matching for request path segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+.idea/
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rand = "0.3"
 linked-hash-map = "0.4"
 num_cpus = "1"
 crossbeam = "0.3"
+regex = "0.2"
 
 [dev-dependencies]
 gotham_derive = { version = "0.1.0", path = "gotham_derive" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate base64;
 extern crate rmp_serde;
 extern crate linked_hash_map;
 extern crate num_cpus;
+extern crate regex;
 #[cfg(windows)]
 extern crate crossbeam;
 

--- a/src/router/tree/node.rs
+++ b/src/router/tree/node.rs
@@ -11,9 +11,15 @@ use router::route::{Route, Delegation};
 use router::tree::{SegmentsProcessed, SegmentMapping, Path};
 use state::{State, request_id};
 
+/// A regular expression that implements PartialEq, Eq, PartialOrd, and ord.
+/// It does so in a potentially error-prone way by comparing the underlying &str
+/// representations of the regular expression.
 pub struct OrderedRegex(Regex);
 
 impl<'a> OrderedRegex {
+    /// Creates a new OrderedRegex from a provided string.
+    /// It wraps the string in begin and end of line anchors to prevent it from matching
+    /// more than intended.
     pub fn new(regex: &'a str) -> Self {
         OrderedRegex(Regex::new(&format!("^{pattern}$", pattern = regex)).unwrap())
     }
@@ -29,21 +35,13 @@ impl Eq for OrderedRegex {}
 
 impl PartialOrd for OrderedRegex {
     fn partial_cmp(&self, other: &OrderedRegex) -> Option<Ordering> {
-        return if self.0.as_str() > other.0.as_str() {
-            Some(Ordering::Greater)
-        } else if self.0.as_str() < other.0.as_str() {
-            Some(Ordering::Less)
-        } else if self.0.as_str() == other.0.as_str() {
-            Some(Ordering::Equal)
-        } else {
-            None
-        }
+        Some(self.0.as_str().cmp(other.0.as_str()))
     }
 }
 
 impl Ord for OrderedRegex {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        self.0.as_str().cmp(other.0.as_str())
     }
 }
 


### PR DESCRIPTION
Adds anchored (^..$) regex matching to the request path segment handling
and drops the `unimplemented!()` macro in favor of a concrete
implementation.

This also adds an `OrderedRegex` newtype as the exist Regex didn't
implement the traits required for PartialEq, Eq, PartialOrd, and Ord.
See the following Github issues for reasons why Regex doesn't natively
implement this:
https://github.com/rust-lang/regex/issues/313
https://github.com/rust-lang/regex/issues/364

This (hopefully) addresses and closes #10.

Only concerns with this pull request are the uses of `unwrap` when constructing the regular expression. Not sure how we want to handle errors for that.