### PR TITLE
Include `Allow` header with a 405 response (rewrite)

### DIFF
--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -5,7 +5,7 @@ pub mod tree;
 pub mod route;
 pub mod request;
 pub mod response;
-mod non_match;
+pub mod non_match;
 
 use std::io;
 use std::sync::Arc;

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -5,12 +5,14 @@ pub mod tree;
 pub mod route;
 pub mod request;
 pub mod response;
+mod non_match;
 
 use std::io;
 use std::sync::Arc;
 
 use futures::{future, Future};
 use hyper::{Response, StatusCode};
+use hyper::header::Allow;
 
 use handler::{Handler, HandlerFuture, IntoResponse, NewHandler};
 use http::request::path::RequestPathSegments;
@@ -106,9 +108,14 @@ impl Handler for Router {
                                 self.dispatch(state, sm, route)
                             }
                         },
-                        Err(status) => {
+                        Err(non_match) => {
+                            let (status, allow) = non_match.deconstruct();
+
                             trace!("[{}] responding with error status", request_id(&state));
-                            let res = create_response(&state, status, None);
+                            let mut res = create_response(&state, status, None);
+                            if let StatusCode::MethodNotAllowed = status {
+                                res.headers_mut().set(Allow(allow));
+                            }
                             Box::new(future::ok((state, res)))
                         }
                     }

--- a/gotham/src/router/non_match.rs
+++ b/gotham/src/router/non_match.rs
@@ -1,0 +1,75 @@
+use std::collections::HashSet;
+
+use hyper::{Method, StatusCode};
+
+pub struct RouteNonMatch {
+    status: StatusCode,
+    allow: HashSet<Method>,
+}
+
+impl RouteNonMatch {
+    pub(super) fn new(status: StatusCode) -> RouteNonMatch {
+        use hyper::Method::*;
+
+        RouteNonMatch {
+            status,
+            allow: [Options, Get, Post, Put, Delete, Head, Patch]
+                .into_iter()
+                .cloned()
+                .collect(),
+        }
+    }
+
+    pub(super) fn with_allow_list(self, allow: &[Method]) -> RouteNonMatch {
+        RouteNonMatch {
+            allow: allow.into_iter().cloned().collect(),
+            ..self
+        }
+    }
+
+    pub(super) fn intersection(self, other: RouteNonMatch) -> RouteNonMatch {
+        let status = higher_precedence_status(self.status, other.status);
+        let allow = self.allow.intersection(&other.allow).cloned().collect();
+        RouteNonMatch { status, allow }
+    }
+
+    pub(super) fn union(self, other: RouteNonMatch) -> RouteNonMatch {
+        let status = higher_precedence_status(self.status, other.status);
+        let allow = self.allow.union(&other.allow).cloned().collect();
+        RouteNonMatch { status, allow }
+    }
+
+    pub(super) fn deconstruct(self) -> (StatusCode, Vec<Method>) {
+        let RouteNonMatch { status, allow } = self;
+        let mut allow: Vec<Method> = allow.into_iter().collect();
+        allow.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
+        (status, allow)
+    }
+}
+
+impl From<RouteNonMatch> for StatusCode {
+    fn from(val: RouteNonMatch) -> StatusCode {
+        val.status
+    }
+}
+
+fn higher_precedence_status(lhs: StatusCode, rhs: StatusCode) -> StatusCode {
+    use hyper::StatusCode::*;
+
+    match (lhs, rhs) {
+        // For 404, prefer routes that indicated *some* kind of match.
+        (NotFound, _) => rhs,
+        (_, NotFound) => lhs,
+        // For 405, prefer routes that matched the HTTP method.
+        (MethodNotAllowed, _) => rhs,
+        (_, MethodNotAllowed) => lhs,
+        // For 406, allow "harder" errors to overrule.
+        (NotAcceptable, _) => rhs,
+        (_, NotAcceptable) => lhs,
+        // This is a silly safeguard that prefers errors over non-errors. This should never be
+        // needed, but guards against strange custom `RouteMatcher` impls in applications.
+        (_, _) if lhs.is_client_error() => lhs,
+        (_, _) if rhs.is_client_error() => rhs,
+        (_, _) => lhs,
+    }
+}

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -4,7 +4,8 @@ use hyper::StatusCode;
 use hyper::header::{Accept, Headers};
 use mime;
 
-use router::route::matcher::RouteMatcher;
+use router::non_match::RouteNonMatch;
+use router::route::RouteMatcher;
 use state::{request_id, FromState, State};
 
 /// A `RouteMatcher` that succeeds when the `Request` has been made with an `Accept` header that
@@ -84,7 +85,7 @@ impl RouteMatcher for AcceptHeaderRouteMatcher {
     /// will also positvely match.
     ///
     /// Quality values within `Accept` header values are not considered by the matcher.
-    fn is_match(&self, state: &State) -> Result<(), StatusCode> {
+    fn is_match(&self, state: &State) -> Result<(), RouteNonMatch> {
         // Request method is valid, ensure valid Accept header
         let headers = Headers::borrow_from(state);
         match headers.get::<Accept>() {
@@ -100,7 +101,7 @@ impl RouteMatcher for AcceptHeaderRouteMatcher {
                     "[{}] did not provide an Accept with media types supported by this Route",
                     request_id(&state)
                 );
-                Err(StatusCode::NotAcceptable)
+                Err(RouteNonMatch::new(StatusCode::NotAcceptable))
             }
             // The client has not specified an `Accept` header, as we can now respond with any type
             // this is valid.

--- a/gotham/src/router/route/matcher/and.rs
+++ b/gotham/src/router/route/matcher/and.rs
@@ -1,7 +1,6 @@
 //! Defines the type `AndRouteMatcher`
 
-use hyper::StatusCode;
-
+use router::non_match::RouteNonMatch;
 use router::route::RouteMatcher;
 use state::State;
 
@@ -73,10 +72,12 @@ where
     T: RouteMatcher,
     U: RouteMatcher,
 {
-    fn is_match(&self, state: &State) -> Result<(), StatusCode> {
-        self.t.is_match(state)?;
-        self.u.is_match(state)?;
-
-        Ok(())
+    fn is_match(&self, state: &State) -> Result<(), RouteNonMatch> {
+        match (self.t.is_match(state), self.u.is_match(state)) {
+            (Ok(_), Ok(_)) => Ok(()),
+            (Err(e), Ok(_)) => Err(e),
+            (Ok(_), Err(e)) => Err(e),
+            (Err(e), Err(e1)) => Err(e.intersection(e1)),
+        }
     }
 }

--- a/gotham/src/router/route/matcher/any.rs
+++ b/gotham/src/router/route/matcher/any.rs
@@ -1,7 +1,6 @@
 //! Defines the type `AnyRouteMatcher`
 
-use hyper::StatusCode;
-
+use router::non_match::RouteNonMatch;
 use router::route::RouteMatcher;
 use state::State;
 
@@ -33,7 +32,7 @@ impl AnyRouteMatcher {
 }
 
 impl RouteMatcher for AnyRouteMatcher {
-    fn is_match(&self, _state: &State) -> Result<(), StatusCode> {
+    fn is_match(&self, _state: &State) -> Result<(), RouteNonMatch> {
         Ok(())
     }
 }

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -11,10 +11,10 @@ use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
 use hyper::Response;
-use hyper::StatusCode;
 
 use router::route::dispatch::Dispatcher;
 use handler::HandlerFuture;
+use router::non_match::RouteNonMatch;
 use router::request::query_string::QueryStringExtractor;
 use router::route::matcher::RouteMatcher;
 use router::tree::SegmentMapping;
@@ -43,7 +43,7 @@ pub enum Delegation {
 /// Applications".
 pub trait Route: RefUnwindSafe {
     /// Determines if this `Route` can be invoked, based on the `Request`.
-    fn is_match(&self, state: &State) -> Result<(), StatusCode>;
+    fn is_match(&self, state: &State) -> Result<(), RouteNonMatch>;
 
     /// Determines if this `Route` intends to delegate requests to a secondary `Router` instance.
     fn delegation(&self) -> Delegation;
@@ -221,7 +221,7 @@ where
     RE: PathExtractor,
     QSE: QueryStringExtractor,
 {
-    fn is_match(&self, state: &State) -> Result<(), StatusCode> {
+    fn is_match(&self, state: &State) -> Result<(), RouteNonMatch> {
         self.matcher.is_match(state)
     }
 


### PR DESCRIPTION
This is a competing solution for #3 (the other solution being #100). This builds the `Allow` list on-demand, rather than prepopulating it in the tree.

The advantages of this approach:

* We're only creating data which represents reality (contrast with #100 which unnecessarily populated a list)
* This is _far_ more capable of handling weird behaviour that could be thrown at us by custom `RouteMatcher` implementations in the future. I can think of some crazy `RouteMatcher` implementations that would trip up the logic in #100.
* The `Allow` list in this case could be used for _other_ error codes if the need arose in future. A small refactor would also see it more widely available (perhaps even via `State`) if/when the need arises. I can't see a reason to do it today, so I haven't.

I'm going to attempt an optimisation to remove the `HashSet` (and therefore the memory allocation) from `RouteNonMatch`, but this is otherwise ready for review / consideration.