### PR TITLE
Correctly specify minimum dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
 # dependencies of kcov, used by coverage
 addons:
   apt:
@@ -18,15 +14,28 @@ env:
   - PATH=$HOME/.cargo/bin:$PATH
 before_script:
   - cargo install cargo-travis -f
-  - rustup toolchain install nightly
-  - rustup component add --toolchain nightly rustfmt-preview
-  - cargo +nightly install --force rustfmt-nightly
 script:
-  - echo "Checking Gotham codebase with rustfmt release `cargo +nightly fmt --version`."
-  - cargo +nightly fmt --all -- --write-mode=diff
   - cargo test --all --features ci
 after_success:
   - cargo coveralls
 matrix:
+  include:
+    - rust: stable
+    - rust: beta
+    - rust: nightly
+    # Run rustfmt in its own shard.
+    - rust: stable
+      env:
+        # Give a useful display name in the job list.
+        - SHARD=rustfmt
+        - PATH=$HOME/.cargo/bin/$PATH
+      before_script:
+        - rustup toolchain install nightly
+        - rustup component add --toolchain nightly rustfmt-preview
+        - cargo +nightly install --force rustfmt-nightly
+      script:
+        - echo "Checking Gotham codebase with rustfmt release `cargo +nightly fmt --version`."
+        - cargo +nightly fmt --all -- --write-mode=diff
+
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ matrix:
       before_script:
         - rustup toolchain install nightly
         - rustup component add --toolchain nightly rustfmt-preview
-        - cargo +nightly install --force rustfmt-nightly
       script:
         - echo "Checking Gotham codebase with rustfmt release `cargo +nightly fmt --version`."
         - cargo +nightly fmt --all -- --write-mode=diff

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -12,14 +12,14 @@ categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "framework", "blockchain"]
 
 [dependencies]
-log = "0.4"
-hyper = { version = "0.11", features = [] }
+log = "0.4.1"
+hyper = { version = "0.11.7", features = [] }
 serde = "1"
 serde_derive = "1"
 bincode = "1"
 mime = "0.3"
 futures = "0.1"
-tokio-core = "0.1"
+tokio-core = "0.1.13"
 mio = "0.6"
 borrow-bag = "1"
 url = "1"
@@ -28,7 +28,7 @@ chrono = "0.4"
 base64 = "0.9"
 rand = "0.4"
 linked-hash-map = "0.5"
-num_cpus = "1"
+num_cpus = "1.2"
 crossbeam = "0.3"
 regex = "0.2"
 


### PR DESCRIPTION
There are cases where Gotham (and by extension, Gotham apps) won't build correctly with the currently specified minimum version. Specifying the minimum version which permits Gotham to build correctly ensures that it can't be broken by apps with old `Cargo.lock` files.

Fixes #180

This also brings the Travis CI changes from #173 and #174 into the 0.2-maint branch.