### PR TITLE
Fix typos

### DIFF
--- a/examples/hello_header/src/main.rs
+++ b/examples/hello_header/src/main.rs
@@ -46,7 +46,7 @@ mod tests {
     use gotham::test::TestServer;
 
     #[test]
-    fn recieve_hello_world_header() {
+    fn receive_hello_world_header() {
         let test_server = TestServer::new(|| Ok(say_hello_through_header)).unwrap();
         let response = test_server
             .client()

--- a/examples/hello_router/src/main.rs
+++ b/examples/hello_router/src/main.rs
@@ -43,7 +43,7 @@ mod tests {
     use gotham::test::TestServer;
 
     #[test]
-    fn recieve_hello_router_response() {
+    fn receive_hello_router_response() {
         let test_server = TestServer::new(router()).unwrap();
         let response = test_server
             .client()

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -38,7 +38,7 @@ mod tests {
     use gotham::test::TestServer;
 
     #[test]
-    fn recieve_hello_world_response() {
+    fn receive_hello_world_response() {
         let test_server = TestServer::new(|| Ok(say_hello)).unwrap();
         let response = test_server
             .client()


### PR DESCRIPTION
Fix typos in examples: replace `recieve` by `receive`