### PR TITLE
Add Basic Path Extractor Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ members = [
     "examples/basic_router",
     "examples/hello_header",
     "examples/basic_into_response",
+    "examples/basic_path_extractor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "examples/hello_world",
     "examples/hello_router",
     "examples/basic_router",
+    "examples/basic_into_response",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
     "examples/hello_world",
     "examples/hello_router",
     "examples/basic_router",
+    "examples/hello_header",
     "examples/basic_into_response",
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ concepts and functionality provided by Gotham from introductory through to advan
 
 1. [Hello World](hello_world) - A Hello World example application for working with Gotham.
 1. [Hello Router](hello_router) - A Hello World example application for working with the Gotham Router.
+1. [Hello Header](hello_header) - A simple introduction to working with Gotham and custom headers.
 1. [Basic Router](basic_router) - An example of the Gotham Router showing usage of HTTP verbs such as Get and Post.
 1. [Into Response](basic_into_response) - An example of implementing the `IntoResponse` trait
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ concepts and functionality provided by Gotham from introductory through to advan
 1. [Hello World](hello_world) - A Hello World example application for working with Gotham.
 1. [Hello Router](hello_router) - A Hello World example application for working with the Gotham Router.
 1. [Basic Router](basic_router) - An example of the Gotham Router showing usage of HTTP verbs such as Get and Post.
+1. [Into Response](basic_into_response) - An example of implementing the `IntoResponse` trait
 
 
 ## License

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ concepts and functionality provided by Gotham from introductory through to advan
 1. [Hello Header](hello_header) - A simple introduction to working with Gotham and custom headers.
 1. [Basic Router](basic_router) - An example of the Gotham Router showing usage of HTTP verbs such as Get and Post.
 1. [Into Response](basic_into_response) - An example of implementing the `IntoResponse` trait
+1. [Basic Path Extractor](basic_path_extractor) - An example of the Gotham Path Extractor.
 
 
 ## License

--- a/examples/basic_into_response/Cargo.toml
+++ b/examples/basic_into_response/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "basic_into_response"
+version = "0.1.0"
+authors = ["Nicolas Pochet <npochet@gmail.com>"]
+
+[dependencies]
+gotham = { path = "../../gotham" }
+gotham_derive = { path = "../../gotham_derive" }
+
+hyper = "0.11"
+futures = "~0.1.11"
+mime = "0.3"
+log = "0.3"
+serde = "~1.0"
+serde_derive = "~1.0"
+serde_json = "~1.0"

--- a/examples/basic_into_response/README.md
+++ b/examples/basic_into_response/README.md
@@ -1,0 +1,53 @@
+# Basic IntoResponse Example 
+
+A simple example implementing the `IntoResponse` trait for a `Product`.
+
+## Running
+
+From the `examples/basic_into_response` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling basic_into_response (file:///.../examples/basic_into_response)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../basic_into_response`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+$ curl -v http://localhost:7878/widgets/t-shirt
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to localhost (127.0.0.1) port 7878 (#0)
+> GET /widgets/t-shirt HTTP/1.1
+> Host: localhost:7878
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Content-Length: 31
+< Content-Type: application/json
+< X-Request-ID: c9a3d057-94c2-4922-8ffd-d483959b566f
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 218
+< Date: Wed, 07 Feb 2018 19:46:33 GMT
+< 
+* Connection #0 to host localhost left intact
+{"name":"t-shirt","price":15.5}%  
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Conduct](../../CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/basic_into_response/src/main.rs
+++ b/examples/basic_into_response/src/main.rs
@@ -1,0 +1,91 @@
+//! A basic example application for working with the Gotham Query String Extractor
+
+extern crate futures;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+use hyper::{Response, StatusCode};
+
+use gotham::http::response::create_response;
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::state::State;
+use gotham::handler::IntoResponse;
+
+
+/// `Product` struct
+///
+/// It represents products that can be queried
+#[derive(Serialize)]
+struct Product {
+    name: String,
+    price: f32,
+}
+
+/// Implement `IntoResponse` trait for `Product`
+///
+/// It allows to create a response out of a `Product`
+impl IntoResponse for Product {
+    fn into_response(self, state: &State) -> Response {
+        create_response(
+            state,
+            StatusCode::Ok,
+            Some((
+                serde_json::to_string(&self).unwrap().into_bytes(),
+                mime::APPLICATION_JSON,
+            )),
+        )
+    }
+}
+
+/// Function to handle the `GET` requests coming to `/widgets/t-shirt`
+/// Returns a `(State, Product)` instead of the usual `(State, Response)`
+fn get_product_handler(state: State) -> (State, Product) {
+    let product = Product {
+        name: "t-shirt".to_string(),
+        price: 15.5,
+    };
+    (state, product)
+}
+
+/// Create a `Router`
+///
+/// /widgets/t-shirt            --> GET
+fn router() -> Router {
+    build_simple_router(|route| {
+        route.get("/widgets/t-shirt").to(get_product_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn get_product_response() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets/t-shirt")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"{\"name\":\"t-shirt\",\"price\":15.5}");
+    }
+}

--- a/examples/basic_path_extractor/Cargo.toml
+++ b/examples/basic_path_extractor/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "basic_path_extractor"
+version = "0.1.0"
+authors = ["Nicolas Pochet <npochet@gmail.com>"]
+
+[dependencies]
+gotham = { path = "../../gotham" }
+gotham_derive = { path = "../../gotham_derive" }
+
+hyper = "0.11"
+futures = "~0.1.11"
+mime = "0.3"
+log = "0.3"
+serde = "~1.0"
+serde_derive = "~1.0"

--- a/examples/basic_path_extractor/README.md
+++ b/examples/basic_path_extractor/README.md
@@ -1,0 +1,53 @@
+# Basic Path Extractor 
+
+A Path Extractor example application for working with the Gotham Path Extractor
+
+## Running
+
+From the `examples/basic_path_extractor` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling basic_path_extractor (file:///.../examples/basic_path_extractor)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../basic_path_extractor`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+curl -v http://localhost:7878/widgets/t-shirt
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to localhost (127.0.0.1) port 7878 (#0)
+> GET /widgets/t-shirt HTTP/1.1
+> Host: localhost:7878
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Content-Length: 16
+< Content-Type: text/plain
+< X-Request-ID: 2f2beb32-58e5-43b8-a27a-a0b61d1792f0
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 214
+< Date: Tue, 06 Feb 2018 20:14:14 GMT
+< 
+* Connection #0 to host localhost left intact
+Product: t-shirt%
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Conduct](../../CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/basic_path_extractor/src/main.rs
+++ b/examples/basic_path_extractor/src/main.rs
@@ -1,0 +1,105 @@
+//! A basic example application for working with the Gotham Path Extractor 
+
+extern crate futures;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate gotham_derive;
+
+use hyper::{Response, StatusCode};
+
+use gotham::http::response::create_response;
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::state::State;
+
+
+/// `Product` struct
+/// 
+/// It contains only a `name` field for the sake of simplicity
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct MyProduct {
+    name: String,
+}
+
+/// Function to handle the `GET` requests coming to `/widgets/:name`
+fn get_product_handler(mut state: State) -> (State, Response) {
+    // Extract `name` from `state`
+    let name = state.take::<MyProduct>().name;
+    // Create a response using `name`
+    let res = create_response(
+        &state,
+        StatusCode::Ok,
+        Some((format!("Product: {}", name).into_bytes(), mime::TEXT_PLAIN)),
+    );
+
+    (state, res)
+}
+
+/// Create a `Router`
+///
+/// /widgets/:name             --> GET
+fn router() -> Router {
+    build_simple_router(|route| {
+        route.get("/widgets/:name")
+            .with_path_extractor::<MyProduct>()
+            .to(get_product_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn index_not_found() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost")
+            .perform()
+            .unwrap();
+        
+        assert_eq!(response.status(), StatusCode::NotFound);
+    }
+
+    #[test]
+    fn product_name_is_extracted() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets/t-shirt")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"Product: t-shirt");
+    }
+
+    #[test]
+    fn not_found_if_uri_not_following_pattern() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets/foo/bar")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NotFound);
+    }
+
+}

--- a/examples/basic_path_extractor/src/main.rs
+++ b/examples/basic_path_extractor/src/main.rs
@@ -1,4 +1,4 @@
-//! A basic example application for working with the Gotham Path Extractor 
+//! A basic example application for working with the Gotham Path Extractor
 
 extern crate futures;
 extern crate gotham;
@@ -19,7 +19,7 @@ use gotham::state::State;
 
 
 /// `Product` struct
-/// 
+///
 /// It contains only a `name` field for the sake of simplicity
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct MyProduct {
@@ -34,7 +34,10 @@ fn get_product_handler(mut state: State) -> (State, Response) {
     let res = create_response(
         &state,
         StatusCode::Ok,
-        Some((format!("Product: {}", name).into_bytes(), mime::TEXT_PLAIN)),
+        Some((
+            format!("Product: {}", name).into_bytes(),
+            mime::TEXT_PLAIN,
+        )),
     );
 
     (state, res)
@@ -45,7 +48,8 @@ fn get_product_handler(mut state: State) -> (State, Response) {
 /// /widgets/:name             --> GET
 fn router() -> Router {
     build_simple_router(|route| {
-        route.get("/widgets/:name")
+        route
+            .get("/widgets/:name")
             .with_path_extractor::<MyProduct>()
             .to(get_product_handler);
     })
@@ -71,7 +75,7 @@ mod tests {
             .get("http://localhost")
             .perform()
             .unwrap();
-        
+
         assert_eq!(response.status(), StatusCode::NotFound);
     }
 

--- a/examples/hello_header/Cargo.toml
+++ b/examples/hello_header/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "hello_header"
+version = "0.1.0"
+authors = ["Bradley Beddoes <bradleybeddoes@gmail.com>",
+           "Shaun Mangelsdorf <s.mangelsdorf@gmail.com>",
+           "Eren Güven <erenguven0@gmail.com>"]
+description = "A simple introduction to working with Gotham and custom headers."
+license = "MIT/Apache-2.0"
+readme = "README.md"
+publish = false
+
+[dependencies]
+gotham = { path = "../../gotham" }
+
+hyper = "0.11"
+futures = "~0.1.11"
+mime = "0.3"

--- a/examples/hello_header/README.md
+++ b/examples/hello_header/README.md
@@ -1,0 +1,53 @@
+# Hello Header
+
+A simple introduction to working with Gotham and custom headers.
+
+## Running
+
+From the `examples/hello_header` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling hello_header (file:///.../examples/hello_header)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.31 secs
+     Running `../hello_header`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+$ curl -v http://127.0.0.1:7878/
+*  Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1:7878
+> User-Agent: curl/7.54.1
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Length: 0
+< Content-Type: text/plain
+< X-Request-ID: 6ebf9a41-dc47-43ef-b431-eb0640b596b4
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Gotham: Hello World!
+< X-Runtime-Microseconds: 41
+< Date: Mon, 05 Feb 2018 01:11:01 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Conduct](../../CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/hello_header/src/main.rs
+++ b/examples/hello_header/src/main.rs
@@ -1,0 +1,63 @@
+//! A simple introduction to working with Gotham and custom headers.
+
+extern crate futures;
+extern crate gotham;
+#[macro_use]
+extern crate hyper;
+extern crate mime;
+
+use hyper::{Response, StatusCode};
+use gotham::http::response::create_response;
+use gotham::state::State;
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+
+// this macro defines our custom header
+header! { (GothamHeader, "X-Gotham") => [String] }
+
+/// Create a `Handler` that adds a custom header.
+pub fn say_hello_through_header(state: State) -> (State, Response) {
+    let mut res = create_response(&state, StatusCode::Ok, None);
+    {
+        let headers = res.headers_mut();
+        headers.set(GothamHeader("Hello World!".to_owned()));
+    };
+
+    (state, res)
+}
+
+/// Create a `Router`
+fn router() -> Router {
+    build_simple_router(|route| {
+        route.get("/").to(say_hello_through_header);
+    })
+}
+
+/// Start a server and call the `Handler` we've defined above for each `Request` we receive.
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn recieve_hello_world_header() {
+        let test_server = TestServer::new(|| Ok(say_hello_through_header)).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+        assert_eq!(
+            response.headers().get::<GothamHeader>().unwrap(),
+            &GothamHeader("Hello World!".to_string())
+        );
+    }
+}

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://gotham.rs"
 repository = "https://github.com/gotham-rs/gotham"
 readme = "README.md"
 categories = ["web-programming::http-server"]
-keywords = ["http", "async", "web", "framework", "gotham"]
+keywords = ["http", "async", "web", "framework", "blockchain"]
 
 [dependencies]
 log = "0.3"


### PR DESCRIPTION
Addresses the issue #108 
It is possible, when running the server to:
```
curl -v http://localhost:7878/widgets/t-shirt
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 7878 (#0)
> GET /widgets/t-shirt HTTP/1.1
> Host: localhost:7878
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 16
< Content-Type: text/plain
< X-Request-ID: 2f2beb32-58e5-43b8-a27a-a0b61d1792f0
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Runtime-Microseconds: 214
< Date: Tue, 06 Feb 2018 20:14:14 GMT
< 
* Connection #0 to host localhost left intact
Product: t-shirt%
```