### PR TITLE
Refactor TestServer API

### DIFF
--- a/src/http/header/x_content_type_options.rs
+++ b/src/http/header/x_content_type_options.rs
@@ -1,6 +1,8 @@
 //! Define the X-Content-Type-Options header.
 
 use std::fmt;
+// TODO: Remove when this import isn't required in stable anymore.
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 use hyper;

--- a/src/http/header/x_frame_options.rs
+++ b/src/http/header/x_frame_options.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 use std::str::FromStr;
+// TODO: Remove when this import isn't required in stable anymore.
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 use hyper;

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -143,8 +143,7 @@ use state::{State, request_id};
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
 /// #   let test_server = TestServer::new(router).unwrap();
-///     let client = test_server.client();
-///     let response = client.get("http://example.com/").unwrap();
+///     let response = test_server.client().get("http://example.com/").unwrap();
 ///     assert_eq!(response.status(), StatusCode::Ok);
 ///     assert_eq!(response.read_body().unwrap(), "[1, 2, 3]".as_bytes());
 /// }
@@ -537,8 +536,7 @@ mod tests {
             })
         }).unwrap();
 
-        let client = test_server.client();
-        let response = client.get("http://localhost/").unwrap();
+        let response = test_server.client().get("http://localhost/").unwrap();
 
         let buf = response.read_body().unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -536,7 +536,11 @@ mod tests {
             })
         }).unwrap();
 
-        let response = test_server.client().get("http://localhost/").unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/")
+            .perform()
+            .unwrap();
 
         let buf = response.read_body().unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -143,9 +143,10 @@ use state::{State, request_id};
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
 /// #   let test_server = TestServer::new(router).unwrap();
-///     let response = test_server.client().get("http://example.com/").unwrap();
+///     let client = test_server.client();
+///     let response = client.get("http://example.com/").unwrap();
 ///     assert_eq!(response.status(), StatusCode::Ok);
-///     assert_eq!(test_server.read_body(response).unwrap(), "[1, 2, 3]".as_bytes());
+///     assert_eq!(response.read_body().unwrap(), "[1, 2, 3]".as_bytes());
 /// }
 /// ```
 pub struct Pipeline<T>
@@ -536,9 +537,10 @@ mod tests {
             })
         }).unwrap();
 
-        let response = test_server.client().get("http://localhost/").unwrap();
+        let client = test_server.client();
+        let response = client.get("http://localhost/").unwrap();
 
-        let buf = test_server.read_body(response).unwrap();
+        let buf = response.read_body().unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());
     }
 }

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -142,10 +142,8 @@ use state::{State, request_id};
 /// #   let response_finalizer = ResponseFinalizerBuilder::new().finalize();
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
-/// #   let mut test_server = TestServer::new(router).unwrap();
-/// #   let client = test_server.client();
-/// #   let uri = "http://example.com/".parse().unwrap();
-///     let response = test_server.run_request(client.get(uri)).unwrap();
+/// #   let test_server = TestServer::new(router).unwrap();
+///     let response = test_server.client().get("http://example.com/").unwrap();
 ///     assert_eq!(response.status(), StatusCode::Ok);
 ///     assert_eq!(test_server.read_body(response).unwrap(), "[1, 2, 3]".as_bytes());
 /// }
@@ -521,7 +519,7 @@ mod tests {
 
     #[test]
     fn pipeline_ordering_test() {
-        let mut test_server = TestServer::new(|| {
+        let test_server = TestServer::new(|| {
             let pipeline = new_pipeline()
                 .add(Number { value: 0 }) // 0
                 .add(Addition { value: 1 }) // 1
@@ -538,9 +536,7 @@ mod tests {
             })
         }).unwrap();
 
-        let uri = "http://localhost/".parse().unwrap();
-        let response = test_server.client().get(uri);
-        let response = test_server.run_request(response).unwrap();
+        let response = test_server.client().get("http://localhost/").unwrap();
 
         let buf = test_server.read_body(response).unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -143,7 +143,7 @@ use state::{State, request_id};
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
 /// #   let mut test_server = TestServer::new(router).unwrap();
-/// #   let client = test_server.client().unwrap();
+/// #   let client = test_server.client();
 /// #   let uri = "http://example.com/".parse().unwrap();
 ///     let response = test_server.run_request(client.get(uri)).unwrap();
 ///     assert_eq!(response.status(), StatusCode::Ok);
@@ -539,7 +539,7 @@ mod tests {
         }).unwrap();
 
         let uri = "http://localhost/".parse().unwrap();
-        let response = test_server.client().unwrap().get(uri);
+        let response = test_server.client().get(uri);
         let response = test_server.run_request(response).unwrap();
 
         let buf = test_server.read_body(response).unwrap();

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -143,7 +143,7 @@ use state::{State, request_id};
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
 /// #   let mut test_server = TestServer::new(router).unwrap();
-/// #   let client = test_server.client("127.0.0.1:10000".parse().unwrap()).unwrap();
+/// #   let client = test_server.client().unwrap();
 /// #   let uri = "http://example.com/".parse().unwrap();
 ///     let response = test_server.run_request(client.get(uri)).unwrap();
 ///     assert_eq!(response.status(), StatusCode::Ok);
@@ -539,10 +539,7 @@ mod tests {
         }).unwrap();
 
         let uri = "http://localhost/".parse().unwrap();
-        let response = test_server
-            .client("127.0.0.1:0".parse().unwrap())
-            .unwrap()
-            .get(uri);
+        let response = test_server.client().unwrap().get(uri);
         let response = test_server.run_request(response).unwrap();
 
         let buf = test_server.read_body(response).unwrap();

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -143,7 +143,7 @@ use state::{State, request_id};
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
 /// #   let test_server = TestServer::new(router).unwrap();
-///     let response = test_server.client().get("http://example.com/").unwrap();
+///     let response = test_server.client().get("http://example.com/").perform().unwrap();
 ///     assert_eq!(response.status(), StatusCode::Ok);
 ///     assert_eq!(response.read_body().unwrap(), "[1, 2, 3]".as_bytes());
 /// }

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -26,7 +26,7 @@ use state::{State, request_id};
 /// # use std::io;
 /// # use gotham::http::response::create_response;
 /// # use gotham::state::State;
-/// # use gotham::handler::{HandlerFuture, NewHandlerService};
+/// # use gotham::handler::HandlerFuture;
 /// # use gotham::middleware::{Middleware, NewMiddleware};
 /// # use gotham::middleware::pipeline::new_pipeline;
 /// # use gotham::router::Router;
@@ -142,8 +142,7 @@ use state::{State, request_id};
 /// #   let response_finalizer = ResponseFinalizerBuilder::new().finalize();
 /// #   let router = Router::new(tree, response_finalizer);
 /// #
-/// #   let new_service = NewHandlerService::new(router);
-/// #   let mut test_server = TestServer::new(new_service).unwrap();
+/// #   let mut test_server = TestServer::new(router).unwrap();
 /// #   let client = test_server.client("127.0.0.1:10000".parse().unwrap()).unwrap();
 /// #   let uri = "http://example.com/".parse().unwrap();
 ///     let response = test_server.run_request(client.get(uri)).unwrap();
@@ -429,7 +428,7 @@ where
 mod tests {
     use super::*;
     use test::TestServer;
-    use handler::{Handler, NewHandlerService, IntoHandlerError};
+    use handler::{Handler, IntoHandlerError};
     use state::StateData;
     use hyper::Response;
     use hyper::StatusCode;
@@ -522,7 +521,7 @@ mod tests {
 
     #[test]
     fn pipeline_ordering_test() {
-        let new_service = NewHandlerService::new(|| {
+        let mut test_server = TestServer::new(|| {
             let pipeline = new_pipeline()
                 .add(Number { value: 0 }) // 0
                 .add(Addition { value: 1 }) // 1
@@ -537,11 +536,9 @@ mod tests {
                 Ok(p) => p.call(state, |state| handler.handle(state)),
                 Err(e) => Box::new(future::err((state, e.into_handler_error()))),
             })
-        });
+        }).unwrap();
 
         let uri = "http://localhost/".parse().unwrap();
-
-        let mut test_server = TestServer::new(new_service).unwrap();
         let response = test_server
             .client("127.0.0.1:0".parse().unwrap())
             .unwrap()

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -284,8 +284,7 @@ mod tests {
             })
         }).unwrap();
 
-        let client = test_server.client();
-        let response = client.get("http://localhost/").unwrap();
+        let response = test_server.client().get("http://localhost/").unwrap();
 
         let buf = response.read_body().unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -286,7 +286,7 @@ mod tests {
 
         let uri = "http://localhost/".parse().unwrap();
 
-        let response = test_server.client().unwrap().get(uri);
+        let response = test_server.client().get(uri);
         let response = test_server.run_request(response).unwrap();
 
         let buf = test_server.read_body(response).unwrap();

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn pipeline_chain_ordering_test() {
-        let mut test_server = TestServer::new(|| {
+        let test_server = TestServer::new(|| {
             Ok(move |state| {
                 let pipelines = new_pipeline_set();
 
@@ -284,10 +284,7 @@ mod tests {
             })
         }).unwrap();
 
-        let uri = "http://localhost/".parse().unwrap();
-
-        let response = test_server.client().get(uri);
-        let response = test_server.run_request(response).unwrap();
+        let response = test_server.client().get("http://localhost/").unwrap();
 
         let buf = test_server.read_body(response).unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -284,7 +284,11 @@ mod tests {
             })
         }).unwrap();
 
-        let response = test_server.client().get("http://localhost/").unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/")
+            .perform()
+            .unwrap();
 
         let buf = response.read_body().unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -286,10 +286,7 @@ mod tests {
 
         let uri = "http://localhost/".parse().unwrap();
 
-        let response = test_server
-            .client("127.0.0.1:0".parse().unwrap())
-            .unwrap()
-            .get(uri);
+        let response = test_server.client().unwrap().get(uri);
         let response = test_server.run_request(response).unwrap();
 
         let buf = test_server.read_body(response).unwrap();

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -284,9 +284,10 @@ mod tests {
             })
         }).unwrap();
 
-        let response = test_server.client().get("http://localhost/").unwrap();
+        let client = test_server.client();
+        let response = client.get("http://localhost/").unwrap();
 
-        let buf = test_server.read_body(response).unwrap();
+        let buf = response.read_body().unwrap();
         assert_eq!(buf.as_slice(), "24".as_bytes());
     }
 }

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -155,7 +155,6 @@ mod tests {
     use super::*;
     use std::io;
     use test::TestServer;
-    use handler::NewHandlerService;
     use middleware::{Middleware, NewMiddleware};
     use middleware::pipeline::new_pipeline;
     use state::StateData;
@@ -249,7 +248,7 @@ mod tests {
 
     #[test]
     fn pipeline_chain_ordering_test() {
-        let new_service = NewHandlerService::new(|| {
+        let mut test_server = TestServer::new(|| {
             Ok(move |state| {
                 let pipelines = new_pipeline_set();
 
@@ -283,11 +282,10 @@ mod tests {
                 let dispatcher = DispatcherImpl::new(new_handler, pipeline_chain, pipelines);
                 dispatcher.dispatch(state)
             })
-        });
+        }).unwrap();
 
         let uri = "http://localhost/".parse().unwrap();
 
-        let mut test_server = TestServer::new(new_service).unwrap();
         let response = test_server
             .client("127.0.0.1:0".parse().unwrap())
             .unwrap()

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -35,8 +35,10 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #
 /// # fn main() {
 /// #   let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
-/// #   let client = test_server.client_with_address("127.0.0.1:9816".parse().unwrap());
-/// #   let response = client.get("http://localhost/").unwrap();
+/// #   let response = test_server
+/// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
+/// #       .get("http://localhost/")
+/// #       .unwrap();
 /// #
 /// #   assert_eq!(response.status(), StatusCode::Ok);
 /// #

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -23,7 +23,6 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// # extern crate hyper;
 /// #
 /// # use hyper::{Response, StatusCode};
-/// # use gotham::handler::NewHandlerService;
 /// # use gotham::state::{State, client_addr};
 /// # use gotham::test::TestServer;
 /// #
@@ -35,8 +34,7 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// }
 /// #
 /// # fn main() {
-/// #   let new_service = NewHandlerService::new(|| Ok(my_handler));
-/// #   let mut test_server = TestServer::new(new_service).unwrap();
+/// #   let mut test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 /// #   let uri = "http://localhost/".parse().unwrap();
 /// #   let response = test_server
 /// #       .client("127.0.0.1:9816".parse().unwrap())

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -1,0 +1,20 @@
+//! Defines storage for the remote address of the client
+
+use std::net::SocketAddr;
+use state::{State, FromState, StateData};
+
+struct ClientAddr {
+    addr: SocketAddr,
+}
+
+impl StateData for ClientAddr {}
+
+pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
+    state.put(ClientAddr { addr })
+}
+
+/// Returns the client `SocketAddr` as reported by hyper, if one was present. Certain connections
+/// do not report a client address, in which case this will return `None`.
+pub fn client_addr(state: &State) -> Option<SocketAddr> {
+    ClientAddr::try_borrow_from(&state).map(|c| c.addr)
+}

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -15,6 +15,40 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 
 /// Returns the client `SocketAddr` as reported by hyper, if one was present. Certain connections
 /// do not report a client address, in which case this will return `None`.
+///
+/// # Examples
+///
+/// ```rust
+/// # extern crate gotham;
+/// # extern crate hyper;
+/// #
+/// # use hyper::{Response, StatusCode};
+/// # use gotham::handler::NewHandlerService;
+/// # use gotham::state::{State, client_addr};
+/// # use gotham::test::TestServer;
+/// #
+/// fn my_handler(state: State) -> (State, Response) {
+///     let addr = client_addr(&state).expect("no client address");
+///     let body = format!("{}", addr);
+///     let response = Response::new().with_status(StatusCode::Ok).with_body(body);
+///     (state, response)
+/// }
+/// #
+/// # fn main() {
+/// #   let new_service = NewHandlerService::new(|| Ok(my_handler));
+/// #   let mut test_server = TestServer::new(new_service).unwrap();
+/// #   let uri = "http://localhost/".parse().unwrap();
+/// #   let response = test_server
+/// #       .client("127.0.0.1:9816".parse().unwrap())
+/// #       .unwrap()
+/// #       .get(uri);
+/// #
+/// #   let response = test_server.run_request(response).unwrap();
+/// #
+/// #   assert_eq!(response.status(), StatusCode::Ok);
+/// #   let buf = test_server.read_body(response).unwrap();
+/// #   assert_eq!(buf.as_slice(), b"127.0.0.1:9816");
+/// # }
 pub fn client_addr(state: &State) -> Option<SocketAddr> {
     ClientAddr::try_borrow_from(&state).map(|c| c.addr)
 }

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -37,7 +37,7 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #   let mut test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 /// #   let uri = "http://localhost/".parse().unwrap();
 /// #   let response = test_server
-/// #       .client("127.0.0.1:9816".parse().unwrap())
+/// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
 /// #       .unwrap()
 /// #       .get(uri);
 /// #

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -38,7 +38,6 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #   let uri = "http://localhost/".parse().unwrap();
 /// #   let response = test_server
 /// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
-/// #       .unwrap()
 /// #       .get(uri);
 /// #
 /// #   let response = test_server.run_request(response).unwrap();

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -38,6 +38,7 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #   let response = test_server
 /// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
 /// #       .get("http://localhost/")
+/// #       .perform()
 /// #       .unwrap();
 /// #
 /// #   assert_eq!(response.status(), StatusCode::Ok);

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -35,14 +35,12 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #
 /// # fn main() {
 /// #   let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
-/// #   let response = test_server
-/// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
-/// #       .get("http://localhost/")
-/// #       .unwrap();
+/// #   let client = test_server.client_with_address("127.0.0.1:9816".parse().unwrap());
+/// #   let response = client.get("http://localhost/").unwrap();
 /// #
 /// #   assert_eq!(response.status(), StatusCode::Ok);
 /// #
-/// #   let buf = test_server.read_body(response).unwrap();
+/// #   let buf = response.read_body().unwrap();
 /// #   assert_eq!(buf.as_slice(), b"127.0.0.1:9816");
 /// # }
 pub fn client_addr(state: &State) -> Option<SocketAddr> {

--- a/src/state/client_addr.rs
+++ b/src/state/client_addr.rs
@@ -34,15 +34,14 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// }
 /// #
 /// # fn main() {
-/// #   let mut test_server = TestServer::new(|| Ok(my_handler)).unwrap();
-/// #   let uri = "http://localhost/".parse().unwrap();
+/// #   let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 /// #   let response = test_server
 /// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
-/// #       .get(uri);
-/// #
-/// #   let response = test_server.run_request(response).unwrap();
+/// #       .get("http://localhost/")
+/// #       .unwrap();
 /// #
 /// #   assert_eq!(response.status(), StatusCode::Ok);
+/// #
 /// #   let buf = test_server.read_body(response).unwrap();
 /// #   assert_eq!(buf.as_slice(), b"127.0.0.1:9816");
 /// # }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -3,14 +3,15 @@
 mod data;
 mod from_state;
 pub mod request_id;
+pub(crate) mod client_addr;
 
 use std::collections::HashMap;
 use std::any::{Any, TypeId};
 
 pub use state::data::StateData;
 pub use state::from_state::FromState;
-pub use state::request_id::request_id;
-pub use state::request_id::set_request_id;
+pub use state::request_id::{request_id, set_request_id};
+pub use state::client_addr::client_addr;
 
 /// Provides storage for request state, and stores one item of each type. The types used for
 /// storage must implement the `gotham::state::StateData` trait to allow its storage.

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -333,11 +333,11 @@ mod tests {
     use state::{State, FromState, client_addr};
 
     #[derive(Clone)]
-    struct TestService {
+    struct TestHandler {
         response: String,
     }
 
-    impl Handler for TestService {
+    impl Handler for TestHandler {
         fn handle(self, state: State) -> Box<HandlerFuture> {
             let path = Uri::borrow_from(&state).path().to_owned();
             match path.as_str() {
@@ -361,7 +361,7 @@ mod tests {
         }
     }
 
-    impl NewHandler for TestService {
+    impl NewHandler for TestHandler {
         type Instance = Self;
 
         fn new_handler(&self) -> io::Result<Self> {
@@ -375,7 +375,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let new_service = move || Ok(TestService { response: format!("time: {}", ticks) });
+        let new_service = move || Ok(TestHandler { response: format!("time: {}", ticks) });
 
         let test_server = TestServer::new(new_service).unwrap();
         let response = test_server.client().get("http://localhost/").unwrap();
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn times_out() {
-        let new_service = || Ok(TestService { response: "".to_owned() });
+        let new_service = || Ok(TestHandler { response: "".to_owned() });
         let test_server = TestServer::new(new_service).unwrap().timeout(1);
 
         match test_server.client().get("http://localhost/timeout") {
@@ -405,7 +405,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let new_service = move || Ok(TestService { response: format!("time: {}", ticks) });
+        let new_service = move || Ok(TestHandler { response: format!("time: {}", ticks) });
         let client_addr = "9.8.7.6:58901".parse().unwrap();
 
         let test_server = TestServer::new(new_service).unwrap();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -25,7 +25,6 @@ use router::Router;
 ///
 /// ```rust
 /// # extern crate hyper;
-/// # extern crate futures;
 /// # extern crate gotham;
 /// #
 /// # use gotham::state::State;
@@ -243,7 +242,6 @@ trait BodyReader {
 ///
 /// ```rust
 /// # extern crate hyper;
-/// # extern crate futures;
 /// # extern crate gotham;
 /// # extern crate mime;
 /// #

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -294,6 +294,15 @@ impl<'a> TestResponse<'a> {
     pub fn read_body(self) -> hyper::Result<Vec<u8>> {
         self.reader.read_body(self.response)
     }
+
+    /// Awaits the UTF-8 encoded body of the underlying `Response`, and returns the `String`. This
+    /// will cause the event loop to execute until the `Response` body has been fully read and the
+    /// `String` created.
+    pub fn read_utf8_body(self) -> hyper::Result<String> {
+        let buf = self.read_body()?;
+        let s = String::from_utf8(buf)?;
+        Ok(s)
+    }
 }
 
 /// `TestConnect` represents the connection between a test client and the `TestServer` instance
@@ -386,8 +395,8 @@ mod tests {
         let response = test_server.client().get("http://localhost/").unwrap();
 
         assert_eq!(response.status(), StatusCode::Ok);
-        let buf = response.read_body().unwrap();
-        assert_eq!(buf.as_slice(), format!("time: {}", ticks).as_bytes());
+        let buf = response.read_utf8_body().unwrap();
+        assert_eq!(buf, format!("time: {}", ticks));
     }
 
     #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -46,7 +46,7 @@ pub use self::request::RequestBuilder;
 ///
 /// let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 ///
-/// let response = test_server.client().get("http://localhost/").unwrap();
+/// let response = test_server.client().get("http://localhost/").perform().unwrap();
 /// assert_eq!(response.status(), StatusCode::Accepted);
 /// # }
 /// ```
@@ -300,7 +300,7 @@ trait BodyReader {
 ///
 /// let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 ///
-/// let response = test_server.client().get("http://localhost/").unwrap();
+/// let response = test_server.client().get("http://localhost/").perform().unwrap();
 /// assert_eq!(response.status(), StatusCode::Ok);
 /// let body = response.read_body().unwrap();
 /// assert_eq!(&body[..], b"This is the body content.");

--- a/src/test/request.rs
+++ b/src/test/request.rs
@@ -1,0 +1,69 @@
+use hyper::{Request, Uri, Method, Body};
+use hyper::error::UriError;
+use hyper::header::Header;
+
+use handler::NewHandler;
+use test::{TestClient, TestResponse, TestRequestError};
+
+/// Builder API for constructing `TestServer` requests.
+#[must_use]
+pub struct RequestBuilder<'a, NH>
+where
+    NH: NewHandler + 'static,
+{
+    client: TestClient<'a, NH>,
+    request: Result<Request, TestRequestError>,
+}
+
+impl<'a, NH> RequestBuilder<'a, NH>
+where
+    NH: NewHandler + 'static,
+{
+    pub(super) fn new(
+        client: TestClient<'a, NH>,
+        method: Method,
+        uri: Result<Uri, UriError>,
+    ) -> RequestBuilder<'a, NH> {
+        let request = match uri {
+            Ok(uri) => Ok(Request::new(method, uri)),
+            Err(e) => Err(e.into()),
+        };
+
+        RequestBuilder { client, request }
+    }
+
+    /// Adds the given header into the underlying `Request`, replacing any existing header of the
+    /// same type.
+    pub fn with_header<H>(self, header: H) -> RequestBuilder<'a, NH>
+    where
+        H: Header,
+    {
+        let mut request = self.request;
+
+        if let Ok(ref mut req) = request {
+            req.headers_mut().set(header);
+        }
+
+        RequestBuilder { request, ..self }
+    }
+
+    /// Adds the given body into the underlying `Request`, replacing any existing body.
+    pub fn with_body<T>(self, body: T) -> RequestBuilder<'a, NH>
+    where
+        T: Into<Body>,
+    {
+        let mut request = self.request;
+
+        if let Ok(ref mut req) = request {
+            req.set_body(body);
+        }
+
+        RequestBuilder { request, ..self }
+    }
+
+    /// Send a constructed request using the `TestClient` used to create this builder, and await
+    /// the response.
+    pub fn perform(self) -> Result<TestResponse<'a>, TestRequestError> {
+        self.client.perform(self.request?)
+    }
+}


### PR DESCRIPTION
The big pieces here:

* Retain the client address in `State` - it was previously available via `Request`, but after #45 we're no longer able to access it
* Refactor `TestServer` to take a `NewHandler` (most commonly this will be a `Router`) instead of a `NewService`. Previously, the test case needed to wrap its own handler in `NewHandlerService`
* Reduce the boilerplate needed to use `TestServer`, and make the API a little more intuitive

Before:

```rust
let new_service = NewHandlerService::new(router);
let mut test_server = TestServer::new(new_service).unwrap();
let client = test_server
    .client("127.0.0.1:10000".parse().unwrap())
    .unwrap();
let uri = "http://example.com/".parse().unwrap();
let response = test_server.run_request(client.get(uri)).unwrap();
assert_eq!(response.status(), StatusCode::Ok);
assert_eq!(
    test_server.read_body(response).unwrap(),
    b"Hello, world!"
);
```

After:

```rust
let test_server = TestServer::new(router).unwrap();
let response = test_server.client().get("http://example.com/").perform().unwrap();
assert_eq!(response.status(), StatusCode::Ok);
assert_eq!(response.read_body().unwrap(), b"Hello, world!");
```

Fixes #16 