### PR TITLE
Only install rustfmt once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ matrix:
       before_script:
         - rustup toolchain install nightly
         - rustup component add --toolchain nightly rustfmt-preview
-        - cargo +nightly install --force rustfmt-nightly
       script:
         - echo "Checking Gotham codebase with rustfmt release `cargo +nightly fmt --version`."
         - cargo +nightly fmt --all -- --write-mode=diff


### PR DESCRIPTION
This regresses us to a more official release (0.3.8 rather than 0.4.0)
but saves 8~10 minutes of compiling rustfmt from scratch.