### PR TITLE
Visibility review

### DIFF
--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -94,6 +94,8 @@ impl IntoHandlerFuture for Box<HandlerFuture> {
 /// # Examples
 ///
 /// ```rust
+/// # #![allow(deprecated)] // TODO: Refactor this.
+/// #
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// #

--- a/gotham/src/http/header/mod.rs
+++ b/gotham/src/http/header/mod.rs
@@ -17,7 +17,7 @@ use hyper;
 use hyper::header::Raw;
 
 /// Reads a single, space delimited, raw string into a Vec.
-pub fn from_one_rws_delimited_raw_str<T: str::FromStr>(raw: &Raw) -> hyper::error::Result<Vec<T>> {
+fn from_one_rws_delimited_raw_str<T: str::FromStr>(raw: &Raw) -> hyper::error::Result<Vec<T>> {
     if let Some(line) = raw.one() {
         if !line.is_empty() {
             return from_rws_delimited_raw_str(raw);
@@ -28,7 +28,7 @@ pub fn from_one_rws_delimited_raw_str<T: str::FromStr>(raw: &Raw) -> hyper::erro
 }
 
 /// Reads a space delimited, raw string into a Vec.
-pub fn from_rws_delimited_raw_str<T: str::FromStr>(raw: &Raw) -> hyper::error::Result<Vec<T>> {
+fn from_rws_delimited_raw_str<T: str::FromStr>(raw: &Raw) -> hyper::error::Result<Vec<T>> {
     let mut result = Vec::new();
     for line in raw {
         let line = try!(str::from_utf8(line.as_ref()));

--- a/gotham/src/http/mod.rs
+++ b/gotham/src/http/mod.rs
@@ -19,7 +19,7 @@ impl PercentDecoded {
     ///
     /// On success encapulate resultant data for use by components that expect this transformation
     /// has already occured.
-    pub fn new(raw: &str) -> Option<Self> {
+    pub(crate) fn new(raw: &str) -> Option<Self> {
         match percent_decode(raw.as_bytes()).decode_utf8() {
             Ok(pd) => {
                 trace!(" percent_decode: {}, src: {}", pd, raw);
@@ -33,11 +33,6 @@ impl PercentDecoded {
             }
         }
     }
-
-    /// Provide the decoded data this type encapsulates
-    pub fn val(&self) -> &str {
-        &self.val
-    }
 }
 
 impl AsRef<str> for PercentDecoded {
@@ -47,7 +42,7 @@ impl AsRef<str> for PercentDecoded {
 }
 
 /// Decode form-urlencoded strings
-pub fn form_url_decode(raw: &str) -> Result<String, std::str::Utf8Error> {
+fn form_url_decode(raw: &str) -> Result<String, std::str::Utf8Error> {
     match percent_decode(raw.replace("+", " ").as_bytes()).decode_utf8() {
         Ok(pd) => {
             trace!(" form_url_decode: {}, src: {}", pd, raw);
@@ -73,16 +68,11 @@ impl FormUrlDecoded {
     ///
     /// On success encapulate resultant data for use by components that expect this transformation
     /// has already occured.
-    pub fn new(raw: &str) -> Option<Self> {
+    pub(crate) fn new(raw: &str) -> Option<Self> {
         match form_url_decode(raw) {
             Ok(val) => Some(FormUrlDecoded { val }),
             Err(_) => None,
         }
-    }
-
-    /// Provide the decoded data this type encapsulates
-    pub fn val(&self) -> &str {
-        &self.val
     }
 }
 
@@ -99,12 +89,12 @@ mod tests {
     #[test]
     fn ensure_valid_percent_decode() {
         let pd = PercentDecoded::new("%41+%42%2B%63%20%64").unwrap();
-        assert_eq!("A+B+c d", pd.val());
+        assert_eq!("A+B+c d", pd.as_ref());
     }
 
     #[test]
     fn ensure_valid_www_form_url_encoded_value() {
         let f = FormUrlDecoded::new("%41+%42%2B%63%20%64").unwrap();
-        assert_eq!("A B+c d", f.val());
+        assert_eq!("A B+c d", f.as_ref());
     }
 }

--- a/gotham/src/http/request/path.rs
+++ b/gotham/src/http/request/path.rs
@@ -20,21 +20,6 @@ impl RequestPathSegments {
     ///
     /// * path: A `Request` uri path that will be split into indivdual segments with
     ///         a leading "/" to represent the root. Empty segments are removed.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # extern crate gotham;
-    /// #
-    /// # use gotham::http::request::path::RequestPathSegments;
-    /// #
-    /// # pub fn main() {
-    ///     let srp = RequestPathSegments::new("/%61ctiv%61te//workflow");
-    ///     assert_eq!("/", srp.segments()[0].val());
-    ///     assert_eq!("activate", srp.segments()[1].val());
-    ///     assert_eq!("workflow", srp.segments()[2].val());
-    /// # }
-    /// ```
     pub(crate) fn new<'r>(path: &'r str) -> Self {
         let mut segments = vec!["/"];
         segments.extend(
@@ -63,21 +48,6 @@ impl RequestPathSegments {
     ///
     /// The offset starts at 0 meaning all segments of the initial Request path will be provided
     /// until the offset is updated.
-    ///
-    /// ```rust
-    /// # extern crate gotham;
-    /// #
-    /// # use gotham::http::request::path::RequestPathSegments;
-    /// #
-    /// # pub fn main() {
-    ///     let mut srp = RequestPathSegments::new("/activate/workflow");
-    ///     assert_eq!("/", srp.segments()[0].val());
-    ///     assert_eq!("activate", srp.segments()[1].val());
-    ///     assert_eq!("workflow", srp.segments()[2].val());
-    ///     srp.increase_offset(1);
-    ///     assert_eq!("/", srp.segments()[0].val());
-    ///     assert_eq!("workflow", srp.segments()[1].val());
-    /// # }
     pub(crate) fn segments<'a>(&'a self) -> Vec<&PercentDecoded> {
         self.segments
             .iter()

--- a/gotham/src/http/request/path.rs
+++ b/gotham/src/http/request/path.rs
@@ -35,7 +35,7 @@ impl RequestPathSegments {
     ///     assert_eq!("workflow", srp.segments()[2].val());
     /// # }
     /// ```
-    pub fn new<'r>(path: &'r str) -> Self {
+    pub(crate) fn new<'r>(path: &'r str) -> Self {
         let mut segments = vec!["/"];
         segments.extend(
             path.split('/')
@@ -78,7 +78,7 @@ impl RequestPathSegments {
     ///     assert_eq!("/", srp.segments()[0].val());
     ///     assert_eq!("workflow", srp.segments()[1].val());
     /// # }
-    pub fn segments<'a>(&'a self) -> Vec<&PercentDecoded> {
+    pub(crate) fn segments<'a>(&'a self) -> Vec<&PercentDecoded> {
         self.segments
             .iter()
             .enumerate()
@@ -95,14 +95,7 @@ impl RequestPathSegments {
     /// Increases the current offset value.
     ///
     /// * add: Indicates how much the offset should be increased by
-    pub fn increase_offset(&mut self, add: usize) {
+    pub(crate) fn increase_offset(&mut self, add: usize) {
         self.offset += add;
-    }
-
-    /// Sets the offset.
-    ///
-    /// * offset: Sets the offset to the supplied value
-    pub fn set_offset(&mut self, offset: usize) {
-        self.offset = offset;
     }
 }

--- a/gotham/src/http/request/query_string.rs
+++ b/gotham/src/http/request/query_string.rs
@@ -13,28 +13,6 @@ pub(crate) type QueryStringMapping = HashMap<String, Vec<FormUrlDecoded>>;
 /// populated with each value provided.
 ///
 /// For keys that are provided but don't have a value associated an empty string will be stored.
-///
-/// #Examples
-///
-/// ```rust
-/// # extern crate gotham;
-/// #
-/// # use gotham::http::request::query_string::split;
-/// #
-/// # pub fn main() {
-///       let res = split(Some("key=val&key2=val"));
-///       assert_eq!("val", res.get("key").unwrap().first().unwrap().val());
-///       assert_eq!("val", res.get("key2").unwrap().first().unwrap().val());
-///
-///       let res = split(Some("k%65y=val&key=%76al+2"));
-///       assert_eq!("val", res.get("key").unwrap().first().unwrap().val());
-///       assert_eq!("val 2", res.get("key").unwrap().last().unwrap().val());
-///
-///       let res = split(Some("key=val&key2="));
-///       assert_eq!("val", res.get("key").unwrap().first().unwrap().val());
-///       assert_eq!("", res.get("key2").unwrap().first().unwrap().val());
-/// # }
-/// ```
 pub(crate) fn split<'r>(query: Option<&'r str>) -> QueryStringMapping {
     match query {
         Some(query) => {

--- a/gotham/src/http/request/query_string.rs
+++ b/gotham/src/http/request/query_string.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use http::{form_url_decode, FormUrlDecoded};
 
 /// Provides a mapping of keys from `Request` query string to their supplied values
-pub type QueryStringMapping = HashMap<String, Vec<FormUrlDecoded>>;
+pub(crate) type QueryStringMapping = HashMap<String, Vec<FormUrlDecoded>>;
 
 /// Splits a query string into pairs and provides a mapping of keys to values.
 ///
@@ -35,7 +35,7 @@ pub type QueryStringMapping = HashMap<String, Vec<FormUrlDecoded>>;
 ///       assert_eq!("", res.get("key2").unwrap().first().unwrap().val());
 /// # }
 /// ```
-pub fn split<'r>(query: Option<&'r str>) -> QueryStringMapping {
+pub(crate) fn split<'r>(query: Option<&'r str>) -> QueryStringMapping {
     match query {
         Some(query) => {
             let pairs = query.split("&").filter(|pair| pair.contains("="));

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -285,6 +285,7 @@ where
 {
     /// Discards the session, invalidating it for future use and removing the data from the
     /// `Backend`.
+    // TODO: Add test case that covers this.
     pub fn discard(self, state: &mut State) -> Result<(), SessionError> {
         state.put(SessionDropData {
             cookie_config: self.cookie_config,

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -43,6 +43,9 @@ pub enum SessionError {
     Backend(String),
     /// The session was unable to be deserialized
     Deserialize,
+    /// Exhaustive match against this enum is unsupported.
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 enum SessionCookieState {
@@ -68,7 +71,7 @@ enum SameSiteEnforcement {
 /// `secure` flag.  `NewSessionMiddleware` provides functions for adjusting the
 /// `SessionCookieConfig`.
 #[derive(Clone, Debug)]
-pub struct SessionCookieConfig {
+struct SessionCookieConfig {
     // If `Expires` / `Max-Age` are ever added update `reset_session` to allow for them.
     name: String,
     secure: bool,

--- a/gotham/src/middleware/session/rng.rs
+++ b/gotham/src/middleware/session/rng.rs
@@ -2,7 +2,7 @@ use rand::{OsRng, Rng, SeedableRng};
 use rand::reseeding::{Reseeder, ReseedingRng};
 use rand::chacha::ChaChaRng;
 
-pub struct OsRngReseeder {
+pub(super) struct OsRngReseeder {
     os_rng: OsRng,
 }
 
@@ -18,9 +18,9 @@ impl Reseeder<ChaChaRng> for OsRngReseeder {
 // Conventional wisdom seems to be that a securely seeded ChaCha20 PRNG is secure enough for
 // cryptographic purposes, so it's certainly secure enough for generating unpredictable session
 // identifiers.
-pub type SessionIdentifierRng = ReseedingRng<ChaChaRng, OsRngReseeder>;
+pub(super) type SessionIdentifierRng = ReseedingRng<ChaChaRng, OsRngReseeder>;
 
-pub fn session_identifier_rng() -> SessionIdentifierRng {
+pub(super) fn session_identifier_rng() -> SessionIdentifierRng {
     let os_rng = match OsRng::new() {
         Ok(rng) => rng,
         Err(e) => {

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -21,6 +21,8 @@ use state::{request_id, State};
 /// # Examples
 ///
 /// ```rust
+/// # #![allow(deprecated)] // TODO: Refactor this.
+/// #
 /// # extern crate gotham;
 /// # #[macro_use]
 /// # extern crate gotham_derive;

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -160,7 +160,7 @@ where
 }
 
 /// Represents an instance of a `Pipeline`. Returned from `Pipeline::construct()`.
-pub struct PipelineInstance<T>
+struct PipelineInstance<T>
 where
     T: MiddlewareChain,
 {
@@ -173,7 +173,7 @@ where
 {
     /// Constructs an instance of this `Pipeline` by creating all `Middleware` instances required
     /// to serve a request. If any middleware fails creation, its error will be returned.
-    pub fn construct(&self) -> io::Result<PipelineInstance<T::Instance>> {
+    fn construct(&self) -> io::Result<PipelineInstance<T::Instance>> {
         Ok(PipelineInstance {
             chain: self.chain.construct()?,
         })
@@ -186,7 +186,7 @@ where
 {
     /// Serves a request using this `PipelineInstance`. Requests that pass through all `Middleware`
     /// will be served with the `f` function.
-    pub fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
+    fn call<F>(self, state: State, f: F) -> Box<HandlerFuture>
     where
         F: FnOnce(State) -> Box<HandlerFuture> + 'static,
     {

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -362,7 +362,7 @@ where
     /// #   }
     /// # }
     /// #
-    /// # pub fn handler(_: State) -> (State, Response) {
+    /// # fn handler(_: State) -> (State, Response) {
     /// #   unreachable!()
     /// # }
     /// #

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -85,7 +85,7 @@ where
         builder.response_finalizer_builder.finalize()
     };
 
-    Router::new(tree_builder.finalize(), response_finalizer)
+    Router::internal_new(tree_builder.finalize(), response_finalizer)
 }
 
 /// Builds a `Router` with **no** middleware using the provided closure. Routes are defined using

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -252,6 +252,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn internal_server_error_if_no_request_path_segments() {
         let tree_builder = TreeBuilder::new();
         let tree = tree_builder.finalize();
@@ -275,6 +276,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn not_found_error_if_request_path_is_not_found() {
         let tree_builder = TreeBuilder::new();
         let tree = tree_builder.finalize();
@@ -289,6 +291,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn custom_error_if_leaf_found_but_matching_route_not_found() {
         let pipeline_set = finalize_pipeline_set(new_pipeline_set());
         let mut tree_builder = TreeBuilder::new();
@@ -315,6 +318,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn success_if_leaf_and_route_found() {
         let pipeline_set = finalize_pipeline_set(new_pipeline_set());
         let mut tree_builder = TreeBuilder::new();
@@ -341,6 +345,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn delegates_to_secondary_router() {
         let delegated_router = {
             let pipeline_set = finalize_pipeline_set(new_pipeline_set());
@@ -400,6 +405,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn executes_response_finalizer_when_present() {
         let tree_builder = TreeBuilder::new();
         let tree = tree_builder.finalize();

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -53,6 +53,8 @@ impl RouterData {
 /// # Examples
 ///
 /// ```
+/// # #![allow(deprecated)] // TODO: Refactor this.
+/// #
 /// # extern crate gotham;
 /// #
 /// # use gotham::router::tree::TreeBuilder;

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -27,7 +27,7 @@ struct RouterData {
 }
 
 impl RouterData {
-    pub fn new(tree: Tree, response_finalizer: ResponseFinalizer) -> RouterData {
+    fn new(tree: Tree, response_finalizer: ResponseFinalizer) -> RouterData {
         RouterData {
             tree,
             response_finalizer,
@@ -137,7 +137,14 @@ impl Handler for Router {
 
 impl Router {
     /// Creates a `Router` instance.
+    #[deprecated(since = "0.2.0",
+                 note = "use the new `gotham::router::builder` API to construct a Router")]
     pub fn new(tree: Tree, response_finalizer: ResponseFinalizer) -> Router {
+        Router::internal_new(tree, response_finalizer)
+    }
+
+    /// Same as `new`, but private and not deprecated.
+    fn internal_new(tree: Tree, response_finalizer: ResponseFinalizer) -> Router {
         let router_data = RouterData::new(tree, response_finalizer);
         Router {
             data: Arc::new(router_data),

--- a/gotham/src/router/non_match.rs
+++ b/gotham/src/router/non_match.rs
@@ -31,9 +31,10 @@ use hyper::{Method, StatusCode};
 /// }
 /// #
 /// # fn main() {
-/// #   let mut state = State::new();
-/// #   state.put(Method::Post);
-/// #   assert!(MyRouteMatcher.is_match(&state).is_err());
+/// #   State::with_new(|state| {
+/// #       state.put(Method::Post);
+/// #       assert!(MyRouteMatcher.is_match(&state).is_err());
+/// #   });
 /// # }
 /// ```
 pub struct RouteNonMatch {

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -32,14 +32,7 @@ where
 /// Extender that does not further alter the response.
 ///
 /// This is likely to only be useful in documentation or example code.
-pub struct NoopResponseExtender {}
-
-impl NoopResponseExtender {
-    /// Creates a new NoopResponseExtender instance.
-    pub fn new() -> Self {
-        NoopResponseExtender {}
-    }
-}
+pub struct NoopResponseExtender;
 
 impl StaticResponseExtender for NoopResponseExtender {
     fn extend(state: &mut State, res: &mut Response) {

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -21,49 +21,52 @@ use state::{request_id, FromState, State};
 /// # extern crate hyper;
 /// # extern crate mime;
 /// # fn main() {
-/// # use hyper::header::{Headers, Accept};
-/// # use gotham::state::State;
-/// # use gotham::router::route::matcher::RouteMatcher;
-/// # use gotham::router::route::matcher::accept::AcceptHeaderRouteMatcher;
+/// #   use hyper::header::{Headers, Accept};
+/// #   use gotham::state::State;
+/// #   use gotham::router::route::matcher::RouteMatcher;
+/// #   use gotham::router::route::matcher::accept::AcceptHeaderRouteMatcher;
 /// #
-///   let supported_media_types = vec![mime::APPLICATION_JSON, mime::IMAGE_STAR];
-///   let matcher = AcceptHeaderRouteMatcher::new(supported_media_types);
-///   let mut state = State::new();
+/// #   State::with_new(|state| {
+/// #
+/// let supported_media_types = vec![mime::APPLICATION_JSON, mime::IMAGE_STAR];
+/// let matcher = AcceptHeaderRouteMatcher::new(supported_media_types);
 ///
-///   // No accept header
-///   state.put(Headers::new());
-///   assert!(matcher.is_match(&state).is_ok());
+/// // No accept header
+/// state.put(Headers::new());
+/// assert!(matcher.is_match(&state).is_ok());
 ///
-///   // Accept header of `*/*`
-///   let mut headers = Headers::new();
-///   headers.set(Accept::star());
-///   state.put(headers);
-///   assert!(matcher.is_match(&state).is_ok());
+/// // Accept header of `*/*`
+/// let mut headers = Headers::new();
+/// headers.set(Accept::star());
+/// state.put(headers);
+/// assert!(matcher.is_match(&state).is_ok());
 ///
-///   // Accept header of `application/json`
-///   let mut headers = Headers::new();
-///   headers.set(Accept::json());
-///   state.put(headers);
-///   assert!(matcher.is_match(&state).is_ok());
+/// // Accept header of `application/json`
+/// let mut headers = Headers::new();
+/// headers.set(Accept::json());
+/// state.put(headers);
+/// assert!(matcher.is_match(&state).is_ok());
 ///
-///   // Not a valid Accept header
-///   let mut headers = Headers::new();
-///   headers.set(Accept::text());
-///   state.put(headers);
-///   assert!(matcher.is_match(&state).is_err());
+/// // Not a valid Accept header
+/// let mut headers = Headers::new();
+/// headers.set(Accept::text());
+/// state.put(headers);
+/// assert!(matcher.is_match(&state).is_err());
 ///
-///   // At least one supported accept header
-///   let mut headers = Headers::new();
-///   headers.set(Accept::text());
-///   headers.set(Accept::json());
-///   state.put(headers);
-///   assert!(matcher.is_match(&state).is_ok());
+/// // At least one supported accept header
+/// let mut headers = Headers::new();
+/// headers.set(Accept::text());
+/// headers.set(Accept::json());
+/// state.put(headers);
+/// assert!(matcher.is_match(&state).is_ok());
 
-///   // Accept header of `image/*`
-///   let mut headers = Headers::new();
-///   headers.set(Accept::image());
-///   state.put(headers);
-///   assert!(matcher.is_match(&state).is_ok());
+/// // Accept header of `image/*`
+/// let mut headers = Headers::new();
+/// headers.set(Accept::image());
+/// state.put(headers);
+/// assert!(matcher.is_match(&state).is_ok());
+/// #
+/// #   });
 /// # }
 /// ```
 pub struct AcceptHeaderRouteMatcher {

--- a/gotham/src/router/route/matcher/and.rs
+++ b/gotham/src/router/route/matcher/and.rs
@@ -13,12 +13,14 @@ use state::State;
 /// # extern crate hyper;
 /// # extern crate mime;
 /// # fn main() {
-/// # use hyper::Method;
-/// # use hyper::header::{Headers, Accept};
-/// # use gotham::state::State;
-/// # use gotham::router::route::matcher::{RouteMatcher, MethodOnlyRouteMatcher};
-/// # use gotham::router::route::matcher::and::AndRouteMatcher;
-/// # use gotham::router::route::matcher::accept::AcceptHeaderRouteMatcher;
+/// #   use hyper::Method;
+/// #   use hyper::header::{Headers, Accept};
+/// #   use gotham::state::State;
+/// #   use gotham::router::route::matcher::{RouteMatcher, MethodOnlyRouteMatcher};
+/// #   use gotham::router::route::matcher::and::AndRouteMatcher;
+/// #   use gotham::router::route::matcher::accept::AcceptHeaderRouteMatcher;
+/// #
+/// #   State::with_new(|state| {
 /// #
 ///   let methods = vec![Method::Get, Method::Head];
 ///   let supported_media_types = vec![mime::APPLICATION_JSON];
@@ -26,7 +28,6 @@ use state::State;
 ///	  let accept_matcher = AcceptHeaderRouteMatcher::new(supported_media_types);
 ///   let matcher = AndRouteMatcher::new(method_matcher, accept_matcher);
 ///
-///   let mut state = State::new();
 ///   state.put(Method::Get);
 ///
 ///   // Request that matches both requirements
@@ -45,6 +46,8 @@ use state::State;
 ///   headers.set(Accept::text());
 ///   state.put(headers);
 ///   assert!(matcher.is_match(&state).is_err());
+/// #
+/// #   });
 /// # }
 /// ```
 pub struct AndRouteMatcher<T, U>

--- a/gotham/src/router/route/matcher/any.rs
+++ b/gotham/src/router/route/matcher/any.rs
@@ -12,14 +12,17 @@ use state::State;
 /// ```rust
 /// # extern crate gotham;
 /// # fn main() {
-/// # use gotham::state::State;
-/// # use gotham::router::route::matcher::RouteMatcher;
-/// # use gotham::router::route::matcher::any::AnyRouteMatcher;
+/// #   use gotham::state::State;
+/// #   use gotham::router::route::matcher::RouteMatcher;
+/// #   use gotham::router::route::matcher::any::AnyRouteMatcher;
+/// #
+/// #   State::with_new(|state| {
 /// #
 ///   let matcher = AnyRouteMatcher::new();
-///   let state = State::new();
 ///
 ///   assert!(matcher.is_match(&state).is_ok());
+/// #
+/// #   });
 /// # }
 /// ```
 pub struct AnyRouteMatcher {}

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -27,18 +27,21 @@ pub trait RouteMatcher: RefUnwindSafe {
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// # fn main() {
-/// # use hyper::Method;
-/// # use gotham::state::State;
-/// # use gotham::router::route::matcher::{RouteMatcher, MethodOnlyRouteMatcher};
+/// #   use hyper::Method;
+/// #   use gotham::state::State;
+/// #   use gotham::router::route::matcher::{RouteMatcher, MethodOnlyRouteMatcher};
+/// #
+/// #   State::with_new(|state| {
+/// #
 ///   let methods = vec![Method::Get, Method::Head];
 ///   let matcher = MethodOnlyRouteMatcher::new(methods);
-///   let mut state = State::new();
 ///
 ///   state.put(Method::Get);
 ///   assert!(matcher.is_match(&state).is_ok());
 ///
 ///   state.put(Method::Post);
 ///   assert!(matcher.is_match(&state).is_err());
+/// #   });
 /// # }
 /// ```
 pub struct MethodOnlyRouteMatcher {

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -111,6 +111,8 @@ pub struct ExtractorFailed;
 /// ## A `Route` which delegates remaining `Request` details to a secondary `Router` instance
 ///
 /// ```rust
+/// # #![allow(deprecated)] // TODO: Refactor this.
+/// #
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// #

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -11,7 +11,7 @@ pub mod regex;
 
 /// A depth ordered `Vec` of `Node` instances that create a routable path through the `Tree` for the
 /// matched `Request` path.
-pub type Path<'a> = Vec<&'a Node>;
+type Path<'a> = Vec<&'a Node>;
 
 /// Number of segments from a `Request` path that are considered to have been processed
 /// by an `Router` traversing its `Tree`.
@@ -107,15 +107,8 @@ pub struct Tree {
 }
 
 impl Tree {
-    /// Borrow the root `Node` of the `Tree`.
-    ///
-    /// To be used in building a `Tree` structure only.
-    pub fn borrow_root(&self) -> &Node {
-        &self.root
-    }
-
     /// Attempt to acquire a path from the `Tree` which matches the `Request` path and is routable.
-    pub fn traverse<'r>(
+    pub(crate) fn traverse<'r>(
         &'r self,
         req_path_segments: &'r [&PercentDecoded],
     ) -> Option<(Path<'r>, &Node, SegmentsProcessed, SegmentMapping<'r>)> {

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -50,12 +50,10 @@ pub type SegmentMapping<'r> = HashMap<&'r str, Vec<&'r PercentDecoded>>;
 /// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::state::State;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
-/// # use gotham::router::tree::TreeBuilder;
+/// # use gotham::router::tree::{Tree, TreeBuilder};
 /// # use gotham::router::tree::node::NodeBuilder;
 /// # use gotham::router::tree::node::SegmentType;
-/// # use gotham::http::request::path::RequestPathSegments;
 /// # use gotham::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-/// # use gotham::http::PercentDecoded;
 /// #
 /// # fn handler(state: State) -> (State, Response) {
 /// #   let res = create_response(&state, StatusCode::Ok, None);
@@ -63,6 +61,10 @@ pub type SegmentMapping<'r> = HashMap<&'r str, Vec<&'r PercentDecoded>>;
 /// # }
 /// #
 /// # fn main() {
+/// #   build_tree();
+/// # }
+/// #
+/// # fn build_tree() -> Tree {
 /// # let pipeline_set = finalize_pipeline_set(new_pipeline_set());
 ///   let mut tree_builder: TreeBuilder = TreeBuilder::new();
 ///
@@ -84,22 +86,7 @@ pub type SegmentMapping<'r> = HashMap<&'r str, Vec<&'r PercentDecoded>>;
 ///   activate_node_builder.add_child(thing_node_builder);
 ///   tree_builder.add_child(activate_node_builder);
 ///
-///   let tree = tree_builder.finalize();
-///
-///   let request_path_segments = RequestPathSegments::new("/%61ctiv%61te/workflow5");
-///   match tree.traverse(request_path_segments.segments().as_slice()) {
-///       Some((path, leaf, segments_processed, segment_mapping)) => {
-///         assert!(path.last().unwrap().is_routable());
-///         assert_eq!(path.last().unwrap().segment(), leaf.segment());
-///         assert_eq!(segments_processed, 2);
-///         assert_eq!(segment_mapping.get("thing").unwrap().last().unwrap().val(), "workflow5");
-///       }
-///       None => panic!(),
-///   }
-///
-///   // These paths are not routable but could be if 1 or more `Route` were added.
-///   assert!(tree.traverse(&[&PercentDecoded::new("/").unwrap()]).is_none());
-///   assert!(tree.traverse(&[&PercentDecoded::new("/activate").unwrap()]).is_none());
+///   tree_builder.finalize()
 /// # }
 /// ```
 pub struct Tree {
@@ -160,5 +147,79 @@ impl TreeBuilder {
         Tree {
             root: self.root.finalize(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::{Method, Response, StatusCode};
+
+    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use http::request::path::RequestPathSegments;
+    use http::response::create_response;
+    use router::route::matcher::MethodOnlyRouteMatcher;
+    use router::route::dispatch::DispatcherImpl;
+    use router::route::{Delegation, Extractors, RouteImpl};
+    use state::State;
+    use pipeline::set::*;
+
+    use super::*;
+
+    fn handler(state: State) -> (State, Response) {
+        let res = create_response(&state, StatusCode::Ok, None);
+        (state, res)
+    }
+
+    #[test]
+    fn tree_traversal_tests() {
+        let pipeline_set = finalize_pipeline_set(new_pipeline_set());
+        let mut tree_builder: TreeBuilder = TreeBuilder::new();
+
+        let mut activate_node_builder = NodeBuilder::new("activate", SegmentType::Static);
+
+        let mut thing_node_builder = NodeBuilder::new("thing", SegmentType::Dynamic);
+        let thing_route = {
+            let methods = vec![Method::Get];
+            let matcher = MethodOnlyRouteMatcher::new(methods);
+            let dispatcher = Box::new(DispatcherImpl::new(|| Ok(handler), (), pipeline_set));
+            let extractors: Extractors<NoopPathExtractor, NoopQueryStringExtractor> =
+                Extractors::new();
+            let route = RouteImpl::new(matcher, dispatcher, extractors, Delegation::Internal);
+            Box::new(route)
+        };
+        thing_node_builder.add_route(thing_route);
+
+        activate_node_builder.add_child(thing_node_builder);
+        tree_builder.add_child(activate_node_builder);
+
+        let tree = tree_builder.finalize();
+
+        let request_path_segments = RequestPathSegments::new("/%61ctiv%61te/workflow5");
+        match tree.traverse(request_path_segments.segments().as_slice()) {
+            Some((path, leaf, segments_processed, segment_mapping)) => {
+                assert!(path.last().unwrap().is_routable());
+                assert_eq!(path.last().unwrap().segment(), leaf.segment());
+                assert_eq!(segments_processed, 2);
+                assert_eq!(
+                    segment_mapping
+                        .get("thing")
+                        .unwrap()
+                        .last()
+                        .unwrap()
+                        .as_ref(),
+                    "workflow5"
+                );
+            }
+            None => panic!(),
+        }
+
+        assert!(
+            tree.traverse(&[&PercentDecoded::new("/").unwrap()])
+                .is_none()
+        );
+        assert!(
+            tree.traverse(&[&PercentDecoded::new("/activate").unwrap()])
+                .is_none()
+        );
     }
 }

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -109,13 +109,8 @@ pub struct Node {
 
 impl Node {
     /// Provides the segment this `Node` represents.
-    pub fn segment(&self) -> &str {
+    pub(crate) fn segment(&self) -> &str {
         &self.segment
-    }
-
-    /// Provides the type of segment this `Node` represents.
-    pub fn segment_type(&self) -> &SegmentType {
-        &self.segment_type
     }
 
     /// Determines if a `Route` instance associated with this `Node` is willing to `Handle` the
@@ -129,7 +124,7 @@ impl Node {
     ///
     /// In the situation where all these avenues are exhausted an InternalServerError will be
     /// provided.
-    pub fn select_route<'a>(
+    pub(crate) fn select_route<'a>(
         &'a self,
         state: &State,
     ) -> Result<&'a Box<Route + Send + Sync>, RouteNonMatch> {
@@ -167,14 +162,9 @@ impl Node {
         }
     }
 
-    /// True if there is at least one child `Node` present
-    pub fn is_parent(&self) -> bool {
-        !self.children.is_empty()
-    }
-
     /// True is there is a least one `Route` represented by this `Node`, that is it can act as a
     /// leaf in a single path through the tree.
-    pub fn is_routable(&self) -> bool {
+    pub(crate) fn is_routable(&self) -> bool {
         !self.routes.is_empty()
     }
 
@@ -191,7 +181,7 @@ impl Node {
     /// 2. Constrained
     /// 3. Dynamic
     /// 4. Glob
-    pub fn traverse<'r>(
+    pub(crate) fn traverse<'r>(
         &'r self,
         req_path_segments: &'r [&PercentDecoded],
     ) -> Option<(Path<'r>, &Node, SegmentsProcessed, SegmentMapping<'r>)> {
@@ -278,10 +268,8 @@ impl Node {
 
     fn is_match(&self, req_path_segment: &PercentDecoded) -> bool {
         match self.segment_type {
-            SegmentType::Static => self.segment == req_path_segment.val(),
-            SegmentType::Constrained { ref regex } => {
-                regex.is_match(req_path_segment.val().as_ref())
-            }
+            SegmentType::Static => self.segment == req_path_segment.as_ref(),
+            SegmentType::Constrained { ref regex } => regex.is_match(req_path_segment.as_ref()),
             SegmentType::Dynamic | SegmentType::Glob => true,
         }
     }

--- a/gotham/src/router/tree/regex.rs
+++ b/gotham/src/router/tree/regex.rs
@@ -29,7 +29,7 @@ impl ConstrainedSegmentRegex {
 
     /// Wraps `regex::Regex::is_match` to return true if and only if the regex matches the string
     /// given.
-    pub fn is_match(&self, s: &str) -> bool {
+    pub(crate) fn is_match(&self, s: &str) -> bool {
         match catch_unwind(|| self.regex.is_match(s)) {
             Ok(b) => b,
             Err(_) => {

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -35,10 +35,12 @@ pub(crate) use state::request_id::set_request_id;
 /// }
 ///
 /// # fn main() {
-/// let mut state = State::new();
-///
+/// #   State::with_new(|state| {
+/// #
 /// state.put(MyStruct { value: 1 });
 /// assert_eq!(state.borrow::<MyStruct>().value, 1);
+/// #
+/// #   });
 /// # }
 /// ```
 pub struct State {
@@ -87,7 +89,7 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 1 });
     /// assert_eq!(state.borrow::<MyStruct>().value, 1);
@@ -97,6 +99,8 @@ impl State {
     ///
     /// assert_eq!(state.borrow::<AnotherStruct>().value, "a string");
     /// assert_eq!(state.borrow::<MyStruct>().value, 100);
+    /// #
+    /// #   });
     /// # }
     /// ```
     pub fn put<T>(&mut self, t: T)
@@ -129,13 +133,15 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 1 });
     /// assert!(state.has::<MyStruct>());
     /// assert_eq!(state.borrow::<MyStruct>().value, 1);
     ///
     /// assert!(!state.has::<AnotherStruct>());
+    /// #
+    /// #   });
     /// # }
     /// ```
     pub fn has<T>(&self) -> bool
@@ -167,13 +173,15 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 1 });
     /// assert!(state.try_borrow::<MyStruct>().is_some());
     /// assert_eq!(state.try_borrow::<MyStruct>().unwrap().value, 1);
     ///
     /// assert!(state.try_borrow::<AnotherStruct>().is_none());
+    /// #
+    /// #   });
     /// # }
     /// ```
     pub fn try_borrow<T>(&self) -> Option<&T>
@@ -206,10 +214,12 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 1 });
     /// assert_eq!(state.borrow::<MyStruct>().value, 1);
+    /// #
+    /// #   });
     /// # }
     /// ```
     pub fn borrow<T>(&self) -> &T
@@ -241,7 +251,7 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 100 });
     ///
@@ -252,6 +262,7 @@ impl State {
     /// assert_eq!(state.borrow::<MyStruct>().value, 110);
     ///
     /// assert!(state.try_borrow_mut::<AnotherStruct>().is_none());
+    /// #   });
     /// # }
     pub fn try_borrow_mut<T>(&mut self) -> Option<&mut T>
     where
@@ -289,7 +300,7 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 100 });
     ///
@@ -301,6 +312,8 @@ impl State {
     /// assert_eq!(state.borrow::<MyStruct>().value, 110);
     ///
     /// assert!(state.try_borrow_mut::<AnotherStruct>().is_none());
+    /// #
+    /// #   });
     /// # }
     pub fn borrow_mut<T>(&mut self) -> &mut T
     where
@@ -331,7 +344,7 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 110 });
     ///
@@ -342,6 +355,8 @@ impl State {
     /// assert!(state.try_borrow::<MyStruct>().is_none());
     ///
     /// assert!(state.try_take::<AnotherStruct>().is_none());
+    /// #
+    /// #   });
     /// # }
     pub fn try_take<T>(&mut self) -> Option<T>
     where
@@ -379,7 +394,7 @@ impl State {
     /// # }
     /// #
     /// # fn main() {
-    /// # let mut state = State::new();
+    /// #   State::with_new(|state| {
     /// #
     /// state.put(MyStruct { value: 110 });
     ///
@@ -388,6 +403,8 @@ impl State {
     /// assert!(state.try_take::<MyStruct>().is_none());
     /// assert!(state.try_borrow_mut::<MyStruct>().is_none());
     /// assert!(state.try_borrow::<MyStruct>().is_none());
+    /// #
+    /// #   });
     /// # }
     pub fn take<T>(&mut self) -> T
     where

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -10,8 +10,10 @@ use std::any::{Any, TypeId};
 
 pub use state::data::StateData;
 pub use state::from_state::FromState;
-pub use state::request_id::{request_id, set_request_id};
+pub use state::request_id::request_id;
 pub use state::client_addr::client_addr;
+
+pub(crate) use state::request_id::set_request_id;
 
 /// Provides storage for request state, and stores one item of each type. The types used for
 /// storage must implement the `gotham::state::StateData` trait to allow its storage.
@@ -45,10 +47,21 @@ pub struct State {
 
 impl State {
     /// Creates a new, empty `State`
-    pub fn new() -> State {
+    pub(crate) fn new() -> State {
         State {
             data: HashMap::new(),
         }
+    }
+
+    /// Creates a new, empty `State` and yields it into the provided closure. This is intended only
+    /// for use in the documentation tests for `State`, since the `State` container cannot be
+    /// constructed otherwise.
+    #[doc(hidden)]
+    pub fn with_new<F>(f: F)
+    where
+        F: FnOnce(&mut State),
+    {
+        f(&mut State::new())
     }
 
     /// Puts a value into the `State` storage. One value of each type is retained. Successive calls

--- a/gotham/src/state/request_id.rs
+++ b/gotham/src/state/request_id.rs
@@ -7,7 +7,7 @@ use http::header::XRequestId;
 use state::{FromState, State};
 
 /// Holds details about the current Request that are useful for enhancing logging.
-pub struct RequestId {
+pub(super) struct RequestId {
     val: String,
 }
 
@@ -20,7 +20,7 @@ pub struct RequestId {
 ///
 /// This method MUST be invoked by Gotham, before handing control to
 /// pipelines or Handlers to ensure that a value for `RequestId` is always available.
-pub fn set_request_id<'a>(state: &'a mut State) -> &'a str {
+pub(crate) fn set_request_id<'a>(state: &'a mut State) -> &'a str {
     if !state.has::<RequestId>() {
         let request_id = match Headers::borrow_from(state).get::<XRequestId>() {
             Some(ex_req_id) => {

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -434,7 +434,7 @@ impl TestResponse {
 
 /// `TestConnect` represents the connection between a test client and the `TestServer` instance
 /// that created it. This type should never be used directly.
-pub struct TestConnect {
+struct TestConnect {
     stream: cell::RefCell<Option<PollEvented<mio::net::TcpStream>>>,
 }
 

--- a/gotham_derive/src/extenders.rs
+++ b/gotham_derive/src/extenders.rs
@@ -3,7 +3,7 @@ use quote;
 
 use helpers::ty_params;
 
-pub fn bad_request_static_response_extender(ast: &syn::DeriveInput) -> quote::Tokens {
+pub(crate) fn bad_request_static_response_extender(ast: &syn::DeriveInput) -> quote::Tokens {
     let (name, borrowed, where_clause) = ty_params(&ast, None);
 
     quote! {

--- a/gotham_derive/src/extractors.rs
+++ b/gotham_derive/src/extractors.rs
@@ -1,7 +1,7 @@
 use syn;
 use quote;
 
-pub fn base_path(_ast: &syn::DeriveInput) -> quote::Tokens {
+pub(crate) fn base_path(_ast: &syn::DeriveInput) -> quote::Tokens {
     quote! {
         compile_error!("#[derive(PathExtractor)] is no longer supported - please switch to \
                         #[derive(Deserialize)]. The `StateData` and `StaticResponseExtender` \
@@ -9,7 +9,7 @@ pub fn base_path(_ast: &syn::DeriveInput) -> quote::Tokens {
     }
 }
 
-pub fn base_query_string(_ast: &syn::DeriveInput) -> quote::Tokens {
+pub(crate) fn base_query_string(_ast: &syn::DeriveInput) -> quote::Tokens {
     quote! {
         compile_error!("#[derive(QueryStringExtractor)] is no longer supported - please switch to \
                         #[derive(Deserialize)]. The `StateData` and `StaticResponseExtender` \

--- a/gotham_derive/src/helpers.rs
+++ b/gotham_derive/src/helpers.rs
@@ -1,7 +1,7 @@
 use syn;
 use quote;
 
-pub fn ty_params<'a>(
+pub(crate) fn ty_params<'a>(
     ast: &'a syn::DeriveInput,
     additional_type_constraint: Option<quote::Tokens>,
 ) -> (&'a syn::Ident, quote::Tokens, quote::Tokens) {

--- a/gotham_derive/src/new_middleware.rs
+++ b/gotham_derive/src/new_middleware.rs
@@ -3,7 +3,7 @@ use quote;
 
 use helpers::ty_params;
 
-pub fn new_middleware(ast: &syn::DeriveInput) -> quote::Tokens {
+pub(crate) fn new_middleware(ast: &syn::DeriveInput) -> quote::Tokens {
     let (name, borrowed, where_clause) = ty_params(&ast, None);
 
     quote! {

--- a/gotham_derive/src/state.rs
+++ b/gotham_derive/src/state.rs
@@ -3,7 +3,7 @@ use quote;
 
 use helpers::ty_params;
 
-pub fn state_data(ast: &syn::DeriveInput) -> quote::Tokens {
+pub(crate) fn state_data(ast: &syn::DeriveInput) -> quote::Tokens {
     let (name, borrowed, where_clause) = ty_params(&ast, None);
 
     quote! {

--- a/misc/borrow_bag/src/handle.rs
+++ b/misc/borrow_bag/src/handle.rs
@@ -16,7 +16,7 @@ pub struct Handle<T, N> {
 }
 
 /// Creates a new `Handle` of any given type.
-pub fn new_handle<T, N>() -> Handle<T, N> {
+pub(crate) fn new_handle<T, N>() -> Handle<T, N> {
     Handle {
         phantom: PhantomData,
     }


### PR DESCRIPTION
Reduces the visibility of things that don't need to be part of our public API.

Fixes #15.

This deprecates the `Router::new` function, and adds `#[allow(deprecated)]` to some test code and some existing rustdoc examples that use it. I'll be doing a review of our rustdoc next, so I'll tackle it there when I revisit the examples.

This deprecation is an early step towards deprecating the entire `TreeBuilder` API from our public API (though obviously we'll still use it internally), with the ultimate goal being that **all** routing needs be served by the builder API.