### PR TITLE
Include `Allow` header with a 405 response

### DIFF
--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -273,6 +273,7 @@ mod tests {
     fn allow_header_if_method_not_allowed() {
         let router = build_simple_router(|route| {
             route.get_or_head("/test").to(handler);
+            route.get("/test").to(handler); // Proves deduplication works.
             route.delete("/test").to(handler);
             route.options("/test/2").to(handler);
         });

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -1,6 +1,6 @@
 //! Defines the type `AcceptMatcher`
 
-use hyper::StatusCode;
+use hyper::{Method, StatusCode};
 use hyper::header::{Accept, Headers};
 use mime;
 
@@ -106,5 +106,9 @@ impl RouteMatcher for AcceptHeaderRouteMatcher {
             // this is valid.
             None => Ok(()),
         }
+    }
+
+    fn allow_header_method_list(&self) -> Vec<Method> {
+        vec![]
     }
 }

--- a/gotham/src/router/route/matcher/and.rs
+++ b/gotham/src/router/route/matcher/and.rs
@@ -1,6 +1,6 @@
 //! Defines the type `AndRouteMatcher`
 
-use hyper::StatusCode;
+use hyper::{Method, StatusCode};
 
 use router::route::RouteMatcher;
 use state::State;
@@ -78,5 +78,13 @@ where
         self.u.is_match(state)?;
 
         Ok(())
+    }
+
+    fn allow_header_method_list(&self) -> Vec<Method> {
+        let t_iter = self.t.allow_header_method_list().into_iter();
+        let u_iter = self.u.allow_header_method_list().into_iter();
+
+        // Deduplication happens later, we don't need to worry about it here.
+        t_iter.chain(u_iter).collect()
     }
 }

--- a/gotham/src/router/route/matcher/any.rs
+++ b/gotham/src/router/route/matcher/any.rs
@@ -1,6 +1,6 @@
 //! Defines the type `AnyRouteMatcher`
 
-use hyper::StatusCode;
+use hyper::{Method, StatusCode};
 
 use router::route::RouteMatcher;
 use state::State;
@@ -35,5 +35,9 @@ impl AnyRouteMatcher {
 impl RouteMatcher for AnyRouteMatcher {
     fn is_match(&self, _state: &State) -> Result<(), StatusCode> {
         Ok(())
+    }
+
+    fn allow_header_method_list(&self) -> Vec<Method> {
+        vec![]
     }
 }

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -15,6 +15,14 @@ use state::{request_id, FromState, State};
 pub trait RouteMatcher: RefUnwindSafe {
     /// Determines if the `Request` meets pre-defined conditions.
     fn is_match(&self, state: &State) -> Result<(), StatusCode>;
+
+    /// Determines the set of HTTP methods which should be added into a 405 response that
+    /// considered this `RouteMatcher`.
+    ///
+    /// This is **only** used to inform the `Allow` header which is sent for a 405 response, and
+    /// may not be suitable for other purposes. In particular, matchers which don't restrict the
+    /// HTTP method may return an empty `Vec`.
+    fn allow_header_method_list(&self) -> Vec<Method>;
 }
 
 /// A `RouteMatcher` that succeeds when the `Request` has been made with one
@@ -70,5 +78,9 @@ impl RouteMatcher for MethodOnlyRouteMatcher {
             );
             Err(StatusCode::MethodNotAllowed)
         }
+    }
+
+    fn allow_header_method_list(&self) -> Vec<Method> {
+        self.methods.clone()
     }
 }


### PR DESCRIPTION
This populates each `Node` in the router tree with a list of HTTP methods that should be sent in an `Allow` header, if a request reaches that `Node` but is rejected with `Err(StatusCode::MethodNotAllowed)`.

It's a different approach to what's described in #3, and if there is some nuance that is missed by this implementation I'm more than happy to discuss / refine / rewrite to make sure we have the correct behaviour. However, all the cases I can think of are covered (particularly, if a correctly-implemented `RouteMatcher` is rejecting a request with a `405` response, the `Allow` list should be correct).

The goal in taking this approach was to avoid mutating `State` during the normal course of serving a request, to populate it with data that won't be used for the vast majority of requests.