### PR TITLE
Update hyper to 0.11.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ci = []
 
 [dependencies]
 log = "0.3"
-hyper = "~0.11.2"
+hyper = "~0.11.7"
 serde = "~1.0"
 serde_derive = "~1.0"
 bincode = "0.8"

--- a/examples/kitchen-sink/Cargo.toml
+++ b/examples/kitchen-sink/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Shaun Mangelsdorf <s.mangelsdorf@gmail.com>",
 gotham = { path = "../.." }
 gotham_derive = { path = "../../gotham_derive" }
 futures = "*"
-hyper="~0.11.2"
+hyper="~0.11.7"
 borrow-bag = "*"
 log = "0.3"
 fern = "0.4"


### PR DESCRIPTION
This allows sharing of the tokio core handle by using [`hyper::server::Http::serve_addr_handle`](https://docs.rs/hyper/0.11.7/hyper/server/struct.Http.html#method.serve_addr_handle) to create the http
server.

Motivation: I'm currently trying to integrate [Sentry](https://github.com/SecurityInsanity/sentry-rs) as Gotham middleware to report errors/crashes. Since the library uses async Hyper, a handle reference is needed. However, with the previous version of Hyper, the handle was created together with the server. At that point the router had to be set up already and thus it was impossible to use the same tokio core. Fortunately, the Hyper lib seems to have added this feature of a shared core recently.