### PR TITLE
Remove unused AsciiExt import

### DIFF
--- a/src/http/header/x_content_type_options.rs
+++ b/src/http/header/x_content_type_options.rs
@@ -1,7 +1,6 @@
 //! Define the X-Content-Type-Options header.
 
 use std::fmt;
-use std::ascii::AsciiExt;
 
 use hyper;
 use hyper::header::{Header, Raw, Formatter, parsing};

--- a/src/http/header/x_frame_options.rs
+++ b/src/http/header/x_frame_options.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 use std::str::FromStr;
-use std::ascii::AsciiExt;
 
 use hyper;
 use hyper::Uri;


### PR DESCRIPTION
This fixes the two following compiler warnings

```
warning: unused import: `std::ascii::AsciiExt`
 --> src/http/header/x_frame_options.rs:5:5
  |
5 | use std::ascii::AsciiExt;
  |     ^^^^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: unused import: `std::ascii::AsciiExt`
 --> src/http/header/x_content_type_options.rs:4:5
  |
4 | use std::ascii::AsciiExt;
  |     ^^^^^^^^^^^^^^^^^^^^
```