### PR TITLE
Refine SessionCookieConfig implementation

### DIFF
--- a/src/middleware/session/mod.rs
+++ b/src/middleware/session/mod.rs
@@ -79,7 +79,7 @@ impl Default for SessionCookieConfig {
             name: "_gotham_session".to_string(),
             secure: true,
             http_only: true,
-            same_site: SameSiteEnforcement::Strict,
+            same_site: SameSiteEnforcement::Lax,
             domain: None,
             path: "/".to_string(),
         }
@@ -977,14 +977,14 @@ mod tests {
         assert_eq!(&m.cookie_config.name, "_gotham_session");
         assert!(m.cookie_config.secure);
         assert!(m.cookie_config.http_only);
-        assert_eq!(m.cookie_config.same_site, SameSiteEnforcement::Strict);
+        assert_eq!(m.cookie_config.same_site, SameSiteEnforcement::Lax);
         assert_eq!(&m.cookie_config.path, "/");
         assert!(m.cookie_config.domain.is_none());
 
         assert_eq!(
             m.cookie_config.to_cookie_string(&identifier.value),
             format!(
-                "_gotham_session={}; Secure; HttpOnly; SameSite=Strict; Path=/",
+                "_gotham_session={}; Secure; HttpOnly; SameSite=Lax; Path=/",
                 &identifier.value
             )
         );


### PR DESCRIPTION
The previous implementation was not ideal when we came to implement
configurable path values, mostly in that it was complex to update an
option that had runtime data associated with it.

The new implementation simply sets values on the SessionCookieConfig
struct directly making updates easier and future extensions simpler.

External usage should not be impacted by this change as the
existing public API was able to be kept and in the case of
`anchor_to_path` extended.