### PR TITLE
Refactor to move the middleware chain, pipeline chain and pipeline set code to their own modules

### DIFF
--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -98,11 +98,12 @@ impl IntoHandlerFuture for Box<HandlerFuture> {
 /// # extern crate hyper;
 /// #
 /// # use gotham::state::State;
+/// # use gotham::pipeline::set::*;
 /// # use gotham::router::Router;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};
 /// # use gotham::router::tree::TreeBuilder;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, DispatcherImpl};
+/// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::handler::IntoResponse;
 /// # use gotham::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 /// # use gotham::router::response::finalizer::ResponseFinalizerBuilder;

--- a/gotham/src/middleware/chain.rs
+++ b/gotham/src/middleware/chain.rs
@@ -1,0 +1,107 @@
+//! Defines the types for connecting multiple middleware into a "chain" when forming a pipeline.
+
+use std::io;
+use std::panic::RefUnwindSafe;
+
+use handler::HandlerFuture;
+use middleware::{Middleware, NewMiddleware};
+use state::{request_id, State};
+
+/// A recursive type representing a pipeline, which is used to spawn a `MiddlewareChain`.
+///
+/// This type should never be implemented outside of Gotham, does not form part of the public API,
+/// and is subject to change without notice.
+#[doc(hidden)]
+pub unsafe trait NewMiddlewareChain: RefUnwindSafe + Sized {
+    type Instance: MiddlewareChain;
+
+    /// Create and return a new `MiddlewareChain` value.
+    fn construct(&self) -> io::Result<Self::Instance>;
+}
+
+unsafe impl<T, U> NewMiddlewareChain for (T, U)
+where
+    T: NewMiddleware,
+    T::Instance: 'static,
+    U: NewMiddlewareChain,
+{
+    type Instance = (T::Instance, U::Instance);
+
+    fn construct(&self) -> io::Result<Self::Instance> {
+        // This works as a recursive `map` over the "list" of `NewMiddleware`, and is used in
+        // creating the `Middleware` instances for serving a single request.
+        //
+        // The reversed order is preserved in the return value.
+        trace!(" adding middleware instance to pipeline");
+        let (ref nm, ref tail) = *self;
+        Ok((nm.new_middleware()?, tail.construct()?))
+    }
+}
+
+unsafe impl NewMiddlewareChain for () {
+    type Instance = ();
+
+    fn construct(&self) -> io::Result<Self::Instance> {
+        // () marks the end of the list, so is returned as-is.
+        trace!(" completed middleware pipeline construction");
+        Ok(())
+    }
+}
+
+/// A recursive type representing an instance of a pipeline, which is used to process a single
+/// request.
+///
+/// This type should never be implemented outside of Gotham, does not form part of the public API,
+/// and is subject to change without notice.
+#[doc(hidden)]
+pub unsafe trait MiddlewareChain: Sized {
+    /// Recursive function for processing middleware and chaining to the given function.
+    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
+    where
+        F: FnOnce(State) -> Box<HandlerFuture> + 'static;
+}
+
+unsafe impl MiddlewareChain for () {
+    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
+    where
+        F: FnOnce(State) -> Box<HandlerFuture> + 'static,
+    {
+        // At the last item in the `MiddlewareChain`, the function is invoked to serve the
+        // request. `f` is the nested function of all `Middleware` and the `Handler`.
+        //
+        // In the case of 0 middleware, `f` is the function created in `MiddlewareChain::call`
+        // which invokes the `Handler` directly.
+        trace!("pipeline complete, invoking handler");
+        f(state)
+    }
+}
+
+unsafe impl<T, U> MiddlewareChain for (T, U)
+where
+    T: Middleware + 'static,
+    U: MiddlewareChain,
+{
+    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
+    where
+        F: FnOnce(State) -> Box<HandlerFuture> + 'static,
+    {
+        let (m, p) = self;
+        // Construct the function from the inside, out. Starting with a function which calls the
+        // `Handler`, and then creating a new function which calls the `Middleware` with the
+        // previous function as the `chain` argument, we end up with a structure somewhat like
+        // this (using `m0`, `m1`, `m2` as middleware names, where `m2` is the last middleware
+        // before the `Handler`):
+        //
+        //  move |state| {
+        //      m0.call(state, move |state| {
+        //          m1.call(state, move |state| {
+        //              m2.call(state, move |state| handler.call(state))
+        //          })
+        //      })
+        //  }
+        //
+        // The resulting function is called by `<() as MiddlewareChain>::call`
+        trace!("[{}] executing middleware", request_id(&state));
+        p.call(state, move |state| m.call(state, f))
+    }
+}

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -6,6 +6,7 @@ use std::panic::RefUnwindSafe;
 use handler::HandlerFuture;
 use state::State;
 
+pub mod chain;
 pub mod session;
 
 /// `Middleware` has the opportunity to provide additional behaviour to the `Request` / `Response`

--- a/gotham/src/pipeline/chain.rs
+++ b/gotham/src/pipeline/chain.rs
@@ -1,0 +1,68 @@
+//! Defines the types for connecting multiple pipeline handles into a "chain" when constructing the
+//! dispatcher for a route.
+
+use std::panic::RefUnwindSafe;
+use borrow_bag::{Handle, Lookup};
+use futures::future;
+
+use handler::{HandlerFuture, IntoHandlerError};
+use middleware::chain::NewMiddlewareChain;
+use pipeline::Pipeline;
+use router::route::dispatch::PipelineSet;
+use state::{request_id, State};
+
+/// A heterogeneous list of `Handle<P, _>` values, where `P` is a pipeline type. The pipelines are
+/// borrowed and invoked in order to serve a request.
+///
+/// Implemented using nested tuples, with `()` marking the end of the list. The list is in the
+/// reverse order of their invocation when a request is dispatched.
+///
+/// That is:
+///
+/// `(p3, (p2, (p1, ())))`
+///
+/// will be invoked as:
+///
+/// `(state, request)` &rarr; `p1` &rarr; `p2` &rarr; `p3` &rarr; `handler`
+pub trait PipelineHandleChain<P>: RefUnwindSafe {
+    /// Invokes this part of the `PipelineHandleChain`, with requests being passed through to `f`
+    /// once all `Middleware` in the `Pipeline` have passed the request through.
+    fn call<F>(&self, pipelines: &PipelineSet<P>, state: State, f: F) -> Box<HandlerFuture>
+    where
+        F: FnOnce(State) -> Box<HandlerFuture> + 'static;
+}
+
+/// Part of a `PipelineHandleChain` which references a `Pipeline` and continues with a tail element.
+impl<'a, P, T, N, U> PipelineHandleChain<P> for (Handle<Pipeline<T>, N>, U)
+where
+    T: NewMiddlewareChain,
+    T::Instance: 'static,
+    U: PipelineHandleChain<P>,
+    P: Lookup<Pipeline<T>, N>,
+    N: RefUnwindSafe,
+{
+    fn call<F>(&self, pipelines: &PipelineSet<P>, state: State, f: F) -> Box<HandlerFuture>
+    where
+        F: FnOnce(State) -> Box<HandlerFuture> + 'static,
+    {
+        let (handle, ref chain) = *self;
+        match pipelines.borrow(handle).construct() {
+            Ok(p) => chain.call(pipelines, state, move |state| p.call(state, f)),
+            Err(e) => {
+                trace!("[{}] error borrowing pipeline", request_id(&state));
+                Box::new(future::err((state, e.into_handler_error())))
+            }
+        }
+    }
+}
+
+/// The marker for the end of a `PipelineHandleChain`.
+impl<P> PipelineHandleChain<P> for () {
+    fn call<F>(&self, _: &PipelineSet<P>, state: State, f: F) -> Box<HandlerFuture>
+    where
+        F: FnOnce(State) -> Box<HandlerFuture> + 'static,
+    {
+        trace!("[{}] start pipeline", request_id(&state));
+        f(state)
+    }
+}

--- a/gotham/src/pipeline/chain.rs
+++ b/gotham/src/pipeline/chain.rs
@@ -8,7 +8,7 @@ use futures::future;
 use handler::{HandlerFuture, IntoHandlerError};
 use middleware::chain::NewMiddlewareChain;
 use pipeline::Pipeline;
-use router::route::dispatch::PipelineSet;
+use pipeline::set::PipelineSet;
 use state::{request_id, State};
 
 /// A heterogeneous list of `Handle<P, _>` values, where `P` is a pipeline type. The pipelines are

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -3,10 +3,10 @@
 pub mod single;
 
 use std::io;
-use std::panic::RefUnwindSafe;
 
 use handler::HandlerFuture;
-use middleware::{Middleware, NewMiddleware};
+use middleware::chain::{MiddlewareChain, NewMiddlewareChain};
+use middleware::NewMiddleware;
 use state::{request_id, State};
 
 /// When using middleware, one or more `Middleware` are combined to form a `Pipeline`.
@@ -325,114 +325,17 @@ where
     }
 }
 
-/// A recursive type representing a pipeline, which is used to spawn a `MiddlewareChain`.
-///
-/// This type should never be implemented outside of Gotham, does not form part of the public API,
-/// and is subject to change without notice.
-#[doc(hidden)]
-pub unsafe trait NewMiddlewareChain: RefUnwindSafe + Sized {
-    type Instance: MiddlewareChain;
-
-    /// Create and return a new `MiddlewareChain` value.
-    fn construct(&self) -> io::Result<Self::Instance>;
-}
-
-unsafe impl<T, U> NewMiddlewareChain for (T, U)
-where
-    T: NewMiddleware,
-    T::Instance: 'static,
-    U: NewMiddlewareChain,
-{
-    type Instance = (T::Instance, U::Instance);
-
-    fn construct(&self) -> io::Result<Self::Instance> {
-        // This works as a recursive `map` over the "list" of `NewMiddleware`, and is used in
-        // creating the `Middleware` instances for serving a single request.
-        //
-        // The reversed order is preserved in the return value.
-        trace!(" adding middleware instance to pipeline");
-        let (ref nm, ref tail) = *self;
-        Ok((nm.new_middleware()?, tail.construct()?))
-    }
-}
-
-unsafe impl NewMiddlewareChain for () {
-    type Instance = ();
-
-    fn construct(&self) -> io::Result<Self::Instance> {
-        // () marks the end of the list, so is returned as-is.
-        trace!(" completed middleware pipeline construction");
-        Ok(())
-    }
-}
-
-/// A recursive type representing an instance of a pipeline, which is used to process a single
-/// request.
-///
-/// This type should never be implemented outside of Gotham, does not form part of the public API,
-/// and is subject to change without notice.
-#[doc(hidden)]
-pub unsafe trait MiddlewareChain: Sized {
-    /// Recursive function for processing middleware and chaining to the given function.
-    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
-    where
-        F: FnOnce(State) -> Box<HandlerFuture> + 'static;
-}
-
-unsafe impl MiddlewareChain for () {
-    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
-    where
-        F: FnOnce(State) -> Box<HandlerFuture> + 'static,
-    {
-        // At the last item in the `MiddlewareChain`, the function is invoked to serve the
-        // request. `f` is the nested function of all `Middleware` and the `Handler`.
-        //
-        // In the case of 0 middleware, `f` is the function created in `MiddlewareChain::call`
-        // which invokes the `Handler` directly.
-        trace!("pipeline complete, invoking handler");
-        f(state)
-    }
-}
-
-unsafe impl<T, U> MiddlewareChain for (T, U)
-where
-    T: Middleware + 'static,
-    U: MiddlewareChain,
-{
-    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
-    where
-        F: FnOnce(State) -> Box<HandlerFuture> + 'static,
-    {
-        let (m, p) = self;
-        // Construct the function from the inside, out. Starting with a function which calls the
-        // `Handler`, and then creating a new function which calls the `Middleware` with the
-        // previous function as the `chain` argument, we end up with a structure somewhat like
-        // this (using `m0`, `m1`, `m2` as middleware names, where `m2` is the last middleware
-        // before the `Handler`):
-        //
-        //  move |state| {
-        //      m0.call(state, move |state| {
-        //          m1.call(state, move |state| {
-        //              m2.call(state, move |state| handler.call(state))
-        //          })
-        //      })
-        //  }
-        //
-        // The resulting function is called by `<() as MiddlewareChain>::call`
-        trace!("[{}] executing middleware", request_id(&state));
-        p.call(state, move |state| m.call(state, f))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test::TestServer;
-    use handler::{Handler, IntoHandlerError};
-    use state::StateData;
-    use hyper::Response;
-    use hyper::StatusCode;
+
+    use hyper::{Response, StatusCode};
     use futures::future;
+
+    use handler::{Handler, IntoHandlerError};
+    use middleware::Middleware;
+    use state::StateData;
+    use test::TestServer;
 
     fn handler(state: State) -> (State, Response) {
         let number = state.borrow::<Number>().value;

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -1,5 +1,6 @@
 //! Defines types for a middleware pipeline
 
+pub mod chain;
 pub mod single;
 
 use std::io;

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -1,6 +1,7 @@
 //! Defines types for a middleware pipeline
 
 pub mod chain;
+pub mod set;
 pub mod single;
 
 use std::io;
@@ -32,11 +33,12 @@ use state::{request_id, State};
 /// # use gotham::handler::HandlerFuture;
 /// # use gotham::middleware::{Middleware, NewMiddleware};
 /// # use gotham::pipeline::new_pipeline;
+/// # use gotham::pipeline::set::*;
 /// # use gotham::router::Router;
 /// # use gotham::router::tree::TreeBuilder;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, DispatcherImpl};
+/// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::test::TestServer;
 /// # use gotham::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 /// # use gotham::router::response::finalizer::ResponseFinalizerBuilder;

--- a/gotham/src/pipeline/set.rs
+++ b/gotham/src/pipeline/set.rs
@@ -1,0 +1,24 @@
+//! Defines the types for adding multiple pipelines into a `PipelineSet` and retaining a handle to
+//! each pipeline for constructing a `PipelineHandleChain`.
+
+use std::sync::Arc;
+use borrow_bag::BorrowBag;
+
+/// Represents the set of all `Pipeline` instances that are available for use with `Routes`.
+pub type PipelineSet<P> = Arc<BorrowBag<P>>;
+
+/// A set of `Pipeline` instances that may continue to grow
+pub type EditablePipelineSet<P> = BorrowBag<P>;
+
+/// Create an empty set of `Pipeline` instances.
+///
+/// See BorrowBag#add to insert new `Pipeline` instances.
+pub fn new_pipeline_set() -> EditablePipelineSet<()> {
+    BorrowBag::new()
+}
+
+/// Wraps the current set of `Pipeline` instances into a thread-safe reference counting pointer for
+/// use with `DispatcherImpl` instances.
+pub fn finalize_pipeline_set<P>(eps: EditablePipelineSet<P>) -> PipelineSet<P> {
+    Arc::new(eps)
+}

--- a/gotham/src/pipeline/single.rs
+++ b/gotham/src/pipeline/single.rs
@@ -3,8 +3,8 @@
 
 use borrow_bag::{Append, Handle};
 
-use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
 use pipeline::{NewMiddlewareChain, Pipeline};
+use pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
 
 /// A `PipelineSet` which contains only a single pipeline.
 pub type SinglePipelineSet<C> = PipelineSet<<() as Append<Pipeline<C>>>::Output>;

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -4,7 +4,7 @@ use std::panic::RefUnwindSafe;
 use hyper::Method;
 
 use pipeline::chain::PipelineHandleChain;
-use router::route::dispatch::PipelineSet;
+use pipeline::set::PipelineSet;
 use router::route::matcher::MethodOnlyRouteMatcher;
 use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 use router::builder::{AssociatedRouteBuilder, DelegateRouteBuilder, RouterBuilder, ScopeBuilder,

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -3,7 +3,8 @@ use std::panic::RefUnwindSafe;
 
 use hyper::Method;
 
-use router::route::dispatch::{PipelineHandleChain, PipelineSet};
+use pipeline::chain::PipelineHandleChain;
+use router::route::dispatch::PipelineSet;
 use router::route::matcher::MethodOnlyRouteMatcher;
 use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 use router::builder::{AssociatedRouteBuilder, DelegateRouteBuilder, RouterBuilder, ScopeBuilder,

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -9,6 +9,7 @@ use std::panic::RefUnwindSafe;
 
 use hyper::{Method, StatusCode};
 
+use pipeline::chain::PipelineHandleChain;
 use router::Router;
 use router::tree::TreeBuilder;
 use router::response::extender::ResponseExtender;
@@ -16,8 +17,7 @@ use router::response::finalizer::ResponseFinalizerBuilder;
 use router::route::{Delegation, Extractors, RouteImpl};
 use router::route::matcher::{MethodOnlyRouteMatcher, RouteMatcher};
 use router::route::matcher::any::AnyRouteMatcher;
-use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set, DispatcherImpl,
-                              PipelineHandleChain, PipelineSet};
+use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set, DispatcherImpl, PipelineSet};
 use extractor::{NoopPathExtractor, NoopQueryStringExtractor, PathExtractor, QueryStringExtractor};
 use router::tree::node::NodeBuilder;
 

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -10,6 +10,7 @@ use std::panic::RefUnwindSafe;
 use hyper::{Method, StatusCode};
 
 use pipeline::chain::PipelineHandleChain;
+use pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
 use router::Router;
 use router::tree::TreeBuilder;
 use router::response::extender::ResponseExtender;
@@ -17,7 +18,7 @@ use router::response::finalizer::ResponseFinalizerBuilder;
 use router::route::{Delegation, Extractors, RouteImpl};
 use router::route::matcher::{MethodOnlyRouteMatcher, RouteMatcher};
 use router::route::matcher::any::AnyRouteMatcher;
-use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set, DispatcherImpl, PipelineSet};
+use router::route::dispatch::DispatcherImpl;
 use extractor::{NoopPathExtractor, NoopQueryStringExtractor, PathExtractor, QueryStringExtractor};
 use router::tree::node::NodeBuilder;
 
@@ -41,8 +42,9 @@ pub type AssociatedSingleRouteBuilder<'a, C, P, PE, QSE> =
 /// # use gotham::router::Router;
 /// # use gotham::router::builder::*;
 /// # use gotham::pipeline::new_pipeline;
+/// # use gotham::pipeline::set::*;
 /// # use gotham::middleware::session::NewSessionMiddleware;
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
+/// #
 /// # fn my_handler(_: State) -> (State, Response) {
 /// #   unreachable!()
 /// # }
@@ -147,8 +149,8 @@ where
     /// # use gotham::router::response::extender::ResponseExtender;
     /// # use gotham::router::builder::*;
     /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
-    /// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
     /// #
     /// struct MyExtender;
     ///
@@ -721,7 +723,6 @@ mod tests {
     use middleware::session::NewSessionMiddleware;
     use state::{State, StateData};
     use service::GothamService;
-    use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set};
     use router::response::extender::StaticResponseExtender;
 
     #[derive(Deserialize)]

--- a/gotham/src/router/builder/replace.rs
+++ b/gotham/src/router/builder/replace.rs
@@ -2,7 +2,7 @@ use std::panic::RefUnwindSafe;
 
 use extractor::{PathExtractor, QueryStringExtractor};
 use router::route::matcher::RouteMatcher;
-use router::route::dispatch::PipelineHandleChain;
+use pipeline::chain::PipelineHandleChain;
 use router::builder::SingleRouteBuilder;
 use router::builder::single::DefineSingleRoute;
 

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -24,7 +24,8 @@ use handler::{Handler, NewHandler};
 /// # use gotham::router::builder::*;
 /// # use gotham::pipeline::new_pipeline;
 /// # use gotham::middleware::session::NewSessionMiddleware;
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
+/// # use gotham::pipeline::set::*;
+/// #
 /// fn my_handler(_: State) -> (State, Response) {
 ///     // Handler implementation elided.
 /// #   unimplemented!()
@@ -61,8 +62,9 @@ pub trait DefineSingleRoute {
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
     /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
-    /// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
+    /// #
     /// fn my_handler(_: State) -> (State, Response) {
     ///     // Handler implementation elided.
     /// #   unimplemented!()
@@ -101,8 +103,9 @@ pub trait DefineSingleRoute {
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
     /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
-    /// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
+    /// #
     /// struct MyNewHandler;
     /// struct MyHandler;
     ///
@@ -157,8 +160,9 @@ pub trait DefineSingleRoute {
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
     /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
-    /// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
+    /// #
     /// #[derive(Deserialize, StateData, StaticResponseExtender)]
     /// struct MyPathParams {
     /// #   #[allow(dead_code)]
@@ -214,8 +218,8 @@ pub trait DefineSingleRoute {
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
     /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
-    /// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set};
     /// #
     /// #[derive(StateData, Deserialize, StaticResponseExtender)]
     /// struct MyQueryParams {

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -1,11 +1,12 @@
 use std::panic::RefUnwindSafe;
 
 use extractor::{PathExtractor, QueryStringExtractor};
+use pipeline::chain::PipelineHandleChain;
 use router::builder::SingleRouteBuilder;
 use router::builder::replace::{ReplacePathExtractor, ReplaceQueryStringExtractor};
 use router::route::{Delegation, Extractors, RouteImpl};
 use router::route::matcher::RouteMatcher;
-use router::route::dispatch::{DispatcherImpl, PipelineHandleChain};
+use router::route::dispatch::DispatcherImpl;
 use handler::{Handler, NewHandler};
 
 /// Describes the API for defining a single route, after determining which request paths will be

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -210,15 +210,16 @@ mod tests {
     use hyper::{Method, Uri};
     use hyper::header::{ContentLength, Headers};
 
+    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use handler::HandlerError;
+    use pipeline::set::*;
+    use router::response::finalizer::ResponseFinalizerBuilder;
+    use router::route::dispatch::DispatcherImpl;
+    use router::route::matcher::MethodOnlyRouteMatcher;
+    use router::route::{Extractors, RouteImpl};
     use router::tree::TreeBuilder;
     use router::tree::node::{NodeBuilder, SegmentType};
-    use router::route::{Extractors, RouteImpl};
-    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-    use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set, DispatcherImpl};
-    use router::route::matcher::MethodOnlyRouteMatcher;
-    use router::response::finalizer::ResponseFinalizerBuilder;
     use state::set_request_id;
-    use handler::HandlerError;
 
     fn handler(state: State) -> (State, Response) {
         (state, Response::new())

--- a/gotham/src/router/route/dispatch.rs
+++ b/gotham/src/router/route/dispatch.rs
@@ -6,7 +6,8 @@ use borrow_bag::{BorrowBag, Handle, Lookup};
 use futures::future;
 
 use handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
-use pipeline::{NewMiddlewareChain, Pipeline};
+use middleware::chain::NewMiddlewareChain;
+use pipeline::Pipeline;
 use state::{request_id, State};
 
 /// Represents the set of all `Pipeline` instances that are available for use with `Routes`.

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -12,11 +12,11 @@ use std::panic::RefUnwindSafe;
 
 use hyper::{Response, Uri};
 
-use http::request::query_string;
-use router::route::dispatch::Dispatcher;
 use handler::HandlerFuture;
+use http::request::query_string;
 use extractor::{self, PathExtractor, QueryStringExtractor};
 use router::non_match::RouteNonMatch;
+use router::route::dispatch::Dispatcher;
 use router::route::matcher::RouteMatcher;
 use router::tree::SegmentMapping;
 use state::{request_id, State};
@@ -87,8 +87,9 @@ pub struct ExtractorFailed;
 /// #
 /// # use gotham::http::response::create_response;
 /// # use gotham::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+/// # use gotham::pipeline::set::*;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, DispatcherImpl};
+/// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::state::State;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};
 /// #
@@ -117,8 +118,9 @@ pub struct ExtractorFailed;
 /// #
 /// # use gotham::http::response::create_response;
 /// # use gotham::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+/// # use gotham::pipeline::set::*;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, DispatcherImpl};
+/// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::state::State;
 /// # use gotham::router::Router;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -45,9 +45,9 @@ pub type SegmentMapping<'r> = HashMap<&'r str, Vec<&'r PercentDecoded>>;
 /// # use hyper::{Response, Method, StatusCode};
 /// #
 /// # use gotham::http::response::create_response;
+/// # use gotham::pipeline::set::*;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set,
-/// #                                       DispatcherImpl};
+/// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::state::State;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
 /// # use gotham::router::tree::TreeBuilder;

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -52,8 +52,9 @@ pub enum SegmentType {
 /// # use gotham::http::PercentDecoded;
 /// # use gotham::http::response::create_response;
 /// # use gotham::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+/// # use gotham::pipeline::set::*;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};
-/// # use gotham::router::route::dispatch::{new_pipeline_set, finalize_pipeline_set, DispatcherImpl};
+/// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::state::State;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
 /// # use gotham::router::tree::node::{NodeBuilder, SegmentType};
@@ -446,8 +447,8 @@ mod tests {
 
     use hyper::{Headers, Method, Response};
 
-    use router::route::dispatch::{finalize_pipeline_set, new_pipeline_set, DispatcherImpl,
-                                  PipelineSet};
+    use pipeline::set::*;
+    use router::route::dispatch::DispatcherImpl;
     use router::route::matcher::MethodOnlyRouteMatcher;
     use router::route::{Extractors, Route, RouteImpl};
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};


### PR DESCRIPTION
I could never remember exactly where these were defined, which seemed like a hint that they weren't in the right place. This introduces three new modules for these concepts: `middleware::chain`, `pipeline::chain`, and `pipeline::set`.

No changes here, just relocation and fixing imports.