### PR TITLE
Help Gotham contributors identify rustfmt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
   - rustup component add --toolchain nightly rustfmt-preview
   - cargo +nightly install --force rustfmt-nightly
 script:
+  - echo "Checking Gotham codebase with rustfmt release `cargo +nightly fmt --version`."
   - cargo +nightly fmt --all -- --write-mode=diff
   - cargo test --all --features ci
 after_success:


### PR DESCRIPTION
Previously it was reasonably painful to figure out which version of `rustfmt` was throwing up a diff when being run on CI.

This is now clearly output in Travis logs.