### PR TITLE
Update Gotham to 0.2-dev

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gotham"
-version = "0.1.2" # Alter html_root_url in lib.rs also
+version = "0.2.0-dev" # Alter html_root_url in lib.rs also
 authors = ["Shaun Mangelsdorf <s.mangelsdorf@gmail.com>",
            "Bradley Beddoes <bradleybeddoes@gmail.com>"]
 description = "A flexible web framework that does not sacrifice safety, security or speed."

--- a/gotham_derive/Cargo.toml
+++ b/gotham_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gotham_derive"
-version = "0.1.0"
+version = "0.2.0-dev"
 authors = ["Bradley Beddoes <bradleybeddoes@gmail.com>",
            "Shaun Mangelsdorf <s.mangelsdorf@gmail.com>"]
 description = "Macros 1.1 implementations for Gotham traits"


### PR DESCRIPTION
In the future appening `-dev` to master will occur the first time we start to make additions towards a future release (for any crate).

Versions with `-dev` will not get published to crates.io.

Once a set of features for a release are complete, `-alpha` and `-beta` identifiers and publishing to crates.io will occur, eventually followed by the final release.