### PR TITLE
Add Basic IntoResponse example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "examples/hello_world",
     "examples/hello_router",
     "examples/basic_router",
+    "examples/basic_into_response",
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ concepts and functionality provided by Gotham from introductory through to advan
 1. [Hello World](hello_world) - A Hello World example application for working with Gotham.
 1. [Hello Router](hello_router) - A Hello World example application for working with the Gotham Router.
 1. [Basic Router](basic_router) - An example of the Gotham Router showing usage of HTTP verbs such as Get and Post.
+1. [Into Response](basic_into_response) - An example of implementing the `IntoResponse` trait
 
 
 ## License

--- a/examples/basic_into_response/Cargo.toml
+++ b/examples/basic_into_response/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "basic_into_response"
+version = "0.1.0"
+authors = ["Nicolas Pochet <npochet@gmail.com>"]
+
+[dependencies]
+gotham = { path = "../../gotham" }
+gotham_derive = { path = "../../gotham_derive" }
+
+hyper = "0.11"
+futures = "~0.1.11"
+mime = "0.3"
+log = "0.3"
+serde = "~1.0"
+serde_derive = "~1.0"
+serde_json = "~1.0"

--- a/examples/basic_into_response/README.md
+++ b/examples/basic_into_response/README.md
@@ -1,0 +1,53 @@
+# Basic IntoResponse Example 
+
+A simple example implementing the `IntoResponse` trait for a `Product`.
+
+## Running
+
+From the `examples/basic_into_response` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling basic_into_response (file:///.../examples/basic_into_response)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../basic_into_response`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+$ curl -v http://localhost:7878/widgets/t-shirt
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to localhost (127.0.0.1) port 7878 (#0)
+> GET /widgets/t-shirt HTTP/1.1
+> Host: localhost:7878
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Content-Length: 31
+< Content-Type: application/json
+< X-Request-ID: c9a3d057-94c2-4922-8ffd-d483959b566f
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 218
+< Date: Wed, 07 Feb 2018 19:46:33 GMT
+< 
+* Connection #0 to host localhost left intact
+{"name":"t-shirt","price":15.5}%  
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Conduct](../../CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/basic_into_response/src/main.rs
+++ b/examples/basic_into_response/src/main.rs
@@ -1,0 +1,91 @@
+//! A basic example application for working with the Gotham Query String Extractor
+
+extern crate futures;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+use hyper::{Response, StatusCode};
+
+use gotham::http::response::create_response;
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::state::State;
+use gotham::handler::IntoResponse;
+
+
+/// `Product` struct
+///
+/// It represents products that can be queried
+#[derive(Serialize)]
+struct Product {
+    name: String,
+    price: f32,
+}
+
+/// Implement `IntoResponse` trait for `Product`
+///
+/// It allows to create a response out of a `Product`
+impl IntoResponse for Product {
+    fn into_response(self, state: &State) -> Response {
+        create_response(
+            state,
+            StatusCode::Ok,
+            Some((
+                serde_json::to_string(&self).unwrap().into_bytes(),
+                mime::APPLICATION_JSON,
+            )),
+        )
+    }
+}
+
+/// Function to handle the `GET` requests coming to `/widgets/t-shirt`
+/// Returns a `(State, Product)` instead of the usual `(State, Response)`
+fn get_product_handler(state: State) -> (State, Product) {
+    let product = Product {
+        name: "t-shirt".to_string(),
+        price: 15.5,
+    };
+    (state, product)
+}
+
+/// Create a `Router`
+///
+/// /widgets/t-shirt            --> GET
+fn router() -> Router {
+    build_simple_router(|route| {
+        route.get("/widgets/t-shirt").to(get_product_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn get_product_response() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets/t-shirt")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"{\"name\":\"t-shirt\",\"price\":15.5}");
+    }
+}


### PR DESCRIPTION
Addresses issue #101
Adapt README.md and Cargo.toml
With the example running, it is now possible to:
```
curl -v http://localhost:7878/widgets/t-shirt
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 7878 (#0)
> GET /widgets/t-shirt HTTP/1.1
> Host: localhost:7878
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 31
< Content-Type: application/json
< X-Request-ID: c9a3d057-94c2-4922-8ffd-d483959b566f
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Runtime-Microseconds: 218
< Date: Wed, 07 Feb 2018 19:46:33 GMT
< 
* Connection #0 to host localhost left intact
{"name":"t-shirt","price":15.5}% 
```