### PR TITLE
Refactor set_request_id into method of State

### DIFF
--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -94,11 +94,10 @@ impl HandlerError {
     /// # use hyper::header::Headers;
     /// # use gotham::state::State;
     /// # use gotham::handler::{IntoResponse, IntoHandlerError};
-    /// # use gotham::state::request_id::set_request_id;
     /// # fn main() {
     /// # let mut state = State::new();
     /// # state.put(Headers::new());
-    /// # set_request_id(&mut state);
+    /// # state.set_request_id();
     /// let io_error = std::io::Error::last_os_error();
     /// let handler_error = io_error
     ///     .into_handler_error()

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -14,7 +14,7 @@ use hyper::server::{NewService, Service};
 use hyper::{Request, Response};
 use futures::{future, Future};
 
-use state::{State, set_request_id};
+use state::State;
 use http::request::path::RequestPathSegments;
 
 mod error;
@@ -157,7 +157,7 @@ where
         state.put(version);
         state.put(headers);
         state.put(body);
-        set_request_id(&mut state);
+        state.set_request_id();
 
         trap::call_handler(self.t.as_ref(), AssertUnwindSafe(state))
     }

--- a/src/handler/trap.rs
+++ b/src/handler/trap.rs
@@ -110,7 +110,6 @@ mod tests {
     use hyper::{StatusCode, Headers};
 
     use http::response::create_response;
-    use state::set_request_id;
     use handler::{IntoHandlerError, HandlerFuture};
 
     #[test]
@@ -124,7 +123,7 @@ mod tests {
 
         let mut state = State::new();
         state.put(Headers::new());
-        set_request_id(&mut state);
+        state.set_request_id();
 
         let r = call_handler(&new_handler, AssertUnwindSafe(state));
         let response = r.wait().unwrap();
@@ -143,7 +142,7 @@ mod tests {
 
         let mut state = State::new();
         state.put(Headers::new());
-        set_request_id(&mut state);
+        state.set_request_id();
 
         let r = call_handler(&new_handler, AssertUnwindSafe(state));
         let response = r.wait().unwrap();
@@ -161,7 +160,7 @@ mod tests {
 
         let mut state = State::new();
         state.put(Headers::new());
-        set_request_id(&mut state);
+        state.set_request_id();
 
         let r = call_handler(&new_handler, AssertUnwindSafe(state));
         let response = r.wait().unwrap();

--- a/src/http/response/mod.rs
+++ b/src/http/response/mod.rs
@@ -38,7 +38,6 @@ pub fn create_response(state: &State, status: StatusCode, body: Option<Body>) ->
 /// # use hyper::{Response, Method, StatusCode};
 /// # use hyper::header::{Headers, ContentType, ContentLength};
 /// # use gotham::state::State;
-/// # use gotham::state::set_request_id;
 /// # use gotham::http::response::extend_response;
 /// # use gotham::http::header::XRequestId;
 /// #
@@ -47,7 +46,7 @@ pub fn create_response(state: &State, status: StatusCode, body: Option<Body>) ->
 /// #   let m = Method::Get;
 /// #   state.put(m);
 /// #   state.put(Headers::new());
-/// #   let req_id = String::from(set_request_id(&mut state));
+/// #   let req_id = String::from(state.set_request_id());
 ///     let status = StatusCode::Ok;
 ///     let mime = mime::TEXT_PLAIN;
 ///     let expected_mime = mime.clone();
@@ -105,14 +104,13 @@ pub fn extend_response(state: &State, res: &mut Response, status: StatusCode, bo
 /// # use hyper::Response;
 /// # use hyper::header::{Headers, ContentType, ContentLength};
 /// # use gotham::state::State;
-/// # use gotham::state::set_request_id;
 /// # use gotham::http::response::set_headers;
 /// # use gotham::http::header::XRequestId;
 /// #
 /// # fn main() {
 /// #   let mut state = State::new();
 /// #   state.put(Headers::new());
-/// #   let req_id = String::from(set_request_id(&mut state));
+/// #   let req_id = String::from(state.set_request_id());
 /// #   let mut res = Response::new();
 ///     let mime = mime::TEXT_HTML;
 ///     let expected_mime = mime.clone();
@@ -132,14 +130,13 @@ pub fn extend_response(state: &State, res: &mut Response, status: StatusCode, bo
 /// # use hyper::Response;
 /// # use hyper::header::{Headers, ContentType, ContentLength};
 /// # use gotham::state::State;
-/// # use gotham::state::set_request_id;
 /// # use gotham::http::response::set_headers;
 /// # use gotham::http::header::XRequestId;
 /// #
 /// # fn main() {
 /// #   let mut state = State::new();
 /// #   state.put(Headers::new());
-/// #   let req_id = String::from(set_request_id(&mut state));
+/// #   let req_id = String::from(state.set_request_id());
 /// #   let mut res = Response::new();
 ///     set_headers(&state, &mut res, None, None);
 ///     assert_eq!(res.headers().get::<XRequestId>().unwrap().as_str(), req_id);

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -217,7 +217,6 @@ mod tests {
     use router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, DispatcherImpl};
     use router::route::matcher::MethodOnlyRouteMatcher;
     use router::response::finalizer::ResponseFinalizerBuilder;
-    use state::set_request_id;
     use handler::HandlerError;
 
     fn handler(state: State) -> (State, Response) {
@@ -236,7 +235,7 @@ mod tests {
         state.put(method);
         state.put(uri);
         state.put(Headers::new());
-        set_request_id(&mut state);
+        state.set_request_id();
 
         r.handle(state).wait()
     }
@@ -254,7 +253,7 @@ mod tests {
         state.put(method);
         state.put(uri);
         state.put(Headers::new());
-        set_request_id(&mut state);
+        state.set_request_id();
 
         match router.handle(state).wait() {
             Ok((_state, res)) => {


### PR DESCRIPTION
This simplifies the exposed interface. IMO it makes sense to have this function as method.