### PR TITLE
Update borrow-bag crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mime = "0.3"
 futures = "~0.1.11"
 tokio-core = "0.1"
 mio = "0.6"
-borrow-bag = "0.3"
+borrow-bag = "0.4"
 url = "1.4.0"
 uuid = { version = "0.5", features = ["v4"] }
 chrono = "0.4"

--- a/src/router/route/dispatch.rs
+++ b/src/router/route/dispatch.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 use std::panic::RefUnwindSafe;
-use borrow_bag::{new_borrow_bag, BorrowBag, Handle, Lookup};
+use borrow_bag::{BorrowBag, Handle, Lookup};
 use futures::future;
 
 use handler::{Handler, NewHandler, HandlerFuture, IntoHandlerError};
@@ -19,7 +19,7 @@ pub type EditablePipelineSet<P> = BorrowBag<P>;
 ///
 /// See BorrowBag#add to insert new `Pipeline` instances.
 pub fn new_pipeline_set() -> EditablePipelineSet<()> {
-    new_borrow_bag()
+    BorrowBag::new()
 }
 
 /// Wraps the current set of `Pipeline` instances into a thread-safe reference counting pointer for


### PR DESCRIPTION
I've simplified the `BorrowBag` construction to idiomatic Rust code.

- [ ] Requires https://github.com/gotham-rs/borrow-bag/pull/8

Let me know what you think. This change seams not to break the public interface.