### PR TITLE
Implement custom derive for NewMiddleware

### DIFF
--- a/examples/kitchen-sink/src/middleware.rs
+++ b/examples/kitchen-sink/src/middleware.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use gotham;
 use gotham::handler::HandlerFuture;
 use gotham::state::State;
-use gotham::middleware::{Middleware, NewMiddleware};
+use gotham::middleware::Middleware;
 use futures::{future, Future};
 
 use gotham::state::request_id;
@@ -13,16 +11,9 @@ pub struct KitchenSinkData {
     pub header_value: String,
 }
 
+#[derive(Clone, NewMiddleware)]
 pub struct KitchenSinkMiddleware {
     pub header_name: &'static str,
-}
-
-impl NewMiddleware for KitchenSinkMiddleware {
-    type Instance = KitchenSinkMiddleware;
-
-    fn new_middleware(&self) -> io::Result<Self::Instance> {
-        Ok(KitchenSinkMiddleware { ..*self })
-    }
 }
 
 impl Middleware for KitchenSinkMiddleware {

--- a/gotham_derive/src/lib.rs
+++ b/gotham_derive/src/lib.rs
@@ -9,6 +9,7 @@ mod extractors;
 mod extenders;
 mod state;
 mod helpers;
+mod new_middleware;
 
 #[proc_macro_derive(PathExtractor)]
 pub fn base_path_extractor(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -35,5 +36,12 @@ pub fn static_response_extender(input: proc_macro::TokenStream) -> proc_macro::T
 pub fn state_data(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse_macro_input(&input.to_string()).unwrap();
     let gen = state::state_data(&ast);
+    gen.parse().unwrap()
+}
+
+#[proc_macro_derive(NewMiddleware)]
+pub fn new_middleware(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse_macro_input(&input.to_string()).unwrap();
+    let gen = new_middleware::new_middleware(&ast);
     gen.parse().unwrap()
 }

--- a/gotham_derive/src/new_middleware.rs
+++ b/gotham_derive/src/new_middleware.rs
@@ -1,0 +1,25 @@
+use syn;
+use quote;
+
+use helpers::ty_params;
+
+pub fn new_middleware(ast: &syn::DeriveInput) -> quote::Tokens {
+    let (name, borrowed, where_clause) = ty_params(&ast, None);
+
+    quote! {
+        impl #borrowed ::gotham::middleware::NewMiddleware for #name #borrowed #where_clause {
+            type Instance = Self;
+
+            fn new_middleware(&self) -> ::std::io::Result<Self> {
+                // Calling it this way makes the error look like this:
+                //
+                // | #[derive(NewMiddleware)]
+                // |          ^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented [...]
+                // |
+                // = note: required by `std::clone::Clone::clone`
+                let new = <Self as Clone>::clone(self);
+                Ok(new)
+            }
+        }
+    }
+}


### PR DESCRIPTION
As raised in #74, it's often the case that the `NewMiddleware` implementation is just a piece of boilerplate. A lot of use cases for middleware can be implementing using a single struct which just uses `Clone` to implement `NewMiddleware`. This goes one step further and allows `NewMiddleware` to be derived too.

The derived `NewMiddleware` implementation requires that the type also implements `Clone`.