### PR TITLE
Implement Clone for NewSessionMiddleware

### DIFF
--- a/src/middleware/session/backend/mod.rs
+++ b/src/middleware/session/backend/mod.rs
@@ -7,7 +7,7 @@ use futures::Future;
 use middleware::session::{SessionError, SessionIdentifier};
 
 /// Creates new `Backend` values.
-pub trait NewBackend: Sync {
+pub trait NewBackend: Sync + Clone {
     /// The type of `Backend` created by the implementor.
     type Instance: Backend + 'static;
 

--- a/src/middleware/session/mod.rs
+++ b/src/middleware/session/mod.rs
@@ -447,6 +447,24 @@ where
     }
 }
 
+impl<B, T> Clone for NewSessionMiddleware<B, T>
+where
+    B: NewBackend,
+    T: Default
+        + Serialize
+        + for<'de> Deserialize<'de>
+        + 'static,
+{
+    fn clone(&self) -> Self {
+        NewSessionMiddleware {
+            new_backend: self.new_backend.clone(),
+            identifier_rng: self.identifier_rng.clone(),
+            cookie_config: self.cookie_config.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl Default for NewSessionMiddleware<MemoryBackend, ()> {
     fn default() -> NewSessionMiddleware<MemoryBackend, ()> {
         NewSessionMiddleware::new(MemoryBackend::default())


### PR DESCRIPTION
To aid applications that want to pin the same session middleware at multiple places in their hierarchy, we can make the `NewSessionMiddleware` implement `Clone`.