### PR TITLE
Allow Router builder to use custom RouteMachers

### DIFF
--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -18,6 +18,34 @@ pub trait RouteMatcher: RefUnwindSafe {
     fn is_match(&self, state: &State) -> Result<(), RouteNonMatch>;
 }
 
+/// Allow various types to represent themselves as a `RouteMatcher`
+pub trait IntoRouteMatcher {
+    /// The concrete RouteMatcher each implementation will provide.
+    type Output: RouteMatcher;
+
+    /// Transform into a `RouteMatcher` of the the associated type identified by `Output`.
+    fn into_route_matcher(self) -> Self::Output;
+}
+
+impl IntoRouteMatcher for Vec<Method> {
+    type Output = MethodOnlyRouteMatcher;
+
+    fn into_route_matcher(self) -> Self::Output {
+        MethodOnlyRouteMatcher::new(self)
+    }
+}
+
+impl<M> IntoRouteMatcher for M
+where
+    M: RouteMatcher + Send + Sync + 'static,
+{
+    type Output = M;
+
+    fn into_route_matcher(self) -> Self::Output {
+        self
+    }
+}
+
 /// A `RouteMatcher` that succeeds when the `Request` has been made with an accepted HTTP request
 /// method.
 ///


### PR DESCRIPTION
This support is necessary for folks who want to dispatch a request on more than matching the method used (or potentially not concern themselves with the method used at all).

A subsequent PR will introduce an `add_matcher` so something like:

```
route.get("/").add_matcher(accept_matcher).to(handler)
```

Will also be feasible.