### PR TITLE
Add example using cookies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "examples/query_string/introduction",
 
     # cookies
+    "examples/cookies/introduction",
 
     # sessions
     "examples/sessions/introduction",

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ information on functionality and ordering.
 | [Routing](routing) | Dispatching `Requests` to functionality provided by your application. | 4 |
 | [Path](path) | Extracting data from the `Request` path ensuring type safety. | 1 |
 | [Query String](query_string) | Extracting data from the `Request` query string whilst ensuring type safety. | 1 |
-| [Cookies](cookies) | Working with Cookies. | 0 |
+| [Cookies](cookies) | Working with Cookies. | 1 |
 | [Sessions](sessions) | Working with Sessions. | 2 |
 | [Headers](headers) | Working with HTTP Headers. | 1 |
 | [Handlers](handlers) | Developing application logic that responds to web requests. | 0 |

--- a/examples/cookies/README.md
+++ b/examples/cookies/README.md
@@ -1,0 +1,32 @@
+# Cookies Examples
+
+A collection of crates showing how to store and retrieve cookie data with the Gotham web framework.
+
+## Ordering
+
+We recommend reviewing our cookies examples in the order shown below:
+
+1. [Introduction](introduction) - Shows how to store and retrieve cookie data.
+
+## Help
+
+You can get help for the Gotham web framework at:
+
+* [The Gotham web framework website](https://gotham.rs)
+* [Gotham web framework API documentation](https://docs.rs/gotham/)
+* [Gitter chatroom](https://gitter.im/gotham-rs/gotham)
+* [Twitter](https://twitter.com/gotham_rs)
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../LICENSE-MIT)
+* [Apache License, Version 2.0](../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/cookies/introduction/Cargo.toml
+++ b/examples/cookies/introduction/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gotham_examples_cookies_introduction"
+description = "An introduction to storing and retrieving cookies with the Gotham web framework."
+version = "0.0.0"
+authors = ["Daniel Wagner-Hall <dawagner@gmail.com>"]
+publish = false
+
+[dependencies]
+gotham = { path = "../../../gotham" }
+
+hyper = "0.11"
+mime = "0.3"

--- a/examples/cookies/introduction/README.md
+++ b/examples/cookies/introduction/README.md
@@ -1,0 +1,88 @@
+# Cookies introduction
+
+An introduction to storing and retrieving cookie data with the Gotham web framework.
+
+## Running
+
+From the `examples/cookies/introduction` directory:
+
+```
+Terminal 1:
+  $ cargo run                                                                                                                                                                                                                     130 ↵
+     Compiling gotham_examples_cookies_introduction v0.0.0 (file://.../gotham/examples/cookies/introduction)
+      Finished dev [unoptimized + debuginfo] target(s) in 2.49 secs
+       Running `.../gotham/target/debug/gotham_examples_cookies_introduction`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+  $ curl -v -c /tmp/cookiejar http://localhost:7878/
+  *   Trying ::1...
+  * TCP_NODELAY set
+  * Connection failed
+  * connect to ::1 port 7878 failed: Connection refused
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to localhost (127.0.0.1) port 7878 (#0)
+  > GET / HTTP/1.1
+  > Host: localhost:7878
+  > User-Agent: curl/7.54.0
+  > Accept: */*
+  >
+  < HTTP/1.1 200 OK
+  < Content-Length: 25
+  < Content-Type: text/plain
+  < X-Request-ID: 1b0ace7a-8d6b-478b-a099-f3e57363d9cd
+  < X-Frame-Options: DENY
+  < X-XSS-Protection: 1; mode=block
+  < X-Content-Type-Options: nosniff
+  * Added cookie adjective="repeat" for domain localhost, path /, expire 0
+  < Set-Cookie: adjective=repeat; HttpOnly
+  < X-Runtime-Microseconds: 65
+  < Date: Wed, 07 Mar 2018 00:05:27 GMT
+  <
+  Hello first time visitor
+  * Connection #0 to host localhost left intact
+  $ curl -v -b /tmp/cookiejar http://localhost:7878/
+  *   Trying ::1...
+  * TCP_NODELAY set
+  * Connection failed
+  * connect to ::1 port 7878 failed: Connection refused
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to localhost (127.0.0.1) port 7878 (#0)
+  > GET / HTTP/1.1
+  > Host: localhost:7878
+  > User-Agent: curl/7.54.0
+  > Accept: */*
+  > Cookie: adjective=repeat
+  >
+  < HTTP/1.1 200 OK
+  < Content-Length: 21
+  < Content-Type: text/plain
+  < X-Request-ID: cc9c1e59-75ea-40e1-b511-98851c393cb9
+  < X-Frame-Options: DENY
+  < X-XSS-Protection: 1; mode=block
+  < X-Content-Type-Options: nosniff
+  * Replaced cookie adjective="repeat" for domain localhost, path /, expire 0
+  < Set-Cookie: adjective=repeat; HttpOnly
+  < X-Runtime-Microseconds: 113
+  < Date: Wed, 07 Mar 2018 00:05:54 GMT
+  <
+  Hello repeat visitor
+  * Connection #0 to host localhost left intact
+
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -1,0 +1,110 @@
+//! An introduction to storing and retrieving cookie data, with the Gotham
+//! web framework.
+
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+
+use hyper::{Response, StatusCode};
+use hyper::header::{Cookie, Headers, SetCookie};
+
+use gotham::http::response::create_response;
+use gotham::state::{FromState, State};
+
+/// The first request will set a cookie, and subsequent requests will echo it back.
+fn handler(state: State) -> (State, Response) {
+    // Define a narrow scope so that state can be borrowed/moved later in the function.
+    let adjective_from_cookie = {
+        // Get the request headers.
+        let headers: &Headers = Headers::borrow_from(&state);
+        // Get the Cookie header from the request.
+        let maybe_cookie = headers.get::<Cookie>();
+        // Get the value of the "adjective" cookie, if set.
+        maybe_cookie.and_then(|cookie| cookie.get("adjective").map(|s| s.to_owned()))
+    };
+
+    let adjective = adjective_from_cookie.unwrap_or("first time".to_owned());
+
+    let mut response = {
+        create_response(
+            &state,
+            StatusCode::Ok,
+            Some((
+                format!("Hello {} visitor\n", adjective).as_bytes().to_vec(),
+                mime::TEXT_PLAIN,
+            )),
+        )
+    };
+    {
+        // Make a new cookie. This is currently one of the less type-safe corners of Gotham.
+        let cookie = "adjective=repeat; HttpOnly".to_owned();
+        set_cookie(cookie, &mut response);
+    }
+    (state, response)
+}
+
+fn set_cookie(cookie: String, response: &mut Response) {
+    // Get the response headers.
+    let headers = response.headers_mut();
+    if let Some(existing_cookies) = headers.get_mut::<SetCookie>() {
+        // If some cookies are already being set (e.g. by some middleware), append to that list.
+        existing_cookies.push(cookie);
+        return;
+    }
+    // Else create a new SetCookie header.
+    headers.set::<SetCookie>(SetCookie(vec![cookie]));
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, || Ok(handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+    use hyper::header::{Cookie, SetCookie};
+
+    #[test]
+    fn cookie_is_set_and_counter_increments() {
+        let test_server = TestServer::new(|| Ok(handler)).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let set_cookie: Vec<String> = {
+            let cookie_header = response.headers().get::<SetCookie>();
+            assert!(cookie_header.is_some());
+            cookie_header.unwrap().0.clone()
+        };
+        assert!(set_cookie.len() == 1);
+        assert_eq!(
+            set_cookie.get(0),
+            Some(&"adjective=repeat; HttpOnly".to_owned())
+        );
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], "Hello first time visitor\n".as_bytes());
+
+        let mut cookie = Cookie::new();
+        cookie.append("adjective", "repeat");
+
+        let response = test_server
+            .client()
+            .get("http://localhost/")
+            .with_header(cookie)
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], "Hello repeat visitor\n".as_bytes());
+    }
+}


### PR DESCRIPTION
This is just using the raw hyper Cookie/SetCookie types, as that's
currently the public interface offered by Gotham. Perhaps in the future
we will offer a more typesafe API, and some better defaults.