### PR TITLE
Fix inconsistent example logs

### DIFF
--- a/examples/basic_router/README.md
+++ b/examples/basic_router/README.md
@@ -12,7 +12,7 @@ $ cargo run
    Compiling basic_router (file:///.../examples/basic_router)
     Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
      Running `../basic_router`
-  Accepting requests at http://127.0.0.1:7878
+  Listening for requests at http://127.0.0.1:7878
 
 Terminal 2:
 $ curl -v http://127.0.0.1:7878/checkout/start

--- a/examples/hello_router/README.md
+++ b/examples/hello_router/README.md
@@ -12,7 +12,7 @@ $ cargo run
    Compiling hello_router (file:///.../examples/hello_router)
     Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
      Running `../hello_router`
-  Accepting requests at http://127.0.0.1:7878
+  Listening for requests at http://127.0.0.1:7878
 
 Terminal 2:
 $ curl -v http://127.0.0.1:7878/

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -12,7 +12,7 @@ $ cargo run
    Compiling hello_world (file:///.../examples/hello_world)
     Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
      Running `../hello_world`
-  Accepting requests at http://127.0.0.1:7878
+  Listening for requests at http://127.0.0.1:7878
 
 Terminal 2:
 $ curl -v http://127.0.0.1:7878/


### PR DESCRIPTION
Minor change to match `examples/*/README.md` examples to code output.