### PR TITLE
Redirect sugar

### DIFF
--- a/gotham/src/http/response/mod.rs
+++ b/gotham/src/http/response/mod.rs
@@ -70,7 +70,6 @@ pub fn create_response(state: &State, status: StatusCode, body: Option<Body>) ->
     res
 }
 
-
 /// Produces a simple empty `Response` with a `Location` header.
 ///
 /// This function is intended as a convenience. For more elaborate redirection
@@ -133,15 +132,18 @@ pub fn create_response(state: &State, status: StatusCode, body: Option<Body>) ->
 /// #     }
 /// # }
 /// ```
-pub fn create_simple_redirect<L: Into<Cow<'static, str>>>(state: &State, permanent: bool, location: L) -> Response {
-    let status = if permanent { StatusCode::PermanentRedirect } else { StatusCode::TemporaryRedirect };
+pub fn create_simple_redirect<L: Into<Cow<'static, str>>>(
+    state: &State,
+    permanent: bool,
+    location: L,
+) -> Response {
+    let status = if permanent {
+        StatusCode::PermanentRedirect
+    } else {
+        StatusCode::TemporaryRedirect
+    };
     let mut res = Response::new().with_status(status);
-    set_headers(
-        &state,
-        &mut res,
-        None,
-        None,
-    );
+    set_headers(&state, &mut res, None, None);
     res.headers_mut().set(Location::new(location));
     res
 }


### PR DESCRIPTION
The type for the location string is made to match the signature of
hyper's Location header. Seems odd to me to reach to `Cow` for this, but
surely the hyper folks know something I don't.

Follow up rev with the old `cargo fmt` on it.