### PR TITLE
Add extra log information from HandlerError

### DIFF
--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -51,6 +51,8 @@ where
     E: Error + 'static,
 {
     fn into_handler_error(self) -> HandlerError {
+        trace!(" converting Error to HandlerError: {}", self);
+
         HandlerError {
             status_code: StatusCode::InternalServerError,
             cause: Box::new(self),
@@ -127,13 +129,14 @@ impl HandlerError {
 
 impl IntoResponse for HandlerError {
     fn into_response(self, state: &State) -> Response {
-        trace!(
-            "[{}] HandlerError generating HTTP response with status: {} {}",
+        debug!(
+            "[{}] HandlerError generating {} {} response: {}",
             request_id(state),
             self.status_code.as_u16(),
             self.status_code
                 .canonical_reason()
-                .unwrap_or("(unregistered)",)
+                .unwrap_or("(unregistered)",),
+            self.cause().map(|e| e.description()).unwrap_or("(none)"),
         );
 
         create_response(state, self.status_code, None)


### PR DESCRIPTION
We had error information being logged in `TRACE` by the `Router`, but this adds an extra log entry at the `DEBUG` level when an application has returned a `HandlerError` which is responsible for generating the `Response`. This ensures that setting the log level to debug yields some useful debug information.

Before:

```
[2018-02-25 21:42:19.274389000][gotham::middleware::chain][TRACE]pipeline complete, invoking handler
[2018-02-25 21:42:19.280751000][gotham::router][TRACE][d49dcd4c-07fb-433d-a42d-a64137f9fe88] converting error into http response during finalization: handler failed to process request (Error { err: "missing field `display_name`" })
[2018-02-25 21:42:19.280804000][gotham::handler::error][TRACE][d49dcd4c-07fb-433d-a42d-a64137f9fe88] HandlerError generating HTTP response with status: 400 Bad Request
[2018-02-25 21:42:19.280890000][gotham::router][TRACE][d49dcd4c-07fb-433d-a42d-a64137f9fe88] handler complete
```

After:

```
[2018-02-25 21:45:45.021858000][gotham::middleware::chain][TRACE]pipeline complete, invoking handler
[2018-02-25 21:45:45.030600000][gotham::handler::error][TRACE] converting Error to HandlerError: missing field `display_name`
[2018-02-25 21:45:45.030673000][gotham::router][TRACE][edd9e639-01e1-416e-a3b8-12bc735fccca] converting error into http response during finalization: handler failed to process request (Error { err: "missing field `display_name`" })
[2018-02-25 21:45:45.030722000][gotham::handler::error][DEBUG][edd9e639-01e1-416e-a3b8-12bc735fccca] HandlerError generating 400 Bad Request response: missing field `display_name`
[2018-02-25 21:45:45.030804000][gotham::router][TRACE][edd9e639-01e1-416e-a3b8-12bc735fccca] handler complete
```