### PR TITLE
Add Basic Path Extractor Example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ members = [
     "examples/basic_router",
     "examples/hello_header",
     "examples/basic_into_response",
+    "examples/basic_path_extractor",
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ concepts and functionality provided by Gotham from introductory through to advan
 1. [Hello Header](hello_header) - A simple introduction to working with Gotham and custom headers.
 1. [Basic Router](basic_router) - An example of the Gotham Router showing usage of HTTP verbs such as Get and Post.
 1. [Into Response](basic_into_response) - An example of implementing the `IntoResponse` trait
+1. [Basic Path Extractor](basic_path_extractor) - An example showing the usage of a Path Extractor
 
 
 ## License

--- a/examples/basic_path_extractor/Cargo.toml
+++ b/examples/basic_path_extractor/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "basic_path_extractor"
+version = "0.1.0"
+authors = ["Nicolas Pochet <npochet@gmail.com>"]
+
+[dependencies]
+gotham = { path = "../../gotham" }
+gotham_derive = { path = "../../gotham_derive" }
+
+hyper = "0.11"
+futures = "~0.1.11"
+mime = "0.3"
+log = "0.3"
+serde = "~1.0"
+serde_derive = "~1.0"

--- a/examples/basic_path_extractor/README.md
+++ b/examples/basic_path_extractor/README.md
@@ -1,0 +1,53 @@
+# Basic Path Extractor 
+
+A Path Extractor example application for working with the Gotham Path Extractor
+
+## Running
+
+From the `examples/basic_path_extractor` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling basic_path_extractor (file:///.../examples/basic_path_extractor)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../basic_path_extractor`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+curl -v http://localhost:7878/widgets/t-shirt
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to localhost (127.0.0.1) port 7878 (#0)
+> GET /widgets/t-shirt HTTP/1.1
+> Host: localhost:7878
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Content-Length: 16
+< Content-Type: text/plain
+< X-Request-ID: 2f2beb32-58e5-43b8-a27a-a0b61d1792f0
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 214
+< Date: Tue, 06 Feb 2018 20:14:14 GMT
+< 
+* Connection #0 to host localhost left intact
+Product: t-shirt%
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Conduct](../../CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/basic_path_extractor/src/main.rs
+++ b/examples/basic_path_extractor/src/main.rs
@@ -2,21 +2,20 @@
 
 extern crate futures;
 extern crate gotham;
+#[macro_use]
+extern crate gotham_derive;
 extern crate hyper;
 extern crate mime;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate gotham_derive;
 
 use hyper::{Response, StatusCode};
 
 use gotham::http::response::create_response;
 use gotham::router::Router;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
-use gotham::state::{State, FromState};
-
+use gotham::state::{FromState, State};
 
 /// `Product` struct
 ///

--- a/examples/basic_path_extractor/src/main.rs
+++ b/examples/basic_path_extractor/src/main.rs
@@ -1,0 +1,86 @@
+//! A basic example application for working with the Gotham Path Extractor
+
+extern crate futures;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate gotham_derive;
+
+use hyper::{Response, StatusCode};
+
+use gotham::http::response::create_response;
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::state::{State, FromState};
+
+
+/// `Product` struct
+///
+/// It contains only a `name` field for the sake of simplicity
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct MyProduct {
+    name: String,
+}
+
+/// Function to handle the `GET` requests coming to `/widgets/:name`
+fn get_product_handler(state: State) -> (State, Response) {
+    // Create the response
+    let res = {
+        // Extract `MyProduct` from `state`
+        let product = MyProduct::borrow_from(&state);
+        create_response(
+            &state,
+            StatusCode::Ok,
+            Some((
+                format!("Product: {}", product.name).into_bytes(),
+                mime::TEXT_PLAIN,
+            )),
+        )
+    };
+
+    (state, res)
+}
+
+/// Create a `Router`
+///
+/// /widgets/:name             --> GET
+fn router() -> Router {
+    build_simple_router(|route| {
+        route
+            .get("/widgets/:name")
+            .with_path_extractor::<MyProduct>()
+            .to(get_product_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn product_name_is_extracted() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/widgets/t-shirt")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"Product: t-shirt");
+    }
+}


### PR DESCRIPTION
Recreate PR (after closing PR #130).
Addresses the issue #108 
It is possible, when running the server to:
```
curl -v http://localhost:7878/widgets/t-shirt
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 7878 (#0)
> GET /widgets/t-shirt HTTP/1.1
> Host: localhost:7878
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Length: 16
< Content-Type: text/plain
< X-Request-ID: 2f2beb32-58e5-43b8-a27a-a0b61d1792f0
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Runtime-Microseconds: 214
< Date: Tue, 06 Feb 2018 20:14:14 GMT
< 
* Connection #0 to host localhost left intact
Product: t-shirt%
```