### PR TITLE
Catch synchronous panics in `NewHandlerService`

### DIFF
--- a/examples/kitchen-sink/src/main.rs
+++ b/examples/kitchen-sink/src/main.rs
@@ -12,6 +12,8 @@ extern crate mime;
 
 mod middleware;
 
+use std::panic::RefUnwindSafe;
+
 use futures::{future, Future, Stream};
 
 use hyper::{Body, Response, Method, StatusCode};
@@ -70,7 +72,7 @@ fn static_route<NH, P, C>(
 where
     NH: NewHandler + 'static,
     C: PipelineHandleChain<P> + Send + Sync + 'static,
-    P: Send + Sync + 'static,
+    P: Send + Sync + RefUnwindSafe + 'static,
 {
     let matcher = MethodOnlyRouteMatcher::new(methods);
     let dispatcher = DispatcherImpl::new(new_handler, active_pipelines, pipeline_set);
@@ -93,7 +95,7 @@ fn dynamic_route<NH, P, C>(
 where
     NH: NewHandler + 'static,
     C: PipelineHandleChain<P> + Send + Sync + 'static,
-    P: Send + Sync + 'static,
+    P: Send + Sync + RefUnwindSafe + 'static,
 {
     let matcher = MethodOnlyRouteMatcher::new(methods);
     let dispatcher = DispatcherImpl::new(new_handler, active_pipelines, pipeline_set);

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -7,7 +7,6 @@
 
 use std::io;
 use std::sync::Arc;
-use std::error::Error;
 use std::panic::{AssertUnwindSafe, RefUnwindSafe};
 
 use hyper;
@@ -15,7 +14,7 @@ use hyper::server::{NewService, Service};
 use hyper::{Request, Response};
 use futures::{future, Future};
 
-use state::{State, set_request_id, request_id};
+use state::{State, set_request_id};
 use http::request::path::RequestPathSegments;
 
 mod error;

--- a/src/handler/timing.rs
+++ b/src/handler/timing.rs
@@ -1,0 +1,72 @@
+//! Defines types for timing requests and emitting timing information into logs and responses.
+
+use std::fmt::{self, Display, Formatter};
+
+use chrono::prelude::*;
+use hyper::Response;
+
+use state::{State, request_id};
+use http::header::XRuntimeMicroseconds;
+
+/// Used by `NewHandlerService` to time requests. The `elapsed` function returns the elapsed time
+/// in a way that can be used for logging and adding the `X-Runtime-Microseconds` header to
+/// responses.
+#[derive(Clone, Copy)]
+pub(super) struct Timer {
+    start: DateTime<Utc>,
+}
+
+impl Timer {
+    /// Begins measuring from the current time.
+    pub(super) fn new() -> Timer {
+        Timer { start: Utc::now() }
+    }
+
+    /// Finishes measuring, and returns the elapsed time as a `Timing` value.
+    pub(super) fn elapsed(self, state: &State) -> Timing {
+        let Timer { start } = self;
+        match Utc::now().signed_duration_since(start).num_microseconds() {
+            Some(dur) => Timing::Microseconds(dur),
+            None => {
+                error!(
+                    "[{}] Unable to measure timing of request, num_microseconds was None",
+                    request_id(state)
+                );
+                Timing::Invalid
+            }
+        }
+    }
+}
+
+/// Represents an elapsed time measured by `Timer`.
+#[derive(Clone, Copy)]
+pub(super) enum Timing {
+    /// A number of microseconds measured by `Timer`.
+    Microseconds(i64),
+
+    /// An invalid state, where the amount of time elapsed was unable to be measured.
+    Invalid,
+}
+
+impl Timing {
+    /// Converts a `Response` into a new `Response` with the `X-Runtime-Microseconds` header
+    /// included (assuming the time elapsed was able to be measured).
+    pub(super) fn add_to_response(&self, response: Response) -> Response {
+        match *self {
+            Timing::Microseconds(i) => response.with_header(XRuntimeMicroseconds(i)),
+            Timing::Invalid => response,
+        }
+    }
+}
+
+impl Display for Timing {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match *self {
+            Timing::Microseconds(i) => {
+                i.fmt(f)?;
+                f.write_str("µs")
+            }
+            Timing::Invalid => f.write_str("invalid"),
+        }
+    }
+}

--- a/src/handler/timing.rs
+++ b/src/handler/timing.rs
@@ -24,16 +24,23 @@ impl Timer {
 
     /// Finishes measuring, and returns the elapsed time as a `Timing` value.
     pub(super) fn elapsed(self, state: &State) -> Timing {
+        let timing = self.elapsed_no_logging();
+
+        if let Timing::Invalid = timing {
+            error!(
+                "[{}] Unable to measure timing of request, num_microseconds was None",
+                request_id(state)
+            );
+        }
+
+        timing
+    }
+
+    pub(super) fn elapsed_no_logging(self) -> Timing {
         let Timer { start } = self;
         match Utc::now().signed_duration_since(start).num_microseconds() {
             Some(dur) => Timing::Microseconds(dur),
-            None => {
-                error!(
-                    "[{}] Unable to measure timing of request, num_microseconds was None",
-                    request_id(state)
-                );
-                Timing::Invalid
-            }
+            None => Timing::Invalid,
         }
     }
 }

--- a/src/handler/trap.rs
+++ b/src/handler/trap.rs
@@ -135,7 +135,6 @@ mod tests {
     fn error() {
         let new_handler = || {
             Ok(|state| {
-                let res = create_response(&state, StatusCode::Accepted, None);
                 Box::new(future::err(
                     (state, io::Error::last_os_error().into_handler_error()),
                 )) as Box<HandlerFuture>
@@ -154,7 +153,7 @@ mod tests {
     #[test]
     fn panic() {
         let new_handler = || {
-            Ok(|state| {
+            Ok(|_| {
                 let val: Option<Box<HandlerFuture>> = None;
                 val.expect("test panic")
             })

--- a/src/handler/trap.rs
+++ b/src/handler/trap.rs
@@ -1,0 +1,101 @@
+//! Defines functionality for processing a request and trapping errors and panics in response
+//! generation.
+
+use std::panic::catch_unwind;
+use std::error::Error;
+
+use hyper::{self, Response, StatusCode};
+use futures::future::{self, Future, FutureResult};
+
+use handler::{NewHandler, Handler, HandlerError, IntoResponse};
+use handler::timing::Timer;
+use state::{State, request_id};
+
+pub(super) fn call_handler<T>(
+    t: &T,
+    state: State,
+) -> Box<Future<Item = Response, Error = hyper::Error>>
+where
+    T: NewHandler,
+{
+    let timer = Timer::new();
+
+    // TODO: catch_unwind
+    let res: Result<_, ()> = {
+        // Hyper doesn't allow us to present an affine-typed `Handler` interface directly. We have
+        // to emulate the promise given by hyper's documentation, by creating a `Handler` value and
+        // immediately consuming it.
+        let b: Box<Future<Item = _, Error = _>> = match t.new_handler() {
+            Ok(handler) => {
+                let f = handler.handle(state).then(move |result| match result {
+                    Ok((state, res)) => finalize_success_response(timer, state, res),
+                    Err((state, err)) => finalize_error_response(timer, state, err),
+                });
+
+                Box::new(f)
+            }
+            Err(e) => Box::new(future::err(e.into())),
+        };
+
+        Ok(b)
+    };
+
+    match res {
+        Ok(f) => f,
+        Err(_) => Box::new(finalize_panic_response(timer)),
+    }
+}
+
+fn finalize_success_response(
+    timer: Timer,
+    state: State,
+    response: Response,
+) -> FutureResult<Response, hyper::Error> {
+    let timing = timer.elapsed(&state);
+
+    info!(
+        "[RESPONSE][{}][{}][{}][{}]",
+        request_id(&state),
+        response.version(),
+        response.status(),
+        timing
+    );
+
+    future::ok(timing.add_to_response(response))
+}
+
+fn finalize_error_response(
+    timer: Timer,
+    state: State,
+    err: HandlerError,
+) -> FutureResult<Response, hyper::Error> {
+    let timing = timer.elapsed(&state);
+
+    {
+        // HandlerError::cause() is far more interesting for logging, but the
+        // API doesn't guarantee its presence (even though it always is).
+        let err_description = err.cause().map(Error::description).unwrap_or(
+            err.description(),
+        );
+
+        error!(
+            "[ERROR][{}][Error: {}][{}]",
+            request_id(&state),
+            err_description,
+            timing
+        );
+    }
+
+    future::ok(err.into_response(&state))
+}
+
+fn finalize_panic_response(timer: Timer) -> FutureResult<Response, hyper::Error> {
+    let timing = timer.elapsed_no_logging();
+
+    error!(
+        "[PANIC][A panic occurred while invoking the handler][{}]",
+        timing
+    );
+
+    future::ok(Response::new().with_status(StatusCode::InternalServerError))
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,6 +1,7 @@
 //! Defines types for Gotham middleware
 
 use std::io;
+use std::panic::RefUnwindSafe;
 
 use handler::HandlerFuture;
 use state::State;
@@ -152,7 +153,7 @@ pub trait Middleware {
 }
 
 /// Creates new `Middleware` values.
-pub trait NewMiddleware: Sync {
+pub trait NewMiddleware: Sync + RefUnwindSafe {
     /// The type of `Middleware` created by the implementor.
     type Instance: Middleware;
 

--- a/src/middleware/pipeline.rs
+++ b/src/middleware/pipeline.rs
@@ -1,6 +1,7 @@
 //! Defines types for a middleware pipeline
 
 use std::io;
+use std::panic::RefUnwindSafe;
 
 use handler::HandlerFuture;
 use middleware::{Middleware, NewMiddleware};
@@ -329,7 +330,7 @@ where
 /// This type should never be implemented outside of Gotham, does not form part of the public API,
 /// and is subject to change without notice.
 #[doc(hidden)]
-pub unsafe trait NewMiddlewareChain: Sized {
+pub unsafe trait NewMiddlewareChain: RefUnwindSafe + Sized {
     type Instance: MiddlewareChain;
 
     /// Create and return a new `MiddlewareChain` value.

--- a/src/middleware/session/backend/mod.rs
+++ b/src/middleware/session/backend/mod.rs
@@ -1,13 +1,14 @@
 pub(super) mod memory;
 
 use std::io;
+use std::panic::RefUnwindSafe;
 
 use futures::Future;
 
 use middleware::session::{SessionError, SessionIdentifier};
 
 /// Creates new `Backend` values.
-pub trait NewBackend: Sync + Clone {
+pub trait NewBackend: Sync + Clone + RefUnwindSafe {
     /// The type of `Backend` created by the implementor.
     type Instance: Backend + 'static;
 

--- a/src/middleware/session/mod.rs
+++ b/src/middleware/session/mod.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
+use std::panic::RefUnwindSafe;
 
 use base64;
 use rand::Rng;
@@ -344,7 +345,7 @@ where
 
 impl StateData for SessionDropData {}
 
-trait SessionTypePhantom<T>: Send + Sync
+trait SessionTypePhantom<T>: Send + Sync + RefUnwindSafe
 where
     T: Send
 {

--- a/src/router/response/extender.rs
+++ b/src/router/response/extender.rs
@@ -1,23 +1,24 @@
 //! Defines functionality for extending a Response
 
+use std::panic::RefUnwindSafe;
 use hyper::Response;
 use state::{State, request_id};
 
 /// Extend the Response based on current State and Response data
-pub trait StaticResponseExtender {
+pub trait StaticResponseExtender: RefUnwindSafe {
     /// Extend the response.
     fn extend(&mut State, &mut Response);
 }
 
 /// Allow complex types to extend the Response based on current State and Response data
-pub trait ResponseExtender {
+pub trait ResponseExtender: RefUnwindSafe {
     /// Extend the Response
     fn extend(&self, &mut State, &mut Response);
 }
 
 impl<F> ResponseExtender for F
 where
-    F: Fn(&mut State, &mut Response) + Send + Sync,
+    F: Fn(&mut State, &mut Response) + Send + Sync + RefUnwindSafe,
 {
     fn extend(&self, state: &mut State, res: &mut Response) {
         trace!(

--- a/src/router/route/matcher/mod.rs
+++ b/src/router/route/matcher/mod.rs
@@ -4,13 +4,15 @@ pub mod any;
 pub mod and;
 pub mod accept;
 
+use std::panic::RefUnwindSafe;
+
 use hyper::{Method, StatusCode};
 
 use state::{State, FromState, request_id};
 
 /// Determines if pre-defined conditions required for the associated `Route` to be invoked by
 /// the `Router` have been met.
-pub trait RouteMatcher {
+pub trait RouteMatcher: RefUnwindSafe {
     /// Determines if the `Request` meets pre-defined conditions.
     fn is_match(&self, state: &State) -> Result<(), StatusCode>;
 }

--- a/src/router/route/mod.rs
+++ b/src/router/route/mod.rs
@@ -8,6 +8,7 @@ pub mod matcher;
 pub mod dispatch;
 
 use std::marker::PhantomData;
+use std::panic::RefUnwindSafe;
 
 use hyper::Response;
 use hyper::StatusCode;
@@ -40,7 +41,7 @@ pub enum Delegation {
 ///
 /// Capable of delegating requests to secondary `Router` instances in order to support "Modular
 /// Applications".
-pub trait Route {
+pub trait Route: RefUnwindSafe {
     /// Determines if this `Route` can be invoked, based on the `Request`.
     fn is_match(&self, state: &State) -> Result<(), StatusCode>;
 

--- a/src/router/tree/mod.rs
+++ b/src/router/tree/mod.rs
@@ -7,6 +7,7 @@ use router::route::Route;
 use router::tree::node::{Node, NodeBuilder, SegmentType};
 
 pub mod node;
+pub mod regex;
 
 /// A depth ordered `Vec` of `Node` instances that create a routable path through the `Tree` for the
 /// matched `Request` path.

--- a/src/router/tree/regex.rs
+++ b/src/router/tree/regex.rs
@@ -3,7 +3,7 @@
 use regex::Regex;
 
 use std::cmp::Ordering;
-use std::panic::{AssertUnwindSafe, UnwindSafe, catch_unwind};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::process;
 
 /// A unwind-safe wrapper for Regex that implements PartialEq, Eq, PartialOrd, and Ord.  These
@@ -29,6 +29,8 @@ impl ConstrainedSegmentRegex {
         }
     }
 
+    /// Wraps `regex::Regex::is_match` to return true if and only if the regex matches the string
+    /// given.
     pub fn is_match(&self, s: &str) -> bool {
         match catch_unwind(|| self.regex.is_match(s)) {
             Ok(b) => b,

--- a/src/router/tree/regex.rs
+++ b/src/router/tree/regex.rs
@@ -1,0 +1,63 @@
+//! Defines the wrapping type for a segment-matching regex.
+
+use regex::Regex;
+
+use std::cmp::Ordering;
+use std::panic::{AssertUnwindSafe, UnwindSafe, catch_unwind};
+use std::process;
+
+/// A unwind-safe wrapper for Regex that implements PartialEq, Eq, PartialOrd, and Ord.  These
+/// traits are implemented in a potentially error-prone way by comparing the underlying &str
+/// representations of the regular expression.
+///
+/// If the `ConstrainedSegmentRegex::is_match` traps a panic from `Regex::is_match`,
+/// `std::process::abort()` will be called and the program will terminate.
+pub struct ConstrainedSegmentRegex {
+    regex: AssertUnwindSafe<Regex>,
+}
+
+impl ConstrainedSegmentRegex {
+    /// Creates a new ConstrainedSegmentRegex from a provided string.
+    ///
+    /// It wraps the string in begin and end of line anchors to prevent it from matching more than
+    /// intended.
+    pub fn new(regex: &str) -> Self {
+        ConstrainedSegmentRegex {
+            regex: AssertUnwindSafe(
+                Regex::new(&format!("^{pattern}$", pattern = regex)).unwrap(),
+            ),
+        }
+    }
+
+    pub fn is_match(&self, s: &str) -> bool {
+        match catch_unwind(|| self.regex.is_match(s)) {
+            Ok(b) => b,
+            Err(_) => {
+                eprintln!(
+                    "PANIC: Regex::is_match caused a panic, unable to rescue with a HTTP error"
+                );
+                process::abort()
+            }
+        }
+    }
+}
+
+impl PartialEq for ConstrainedSegmentRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.regex.as_str() == other.regex.as_str()
+    }
+}
+
+impl Eq for ConstrainedSegmentRegex {}
+
+impl PartialOrd for ConstrainedSegmentRegex {
+    fn partial_cmp(&self, other: &ConstrainedSegmentRegex) -> Option<Ordering> {
+        Some(self.regex.as_str().cmp(other.regex.as_str()))
+    }
+}
+
+impl Ord for ConstrainedSegmentRegex {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.regex.as_str().cmp(other.regex.as_str())
+    }
+}


### PR DESCRIPTION
This is part 1 of solving #17:

> A `catch_unwind` which handles a panic in a `Handler` and/or `Middleware` below, before the `Future` is returned

A few notes about this:

1. We've introduced `RefUnwindSafe` in quite a few places. The need for this originated from `NewHandler: RefUnwindSafe`, which has transitively required the trait bound elsewhere;
2. The `regex::Regex` type (which we use for segment constraints) [isn't unwind safe due to interior mutability](https://play.rust-lang.org/?gist=957e5ca4ed4a293241b3cddef314fcbb&version=stable). We work around this by:
    1. Reducing the surface area to only the `is_match` function, via our `ConstrainedSegmentRegex` wrapper; and
    2. Trapping a panic (which should be impossible) therein, and **aborting the process** to avoid leaving invalid state in the thread-local storage inside `Regex`.
3. This PR adds a `catch_unwind` to the `NewHandlerService` logic, which is intended to be a last resort effort to stop the application server falling over. Future work will hopefully see a more graceful panic-catching middleware which gives the `ResponseExtender` time to intervene before the `Response` is sent. There's no ability, nor any intention, to be able to customise the response which is sent at the `NewHandlerService` level.