### PR TITLE
Disallow warnings when building in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 before_script:
   - cargo install cargo-travis -f
 script:
-  - cargo test
+  - cargo test --features ci
 after_success:
   - cargo coveralls
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "framework", "gotham"]
 
+[features]
+default = []
+ci = []
+
 [dependencies]
 log = "0.3"
 hyper = "~0.11.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 //! We look forward to welcoming you into the Gotham community!
 #![doc(html_root_url = "https://docs.rs/gotham/0.1.1")] // Update when changed in Cargo.toml
 #![warn(missing_docs, deprecated)]
+
+// Stricter requirements once we get to pull request stage, all warnings must be resolved.
+#![cfg_attr(feature = "ci", deny(warnings))]
+
 #![doc(test(no_crate_inject, attr(deny(warnings))))]
 // TODO: Remove this when it's a hard error by default (error E0446).
 // See Rust issue #34537 <https://github.com/rust-lang/rust/issues/34537>


### PR DESCRIPTION
Turns out it's pretty easy to miss these, since they don't appear when rebuilding an unchanged project. Trapping them at the CI level ensures we don't miss them during review.