### PR TITLE
Query string extraction example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ members = [
     "examples/basic_router",
     "examples/hello_header",
     "examples/basic_into_response",
+    "examples/basic_query_extractor",
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ concepts and functionality provided by Gotham from introductory through to advan
 1. [Hello Header](hello_header) - A simple introduction to working with Gotham and custom headers.
 1. [Basic Router](basic_router) - An example of the Gotham Router showing usage of HTTP verbs such as Get and Post.
 1. [Into Response](basic_into_response) - An example of implementing the `IntoResponse` trait
+1. [Basic Query Extractor](basic_query_extractor) - An example of the Gotham Query String Extractor.
 
 
 ## License

--- a/examples/basic_query_extractor/Cargo.toml
+++ b/examples/basic_query_extractor/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "basic_query_extractor"
+version = "0.1.0"
+authors = ["Nicolas Pochet <npochet@gmail.com>"]
+
+[dependencies]
+gotham = { path = "../../gotham" }
+gotham_derive = { path = "../../gotham_derive" }
+
+hyper = "0.11"
+futures = "~0.1.11"
+mime = "0.3"
+log = "0.3"
+serde = "~1.0"
+serde_derive = "~1.0"
+serde_json = "~1.0"

--- a/examples/basic_query_extractor/README.md
+++ b/examples/basic_query_extractor/README.md
@@ -35,7 +35,7 @@ $ curl -v 'http://localhost:7878/widgets?name=t-shirt'
 < Date: Wed, 07 Feb 2018 18:52:15 GMT
 < 
 * Connection #0 to host localhost left intact
-{"name":"t-shirt","price":15.5}% 
+{"name":"t-shirt","description":"t-shirt"}% 
 ```
 
 ## License

--- a/examples/basic_query_extractor/README.md
+++ b/examples/basic_query_extractor/README.md
@@ -1,0 +1,53 @@
+# Basic Query String Extractor
+
+A simple example of a query string extractor 
+
+## Running
+
+From the `examples/basic_query_extractor` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling basic_query_extractor (file:///.../examples/basic_query_extractor)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../basic_query_extractor`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+$ curl -v 'http://localhost:7878/widgets?name=t-shirt'
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to localhost (127.0.0.1) port 7878 (#0)
+> GET /widgets?name=t-shirt HTTP/1.1
+> Host: localhost:7878
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Content-Length: 31
+< Content-Type: text/plain
+< X-Request-ID: 09542fc7-6739-465c-9ee8-8aa18c3a5271
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 308
+< Date: Wed, 07 Feb 2018 18:52:15 GMT
+< 
+* Connection #0 to host localhost left intact
+{"name":"t-shirt","price":15.5}% 
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Conduct](../../CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/basic_query_extractor/src/main.rs
+++ b/examples/basic_query_extractor/src/main.rs
@@ -2,21 +2,21 @@
 
 extern crate futures;
 extern crate gotham;
+#[macro_use]
+extern crate gotham_derive;
 extern crate hyper;
 extern crate mime;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-#[macro_use]
-extern crate gotham_derive;
 
 use hyper::{Response, StatusCode};
 
 use gotham::http::response::create_response;
 use gotham::router::Router;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
-use gotham::state::{State, FromState};
+use gotham::state::{FromState, State};
 
 /// `QueryParam` struct
 ///
@@ -52,16 +52,11 @@ fn generate_products() -> Vec<Product> {
 /// is returned.
 fn product_matcher(requested: &str, products: &Vec<Product>, state: &State) -> Response {
     match products.iter().find(|p| p.name == requested) {
-        Some(product) => {
-            create_response(
-                state,
-                StatusCode::Ok,
-                Some((
-                    serde_json::to_vec(product).unwrap(),
-                    mime::APPLICATION_JSON,
-                )),
-            )
-        }
+        Some(product) => create_response(
+            state,
+            StatusCode::Ok,
+            Some((serde_json::to_vec(product).unwrap(), mime::APPLICATION_JSON)),
+        ),
         None => Response::new().with_status(StatusCode::NotFound),
     }
 }

--- a/examples/basic_query_extractor/src/main.rs
+++ b/examples/basic_query_extractor/src/main.rs
@@ -1,0 +1,149 @@
+//! A basic example application for working with the Gotham Query String Extractor 
+
+extern crate futures;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+#[macro_use]
+extern crate gotham_derive;
+
+use hyper::{Response, StatusCode};
+
+use gotham::http::response::create_response;
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::state::State;
+
+/// `QueryParam` struct
+///
+/// It contains only a `name` field for the sake of simplicity
+/// It permits to use it as query parameter like:
+/// GET /widgets?name=t-shirt
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct QueryParam {
+    name: String,
+}
+
+/// `Product` struct
+///
+/// It represents products that can be queried
+#[derive(Serialize)]
+struct Product {
+    name: String,
+    price: f32,
+}
+
+// Generate a `Vec<Product>`
+fn generate_products() -> Vec<Product> {
+    let mut products = Vec::with_capacity(3);
+    products.push(Product {
+        name: "t-shirt".to_string(),
+        price: 15.5,
+    });
+    products.push(Product {
+        name: "sticker".to_string(),
+        price: 1.5,
+    });
+    products.push(Product {
+        name: "mug".to_string(),
+        price: 10.0,
+    });
+    products
+}
+
+/// Function to handle the `GET` requests coming to `/widgets/:name`
+fn get_product_handler(mut state: State) -> (State, Response) {
+    // Extract `name` from `state`
+    let name = state.take::<QueryParam>().name;
+    // Generate the products and try to find a match
+    let products = generate_products()
+        .into_iter()
+        .filter(|p| p.name == name)
+        .collect::<Vec<Product>>();
+    // Check if a product is found. If not, return `StatusCode::NotFound`
+    let product = match products.get(0) {
+        Some(p) => p,
+        None => return (state, Response::new().with_status(StatusCode::NotFound)),
+    };
+    // Create a response using `Product` serialized to JSON
+    let res = create_response(
+        &state,
+        StatusCode::Ok,
+        Some((
+            format!("{}", serde_json::to_string(&product).unwrap())
+                .into_bytes(),
+            mime::TEXT_PLAIN,
+        )),
+    );
+
+    (state, res)
+}
+
+/// Create a `Router`
+///
+/// /widgets?name=...             --> GET
+fn router() -> Router {
+    build_simple_router(|route| {
+        route
+            .get("/widgets")
+            .with_query_string_extractor::<QueryParam>()
+            .to(get_product_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn index_not_found() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NotFound);
+    }
+
+    #[test]
+    fn tshirt_found() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets?name=t-shirt")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"{\"name\":\"t-shirt\",\"price\":15.5}");
+    }
+
+    #[test]
+    fn foo_not_found() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets?name=foo")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NotFound);
+    }
+
+}


### PR DESCRIPTION
Reopening the PR (sorry for the inconvenience).
This new PR takes into account the remarks from @bradleybeddoes made in PR #133 
This PR addresses issue #109 
It is possible, when running the example to:
```
curl -v 'http://localhost:7878/widgets?name=t-shirt'
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 7878 (#0)
> GET /widgets?name=t-shirt HTTP/1.1
> Host: localhost:7878
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 31
< Content-Type: text/plain
< X-Request-ID: 09542fc7-6739-465c-9ee8-8aa18c3a5271
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Runtime-Microseconds: 308
< Date: Wed, 07 Feb 2018 18:52:15 GMT
< 
* Connection #0 to host localhost left intact
{"name":"t-shirt","price":15.5}%
```