### PR TITLE
Refactor core creation out of serve & listen

### DIFF
--- a/gotham/src/os/unix.rs
+++ b/gotham/src/os/unix.rs
@@ -1,10 +1,11 @@
+use std::io;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::thread;
 use std::sync::Arc;
 
 use hyper::server::Http;
 use tokio_core;
-use tokio_core::reactor::Core;
+use tokio_core::reactor::{Core, Handle};
 use futures::{Future, Stream};
 
 use handler::NewHandler;
@@ -32,29 +33,42 @@ where
         let listener = listener.try_clone().expect("unable to clone TCP listener");
         let protocol = protocol.clone();
         let new_handler = new_handler.clone();
-        thread::spawn(move || serve(listener, &addr, &protocol, new_handler));
+        thread::spawn(move || start_core(listener, &addr, &protocol, new_handler));
     }
 
-    serve(listener, &addr, &protocol, new_handler);
+    start_core(listener, &addr, &protocol, new_handler);
 }
 
-fn serve<NH>(listener: TcpListener, addr: &SocketAddr, protocol: &Http, new_handler: Arc<NH>)
+fn start_core<NH>(listener: TcpListener, addr: &SocketAddr, protocol: &Http, new_handler: Arc<NH>)
 where
     NH: NewHandler + 'static,
 {
     let mut core = Core::new().expect("unable to spawn tokio reactor");
     let handle = core.handle();
+    core.run(serve(listener, addr, protocol, new_handler, handle))
+        .expect("unable to run reactor over listener");
+}
 
+fn serve<'a, NH>(
+    listener: TcpListener,
+    addr: &SocketAddr,
+    protocol: &'a Http,
+    new_handler: Arc<NH>,
+    handle: Handle,
+) -> Box<Future<Item = (), Error = io::Error> + 'a>
+where
+    NH: NewHandler + 'static,
+{
     let gotham_service = GothamService::new(new_handler, handle.clone());
 
     let listener = tokio_core::net::TcpListener::from_listener(listener, addr, &handle)
         .expect("unable to convert TCP listener to tokio listener");
 
-    core.run(listener.incoming().for_each(|(socket, addr)| {
+    Box::new(listener.incoming().for_each(move |(socket, addr)| {
         let service = gotham_service.connect(addr);
         let f = protocol.serve_connection(socket, service).then(|_| Ok(()));
 
         handle.spawn(f);
         Ok(())
-    })).expect("unable to run reactor over listener");
+    }))
 }

--- a/gotham/src/os/windows.rs
+++ b/gotham/src/os/windows.rs
@@ -82,7 +82,7 @@ where
 fn start_listen_core(listener: TcpListener, addr: SocketAddr, queue: SocketQueue) {
     let mut core = Core::new().expect("unable to spawn tokio reactor");
     let handle = core.handle();
-    core.run(listen(listener, addr, queue, handle))
+    core.run(listen(listener, addr, queue, &handle))
         .expect("unable to run reactor over listener");
 }
 
@@ -90,9 +90,9 @@ fn listen(
     listener: TcpListener,
     addr: SocketAddr,
     queue: SocketQueue,
-    handle: Handle,
+    handle: &Handle,
 ) -> Box<Future<Item = (), Error = io::Error>> {
-    let listener = tokio_core::net::TcpListener::from_listener(listener, &addr, &handle)
+    let listener = tokio_core::net::TcpListener::from_listener(listener, &addr, handle)
         .expect("unable to convert TCP listener to tokio listener");
 
     let mut n: usize = 0;
@@ -116,7 +116,7 @@ where
 {
     let mut core = Core::new().expect("unable to spawn tokio reactor");
     let handle = core.handle();
-    core.run(serve(queue, protocol, new_handler, handle))
+    core.run(serve(queue, protocol, new_handler, &handle))
         .expect("unable to run reactor for work stealing");
 }
 
@@ -124,7 +124,7 @@ fn serve<'a, NH>(
     queue: SocketQueue,
     protocol: &'a Http,
     new_handler: Arc<NH>,
-    handle: Handle,
+    handle: &'a Handle,
 ) -> Box<Future<Item = (), Error = ()> + 'a>
 where
     NH: NewHandler + 'static,


### PR DESCRIPTION
This change decouples the code that creates a `Core` and `Handle` from the code that uses it - the former is pulled out into new functions `start_code` and co, while the latter remains in `serve` and `listen`.

As discussed in #95, the intention is for `serve`, `listen` and other necessary parts of the code can then be made public, providing an interface by which a user can start a gotham server on a provided `Handle` instance.