### PR TITLE
Write ThreadId as debug log statement

### DIFF
--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! [handler-impl]: trait.Handler.html#implementors
 
-use std::io;
+use std::{io, thread};
 use std::sync::Arc;
 use std::panic::{AssertUnwindSafe, RefUnwindSafe};
 
@@ -14,7 +14,7 @@ use hyper::server::{NewService, Service};
 use hyper::{Request, Response};
 use futures::{future, Future};
 
-use state::{State, set_request_id};
+use state::{State, request_id, set_request_id};
 use state::client_addr::put_client_addr;
 use http::request::path::RequestPathSegments;
 
@@ -164,6 +164,12 @@ where
         state.put(headers);
         state.put(body);
         set_request_id(&mut state);
+
+        debug!(
+            "[DEBUG][{}][Thread][{:?}]",
+            request_id(&state),
+            thread::current().id(),
+        );
 
         trap::call_handler(self.t.as_ref(), AssertUnwindSafe(state))
     }


### PR DESCRIPTION
To assist with diagnosing issues with concurrency, we can ensure the current thread is written as a debug log statement before the request is dispatched to a Handler. The value should be considered opaque and need not correspond to any system-designated identifier for the thread, but is sufficient for proving whether requests are served by the same, or different threads.