### PR TITLE
Update to rustfmt-nightly 0.4.1 formatting

### DIFF
--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -5,8 +5,8 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Response, StatusCode};
 use hyper::header::{Cookie, Headers, SetCookie};
+use hyper::{Response, StatusCode};
 
 use gotham::http::response::create_response;
 use gotham::state::{FromState, State};

--- a/examples/example_contribution_template/name/src/main.rs
+++ b/examples/example_contribution_template/name/src/main.rs
@@ -25,11 +25,11 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Response, StatusCode};
 use gotham::http::response::create_response;
-use gotham::state::State;
 use gotham::router::Router;
 use gotham::router::builder::*;
+use gotham::state::State;
+use hyper::{Response, StatusCode};
 
 /// Create a `Handler` that ...
 pub fn well_named_function(state: State) -> (State, Response) {

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -20,8 +20,8 @@ use hyper::{Client, Uri};
 use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::http::response::create_response;
 use gotham::router::Router;
-use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::builder::DefineSingleRoute;
+use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::state::{FromState, State};
 
 use tokio_core::reactor::Handle;

--- a/examples/handlers/request_data/src/main.rs
+++ b/examples/handlers/request_data/src/main.rs
@@ -5,14 +5,14 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Body, Headers, HttpVersion, Method, Response, StatusCode, Uri};
 use futures::{future, Future, Stream};
+use hyper::{Body, Headers, HttpVersion, Method, Response, StatusCode, Uri};
 
+use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::http::response::create_response;
-use gotham::state::{FromState, State};
 use gotham::router::Router;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
-use gotham::handler::{HandlerFuture, IntoHandlerError};
+use gotham::state::{FromState, State};
 
 /// Extract the main elements of the request except for the `Body`
 fn print_request_elements(state: &State) {

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -12,16 +12,16 @@ extern crate serde_derive;
 extern crate tokio_core;
 extern crate tokio_timer;
 
-use std::time::Duration;
 use futures::{stream, Future, Stream};
+use std::time::Duration;
 
 use hyper::StatusCode;
 
 use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::http::response::create_response;
 use gotham::router::Router;
-use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::builder::DefineSingleRoute;
+use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::state::{FromState, State};
 
 use tokio_timer::{Timer, TimerError};

--- a/examples/headers/setting/src/main.rs
+++ b/examples/headers/setting/src/main.rs
@@ -6,11 +6,11 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Response, StatusCode};
 use gotham::http::response::create_response;
-use gotham::state::State;
 use gotham::router::Router;
 use gotham::router::builder::*;
+use gotham::state::State;
+use hyper::{Response, StatusCode};
 
 // Define a custom header via the standard Hyper provided macro
 header! { (GothamHeader, "X-Gotham") => [String] }

--- a/examples/into_response/introduction/src/main.rs
+++ b/examples/into_response/introduction/src/main.rs
@@ -11,11 +11,11 @@ extern crate serde_json;
 
 use hyper::{Response, StatusCode};
 
+use gotham::handler::IntoResponse;
 use gotham::http::response::create_response;
 use gotham::router::Router;
 use gotham::router::builder::*;
 use gotham::state::State;
-use gotham::handler::IntoResponse;
 
 /// A Product
 #[derive(Serialize)]

--- a/examples/middleware/introduction/src/main.rs
+++ b/examples/middleware/introduction/src/main.rs
@@ -8,16 +8,16 @@ extern crate hyper;
 extern crate mime;
 
 use futures::{future, Future};
-use hyper::{Response, StatusCode};
-use hyper::header::{Headers, UserAgent};
-use gotham::http::response::create_response;
 use gotham::handler::HandlerFuture;
+use gotham::http::response::create_response;
 use gotham::middleware::Middleware;
-use gotham::state::{FromState, State};
-use gotham::router::Router;
-use gotham::router::builder::*;
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
+use gotham::router::Router;
+use gotham::router::builder::*;
+use gotham::state::{FromState, State};
+use hyper::header::{Headers, UserAgent};
+use hyper::{Response, StatusCode};
 
 /// A simple struct which holds an identifier for the user agent which made the request.
 ///

--- a/examples/routing/introduction/src/main.rs
+++ b/examples/routing/introduction/src/main.rs
@@ -8,9 +8,9 @@ extern crate mime;
 use hyper::{Response, StatusCode};
 
 use gotham::http::response::create_response;
-use gotham::state::State;
 use gotham::router::Router;
 use gotham::router::builder::*;
+use gotham::state::State;
 
 /// Create a `Handler` that is invoked for requests to the path "/"
 pub fn say_hello(state: State) -> (State, Response) {

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -14,12 +14,12 @@ extern crate time;
 use hyper::{Response, StatusCode};
 
 use gotham::http::response::create_response;
+use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
 use gotham::router::Router;
 use gotham::router::builder::*;
 use gotham::state::{FromState, State};
-use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 
 // A custom type for storing data associated with the user's session.
 #[derive(Clone, Deserialize, Serialize, StateData)]

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -8,12 +8,12 @@ extern crate mime;
 use hyper::{Response, StatusCode};
 
 use gotham::http::response::create_response;
+use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
 use gotham::router::Router;
 use gotham::router::builder::*;
 use gotham::state::{FromState, State};
-use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 
 /// Handler function for `GET` requests directed to `/`
 ///

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -4,14 +4,14 @@
 
 use std::error::Error;
 use std::fmt::{self, Display};
-use std::str::FromStr;
 use std::marker::PhantomData;
+use std::str::FromStr;
 
 use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, MapAccess,
                 SeqAccess, VariantAccess, Visitor};
 
-use router::tree::SegmentMapping;
 use http::request::query_string::QueryStringMapping;
+use router::tree::SegmentMapping;
 
 /// Describes the error cases which can result from deserializing a `ExtractorDeserializer` into a
 /// `PathExtractor` provided by the application.
@@ -859,8 +859,8 @@ mod tests {
     }
 
     mod byte_buf {
-        use std::fmt;
         use serde::de::*;
+        use std::fmt;
 
         pub fn deserialize<'de, D>(de: D) -> Result<Vec<u8>, D::Error>
         where
@@ -922,8 +922,8 @@ mod tests {
     }
 
     mod borrowed_bytes {
-        use std::fmt;
         use serde::de::*;
+        use std::fmt;
 
         pub fn deserialize<'de, D>(de: D) -> Result<&'de [u8], D::Error>
         where
@@ -985,8 +985,8 @@ mod tests {
     }
 
     mod borrowed_str {
-        use std::fmt;
         use serde::de::*;
+        use std::fmt;
 
         pub fn deserialize<'de, D>(de: D) -> Result<&'de str, D::Error>
         where

--- a/gotham/src/extractor/mod.rs
+++ b/gotham/src/extractor/mod.rs
@@ -8,9 +8,9 @@
 //! the data and store it within the request `State` before the request is dispatched to the
 //! `Handler`.
 
-mod query_string;
-mod path;
 pub(crate) mod internal;
+mod path;
+mod query_string;
 
-pub use self::query_string::*;
 pub use self::path::*;
+pub use self::query_string::*;

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -1,8 +1,8 @@
-use serde::{Deserialize, Deserializer};
 use hyper::Response;
+use serde::{Deserialize, Deserializer};
 
-use state::{State, StateData};
 use router::response::extender::StaticResponseExtender;
+use state::{State, StateData};
 
 /// Defines a binding for storing the dynamic segments of the `Request` path in `State`. On failure
 /// the `StaticResponseExtender` implementation extends the `Response` to indicate why the
@@ -74,9 +74,7 @@ use router::response::extender::StaticResponseExtender;
 /// #   let body = response.read_utf8_body().unwrap();
 /// #   assert_eq!(body, "id = 1551, slug = ten-reasons-serde-is-amazing");
 /// # }
-pub trait PathExtractor
-    : for<'de> Deserialize<'de> + StaticResponseExtender + StateData {
-}
+pub trait PathExtractor: for<'de> Deserialize<'de> + StaticResponseExtender + StateData {}
 
 impl<T> PathExtractor for T
 where

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -1,8 +1,8 @@
-use serde::{Deserialize, Deserializer};
 use hyper::Response;
+use serde::{Deserialize, Deserializer};
 
-use state::{State, StateData};
 use router::response::extender::StaticResponseExtender;
+use state::{State, StateData};
 
 /// Defines a binding for storing the query parameters from the `Request` URI in `State`. On
 /// failure the `StaticResponseExtender` implementation extends the `Response` to indicate why the
@@ -82,8 +82,9 @@ use router::response::extender::StaticResponseExtender;
 /// #   let body = response.read_utf8_body().unwrap();
 /// #   assert_eq!(body, "x = 15, y = B");
 /// # }
-pub trait QueryStringExtractor
-    : for<'de> Deserialize<'de> + StaticResponseExtender + StateData {
+pub trait QueryStringExtractor:
+    for<'de> Deserialize<'de> + StaticResponseExtender + StateData
+{
 }
 
 impl<T> QueryStringExtractor for T

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -4,8 +4,8 @@ use std::fmt::{self, Debug, Display, Formatter};
 use hyper::{Response, StatusCode};
 
 use handler::IntoResponse;
-use state::{request_id, State};
 use http::response::create_response;
+use state::{request_id, State};
 
 /// Describes an error which occurred during handler execution, and allows the creation of a HTTP
 /// `Response`.

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -6,8 +6,8 @@
 use std::io;
 use std::panic::RefUnwindSafe;
 
-use hyper::Response;
 use futures::{future, Future};
+use hyper::Response;
 
 use state::State;
 

--- a/gotham/src/http/header/mod.rs
+++ b/gotham/src/http/header/mod.rs
@@ -1,20 +1,20 @@
 //! Defines HTTP headers which are set by Gotham but not provided by Hyper.
 
-mod x_request_id;
-mod x_frame_options;
-mod x_xss_protection;
 mod x_content_type_options;
+mod x_frame_options;
+mod x_request_id;
 mod x_runtime_microseconds;
+mod x_xss_protection;
 
-pub use http::header::x_request_id::XRequestId;
-pub use http::header::x_frame_options::XFrameOptions;
-pub use http::header::x_xss_protection::XXssProtection;
 pub use http::header::x_content_type_options::XContentTypeOptions;
+pub use http::header::x_frame_options::XFrameOptions;
+pub use http::header::x_request_id::XRequestId;
 pub use http::header::x_runtime_microseconds::XRuntimeMicroseconds;
+pub use http::header::x_xss_protection::XXssProtection;
 
-use std::str;
 use hyper;
 use hyper::header::Raw;
+use std::str;
 
 /// Reads a single, space delimited, raw string into a Vec.
 fn from_one_rws_delimited_raw_str<T: str::FromStr>(raw: &Raw) -> hyper::error::Result<Vec<T>> {

--- a/gotham/src/http/mod.rs
+++ b/gotham/src/http/mod.rs
@@ -1,8 +1,8 @@
 //! Helpers for HTTP request handling and response generation
 
+pub mod header;
 pub mod request;
 pub mod response;
-pub mod header;
 
 use std;
 use url::percent_encoding::percent_decode;

--- a/gotham/src/http/response/mod.rs
+++ b/gotham/src/http/response/mod.rs
@@ -1,11 +1,11 @@
 //! Helpers for HTTP response generation
 
-use hyper::{Method, Response, StatusCode};
 use hyper::header::{ContentLength, ContentType};
+use hyper::{Method, Response, StatusCode};
 use mime::Mime;
 
-use state::{request_id, FromState, State};
 use http::header::{XContentTypeOptions, XFrameOptions, XRequestId, XXssProtection};
+use state::{request_id, FromState, State};
 
 type Body = (Vec<u8>, Mime);
 

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -41,19 +41,19 @@ extern crate serde_derive;
 
 pub mod extractor;
 pub mod handler;
-pub mod middleware;
-pub mod pipeline;
 pub mod http;
+pub mod middleware;
+mod os;
+pub mod pipeline;
 pub mod router;
 mod service;
 pub mod state;
 pub mod test;
-mod os;
 
 pub use os::current::start_with_num_threads;
 
-use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use handler::NewHandler;
+use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 
 /// Starts a Gotham application, with the default number of threads (equal to the number of CPUs).
 ///

--- a/gotham/src/middleware/session/backend/memory.rs
+++ b/gotham/src/middleware/session/backend/memory.rs
@@ -2,11 +2,11 @@ use std::sync::{Arc, Mutex, PoisonError, Weak};
 use std::time::{Duration, Instant};
 use std::{io, thread};
 
-use linked_hash_map::LinkedHashMap;
 use futures::future;
+use linked_hash_map::LinkedHashMap;
 
-use middleware::session::{SessionError, SessionIdentifier};
 use middleware::session::backend::{Backend, NewBackend, SessionFuture};
+use middleware::session::{SessionError, SessionIdentifier};
 
 /// Defines the in-process memory based session storage.
 ///

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -1,30 +1,30 @@
 //! Defines a session middleware with a pluggable backend.
 
 use std::io;
-use std::sync::{Arc, Mutex, PoisonError};
-use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::panic::RefUnwindSafe;
+use std::sync::{Arc, Mutex, PoisonError};
 
 use base64;
-use rand::Rng;
-use hyper::StatusCode;
-use hyper::server::Response;
-use hyper::header::{Cookie, Headers, SetCookie};
-use futures::{future, Future};
-use serde::{Deserialize, Serialize};
 use bincode;
+use futures::{future, Future};
+use hyper::StatusCode;
+use hyper::header::{Cookie, Headers, SetCookie};
+use hyper::server::Response;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
 
 use super::{Middleware, NewMiddleware};
 use handler::{HandlerError, HandlerFuture, IntoHandlerError};
-use state::{self, FromState, State, StateData};
 use http::response::create_response;
+use state::{self, FromState, State, StateData};
 
 mod backend;
 mod rng;
 
-pub use self::backend::{Backend, NewBackend};
 pub use self::backend::memory::MemoryBackend;
+pub use self::backend::{Backend, NewBackend};
 
 const SECURE_COOKIE_PREFIX: &'static str = "__Secure-";
 const HOST_COOKIE_PREFIX: &'static str = "__Host-";
@@ -1034,11 +1034,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyper::header::Headers;
+    use hyper::{Response, StatusCode};
+    use rand;
     use std::sync::Mutex;
     use std::time::Duration;
-    use rand;
-    use hyper::{Response, StatusCode};
-    use hyper::header::Headers;
 
     #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
     struct TestSession {

--- a/gotham/src/middleware/session/rng.rs
+++ b/gotham/src/middleware/session/rng.rs
@@ -1,6 +1,6 @@
-use rand::{OsRng, Rng, SeedableRng};
-use rand::reseeding::{Reseeder, ReseedingRng};
 use rand::chacha::ChaChaRng;
+use rand::reseeding::{Reseeder, ReseedingRng};
+use rand::{OsRng, Rng, SeedableRng};
 
 pub(super) struct OsRngReseeder {
     os_rng: OsRng,

--- a/gotham/src/os/unix.rs
+++ b/gotham/src/os/unix.rs
@@ -1,12 +1,12 @@
 use std::io;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
-use std::thread;
 use std::sync::Arc;
+use std::thread;
 
+use futures::{Future, Stream};
 use hyper::server::Http;
 use tokio_core;
 use tokio_core::reactor::{Core, Handle};
-use futures::{Future, Stream};
 
 use handler::NewHandler;
 use service::GothamService;

--- a/gotham/src/os/windows.rs
+++ b/gotham/src/os/windows.rs
@@ -1,13 +1,13 @@
 use std::io;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
-use std::thread;
 use std::sync::{Arc, Mutex};
+use std::thread;
 
+use futures::{future, task, Async, Future, Poll, Stream};
 use hyper::server::Http;
 use tokio_core;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::{Core, Handle};
-use futures::{future, task, Async, Future, Poll, Stream};
 
 use handler::NewHandler;
 use service::GothamService;

--- a/gotham/src/pipeline/chain.rs
+++ b/gotham/src/pipeline/chain.rs
@@ -1,9 +1,9 @@
 //! Defines the types for connecting multiple pipeline handles into a "chain" when constructing the
 //! dispatcher for a route.
 
-use std::panic::RefUnwindSafe;
 use borrow_bag::{Handle, Lookup};
 use futures::future;
+use std::panic::RefUnwindSafe;
 
 use handler::{HandlerFuture, IntoHandlerError};
 use middleware::chain::NewMiddlewareChain;

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -7,8 +7,8 @@ pub mod single;
 use std::io;
 
 use handler::HandlerFuture;
-use middleware::chain::{MiddlewareChain, NewMiddlewareChain};
 use middleware::NewMiddleware;
+use middleware::chain::{MiddlewareChain, NewMiddlewareChain};
 use state::{request_id, State};
 
 /// When using middleware, one or more `Middleware` are combined to form a `Pipeline`.
@@ -276,8 +276,8 @@ where
 mod tests {
     use super::*;
 
-    use hyper::{Response, StatusCode};
     use futures::future;
+    use hyper::{Response, StatusCode};
 
     use handler::{Handler, IntoHandlerError};
     use middleware::Middleware;

--- a/gotham/src/pipeline/set.rs
+++ b/gotham/src/pipeline/set.rs
@@ -1,8 +1,8 @@
 //! Defines the types for adding multiple pipelines into a `PipelineSet` and retaining a handle to
 //! each pipeline for constructing a `PipelineHandleChain`.
 
-use std::sync::Arc;
 use borrow_bag::BorrowBag;
+use std::sync::Arc;
 
 /// Represents the set of all `Pipeline` instances that are available for use when building a
 /// `Router`. A `PipelineSet` is "frozen".

--- a/gotham/src/pipeline/single.rs
+++ b/gotham/src/pipeline/single.rs
@@ -3,8 +3,8 @@
 
 use borrow_bag::{Append, Handle};
 
-use pipeline::{NewMiddlewareChain, Pipeline};
 use pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
+use pipeline::{NewMiddlewareChain, Pipeline};
 
 /// A `PipelineSet` which contains only a single pipeline.
 pub type SinglePipelineSet<C> = PipelineSet<<() as Append<Pipeline<C>>>::Output>;
@@ -65,8 +65,8 @@ where
 mod tests {
     use super::*;
 
-    use router::builder::*;
     use pipeline::new_pipeline;
+    use router::builder::*;
 
     #[test]
     fn test_pipeline_construction() {

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -3,12 +3,12 @@ use std::panic::RefUnwindSafe;
 
 use hyper::Method;
 
+use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 use pipeline::chain::PipelineHandleChain;
 use pipeline::set::PipelineSet;
-use router::route::matcher::{IntoRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher};
-use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 use router::builder::{AssociatedRouteBuilder, DelegateRouteBuilder, RouterBuilder, ScopeBuilder,
                       SingleRouteBuilder};
+use router::route::matcher::{IntoRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher};
 use router::tree::node::{NodeBuilder, SegmentType};
 use router::tree::regex::ConstrainedSegmentRegex;
 
@@ -929,16 +929,16 @@ where
 mod tests {
     use std::io;
 
-    use hyper::{Response, StatusCode};
     use futures::future;
+    use hyper::{Response, StatusCode};
 
     use handler::HandlerFuture;
-    use middleware::{Middleware, NewMiddleware};
-    use state::State;
-    use router::builder::*;
-    use pipeline::*;
-    use pipeline::single::*;
     use http::response::create_response;
+    use middleware::{Middleware, NewMiddleware};
+    use pipeline::single::*;
+    use pipeline::*;
+    use router::builder::*;
+    use state::State;
     use test::TestServer;
 
     #[derive(Clone, Copy)]

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -1,29 +1,29 @@
 //! Defines a builder API for constructing a `Router`.
 
 mod draw;
-mod single;
 mod modify;
+mod single;
 
 use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
 use hyper::{Method, StatusCode};
 
+use extractor::{NoopPathExtractor, NoopQueryStringExtractor, PathExtractor, QueryStringExtractor};
 use pipeline::chain::PipelineHandleChain;
 use pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
 use router::Router;
-use router::tree::TreeBuilder;
 use router::response::extender::ResponseExtender;
 use router::response::finalizer::ResponseFinalizerBuilder;
-use router::route::{Delegation, Extractors, RouteImpl};
-use router::route::matcher::{AnyRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher};
 use router::route::dispatch::DispatcherImpl;
-use extractor::{NoopPathExtractor, NoopQueryStringExtractor, PathExtractor, QueryStringExtractor};
+use router::route::matcher::{AnyRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher};
+use router::route::{Delegation, Extractors, RouteImpl};
+use router::tree::TreeBuilder;
 use router::tree::node::NodeBuilder;
 
-pub use self::single::DefineSingleRoute;
 pub use self::draw::DrawRoutes;
 pub use self::modify::{ExtendRouteMatcher, ReplacePathExtractor, ReplaceQueryStringExtractor};
+pub use self::single::DefineSingleRoute;
 
 /// The default type returned when building a single associated route. See
 /// `router::builder::DefineSingleRoute` for an overview of the ways that a route can be specified.
@@ -886,16 +886,16 @@ mod tests {
 
     use std::sync::Arc;
 
-    use hyper::{Method, Request, Response, StatusCode};
-    use hyper::server::Service;
     use futures::{Future, Stream};
+    use hyper::server::Service;
+    use hyper::{Method, Request, Response, StatusCode};
     use tokio_core::reactor::Core;
 
-    use pipeline::new_pipeline;
     use middleware::session::NewSessionMiddleware;
-    use state::{State, StateData};
-    use service::GothamService;
+    use pipeline::new_pipeline;
     use router::response::extender::StaticResponseExtender;
+    use service::GothamService;
+    use state::{State, StateData};
 
     #[derive(Deserialize)]
     struct SalutationParams {

--- a/gotham/src/router/builder/modify.rs
+++ b/gotham/src/router/builder/modify.rs
@@ -1,10 +1,10 @@
 use std::panic::RefUnwindSafe;
 
 use extractor::{PathExtractor, QueryStringExtractor};
-use router::route::matcher::{AndRouteMatcher, RouteMatcher};
 use pipeline::chain::PipelineHandleChain;
 use router::builder::SingleRouteBuilder;
 use router::builder::single::DefineSingleRoute;
+use router::route::matcher::{AndRouteMatcher, RouteMatcher};
 
 /// Describes the operation of replacing a `PathExtractor` on a route. This trait exists to remove
 /// type clutter from the documentation of `SingleRouteBuilder::with_path_extractor`.

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -1,13 +1,13 @@
 use std::panic::RefUnwindSafe;
 
 use extractor::{PathExtractor, QueryStringExtractor};
+use handler::{Handler, NewHandler};
 use pipeline::chain::PipelineHandleChain;
 use router::builder::{ExtendRouteMatcher, ReplacePathExtractor, ReplaceQueryStringExtractor,
                       SingleRouteBuilder};
-use router::route::{Delegation, Extractors, RouteImpl};
-use router::route::matcher::RouteMatcher;
 use router::route::dispatch::DispatcherImpl;
-use handler::{Handler, NewHandler};
+use router::route::matcher::RouteMatcher;
+use router::route::{Delegation, Extractors, RouteImpl};
 
 /// Describes the API for defining a single route, after determining which request paths will be
 /// dispatched here. The API here uses chained function calls to build and add the route into the

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -1,17 +1,17 @@
 //! Defines the Gotham `Router` and supporting types.
 
 pub mod builder;
-pub mod tree;
-pub mod route;
-pub mod response;
 pub mod non_match;
+pub mod response;
+pub mod route;
+pub mod tree;
 
 use std::io;
 use std::sync::Arc;
 
 use futures::{future, Future};
-use hyper::{Response, StatusCode};
 use hyper::header::Allow;
+use hyper::{Response, StatusCode};
 
 use handler::{Handler, HandlerFuture, IntoResponse, NewHandler};
 use http::request::path::RequestPathSegments;
@@ -193,9 +193,9 @@ impl Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
-    use hyper::{Method, Uri};
     use hyper::header::{ContentLength, Headers};
+    use hyper::{Method, Uri};
+    use std::str::FromStr;
 
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
     use handler::HandlerError;

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -1,8 +1,8 @@
 //! Defines functionality for extending a Response.
 
-use std::panic::RefUnwindSafe;
 use hyper::Response;
 use state::{request_id, State};
+use std::panic::RefUnwindSafe;
 
 /// Extend the `Response` based on current `State` and `Response` data.
 pub trait StaticResponseExtender: RefUnwindSafe {

--- a/gotham/src/router/response/finalizer.rs
+++ b/gotham/src/router/response/finalizer.rs
@@ -1,8 +1,8 @@
 //! Defines functionality for finalizing a `Response` after all pipelines, middlewares, handlers
 //! and internal extenders have completed.
 
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use futures::future;
 use hyper::{Response, StatusCode};

--- a/gotham/src/router/route/dispatch.rs
+++ b/gotham/src/router/route/dispatch.rs
@@ -1,7 +1,7 @@
 //! Defines the route `Dispatcher` and supporting types.
 
-use std::panic::RefUnwindSafe;
 use futures::future;
+use std::panic::RefUnwindSafe;
 
 use handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
 use pipeline::chain::PipelineHandleChain;

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -1,19 +1,19 @@
 //! Defines the type `RouteMatcher` and default implementations.
 
-pub mod any;
-pub mod and;
 pub mod accept;
+pub mod and;
+pub mod any;
 
-pub use self::any::AnyRouteMatcher;
-pub use self::and::AndRouteMatcher;
 pub use self::accept::AcceptHeaderRouteMatcher;
+pub use self::and::AndRouteMatcher;
+pub use self::any::AnyRouteMatcher;
 
 use std::panic::RefUnwindSafe;
 
 use hyper::{Method, StatusCode};
 
-use state::{request_id, FromState, State};
 use router::non_match::RouteNonMatch;
+use state::{request_id, FromState, State};
 
 /// Determines if conditions required for the associated `Route` to be invoked by the `Router` have
 /// been met.

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -4,17 +4,17 @@
 //! iterate to find the first matching `Route` (indicated by `Route::is_match`). The request will
 //! be dispatched to the first `Route` which matches.
 
-pub mod matcher;
 pub mod dispatch;
+pub mod matcher;
 
 use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
 use hyper::{Response, Uri};
 
+use extractor::{self, PathExtractor, QueryStringExtractor};
 use handler::HandlerFuture;
 use http::request::query_string;
-use extractor::{self, PathExtractor, QueryStringExtractor};
 use router::non_match::RouteNonMatch;
 use router::route::dispatch::Dispatcher;
 use router::route::matcher::RouteMatcher;
@@ -206,9 +206,9 @@ where
 mod tests {
     use super::*;
 
-    use std::str::FromStr;
     use futures::Async;
     use hyper::{Headers, Method, StatusCode, Uri};
+    use std::str::FromStr;
 
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
     use http::request::path::RequestPathSegments;

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -92,11 +92,11 @@ mod tests {
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
     use http::request::path::RequestPathSegments;
     use http::response::create_response;
-    use router::route::matcher::MethodOnlyRouteMatcher;
+    use pipeline::set::*;
     use router::route::dispatch::DispatcherImpl;
+    use router::route::matcher::MethodOnlyRouteMatcher;
     use router::route::{Delegation, Extractors, RouteImpl};
     use state::State;
-    use pipeline::set::*;
 
     use super::*;
 

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -1,14 +1,14 @@
 //! Defines `Node` and `SegmentType` for `Tree`
 
-use std::cmp::Ordering;
-use std::borrow::Borrow;
 use hyper::StatusCode;
+use std::borrow::Borrow;
+use std::cmp::Ordering;
 
 use http::PercentDecoded;
 use router::non_match::RouteNonMatch;
 use router::route::{Delegation, Route};
-use router::tree::{Path, SegmentMapping, SegmentsProcessed};
 use router::tree::regex::ConstrainedSegmentRegex;
+use router::tree::{Path, SegmentMapping, SegmentsProcessed};
 use state::{request_id, State};
 
 /// Indicates the type of segment which is being represented by this Node.
@@ -376,12 +376,12 @@ mod tests {
 
     use hyper::{Headers, Method, Response};
 
+    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use http::request::path::RequestPathSegments;
     use pipeline::set::*;
     use router::route::dispatch::DispatcherImpl;
     use router::route::matcher::MethodOnlyRouteMatcher;
     use router::route::{Extractors, Route, RouteImpl};
-    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-    use http::request::path::RequestPathSegments;
     use state::{set_request_id, State};
 
     fn handler(state: State) -> (State, Response) {

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -1,21 +1,21 @@
 //! Defines the `GothamService` type which is used to wrap a Gotham application and interface with
 //! Hyper.
 
-use std::thread;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::thread;
 
+use futures::Future;
 use hyper;
 use hyper::server::Service;
 use hyper::{Request, Response};
-use futures::Future;
 use tokio_core::reactor::Handle;
 
 use handler::NewHandler;
-use state::{request_id, set_request_id, State};
-use state::client_addr::put_client_addr;
 use http::request::path::RequestPathSegments;
+use state::client_addr::put_client_addr;
+use state::{request_id, set_request_id, State};
 
 mod timing;
 mod trap;

--- a/gotham/src/service/timing.rs
+++ b/gotham/src/service/timing.rs
@@ -5,8 +5,8 @@ use std::fmt::{self, Display, Formatter};
 use chrono::prelude::*;
 use hyper::Response;
 
-use state::{request_id, State};
 use http::header::XRuntimeMicroseconds;
+use state::{request_id, State};
 
 /// Used by `GothamService` to time requests. The `elapsed` function returns the elapsed time
 /// in a way that can be used for logging and adding the `X-Runtime-Microseconds` header to

--- a/gotham/src/service/trap.rs
+++ b/gotham/src/service/trap.rs
@@ -1,14 +1,14 @@
 //! Defines functionality for processing a request and trapping errors and panics in response
 //! generation.
 
-use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::error::Error;
 use std::any::Any;
+use std::error::Error;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::{io, mem};
 
-use hyper::{self, Response, StatusCode};
 use futures::Async;
 use futures::future::{self, Future, FutureResult};
+use hyper::{self, Response, StatusCode};
 
 use handler::{Handler, HandlerError, IntoResponse, NewHandler};
 use service::timing::Timer;
@@ -192,9 +192,9 @@ mod tests {
 
     use hyper::{Headers, StatusCode};
 
+    use handler::{HandlerFuture, IntoHandlerError};
     use http::response::create_response;
     use state::set_request_id;
-    use handler::{HandlerFuture, IntoHandlerError};
 
     #[test]
     fn success() {

--- a/gotham/src/state/client_addr.rs
+++ b/gotham/src/state/client_addr.rs
@@ -1,7 +1,7 @@
 //! Defines storage for the remote address of the client
 
-use std::net::SocketAddr;
 use state::{FromState, State, StateData};
+use std::net::SocketAddr;
 
 struct ClientAddr {
     addr: SocketAddr,

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -1,17 +1,17 @@
 //! Defines types for passing request state through `Middleware` and `Handler` implementations
 
+pub(crate) mod client_addr;
 mod data;
 mod from_state;
 pub mod request_id;
-pub(crate) mod client_addr;
 
-use std::collections::HashMap;
 use std::any::{Any, TypeId};
+use std::collections::HashMap;
 
+pub use state::client_addr::client_addr;
 pub use state::data::StateData;
 pub use state::from_state::FromState;
 pub use state::request_id::request_id;
-pub use state::client_addr::client_addr;
 
 pub(crate) use state::request_id::set_request_id;
 

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -2,26 +2,26 @@
 //!
 //! See the `TestServer` type for example usage.
 
-use std::{cell, io, net, time};
 use std::cell::RefCell;
 use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream};
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use std::sync::Arc;
+use std::{cell, io, net, time};
 
 use futures::{future, Future, Stream};
-use hyper::{self, Body, Method, Request, Response, Uri};
 use hyper::client::{self, Client};
 use hyper::error::UriError;
 use hyper::header::ContentType;
 use hyper::server::{self, Http};
+use hyper::{self, Body, Method, Request, Response, Uri};
 use mime;
 use mio;
 use tokio_core::reactor::{Core, PollEvented, Timeout};
 
 use handler::NewHandler;
-use service::GothamService;
 use router::Router;
+use service::GothamService;
 
 mod request;
 
@@ -463,8 +463,8 @@ mod tests {
 
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use hyper::{Body, StatusCode, Uri};
     use hyper::header::{ContentLength, ContentType};
+    use hyper::{Body, StatusCode, Uri};
     use mime;
 
     use handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};

--- a/gotham/src/test/request.rs
+++ b/gotham/src/test/request.rs
@@ -1,6 +1,6 @@
-use hyper::{Body, Method, Request, Uri};
 use hyper::error::UriError;
 use hyper::header::Header;
+use hyper::{Body, Method, Request, Uri};
 
 use handler::NewHandler;
 use test::{TestClient, TestRequestError, TestResponse};

--- a/gotham_derive/src/extenders.rs
+++ b/gotham_derive/src/extenders.rs
@@ -1,5 +1,5 @@
-use syn;
 use quote;
+use syn;
 
 pub(crate) fn bad_request_static_response_extender(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;

--- a/gotham_derive/src/extractors.rs
+++ b/gotham_derive/src/extractors.rs
@@ -1,5 +1,5 @@
-use syn;
 use quote;
+use syn;
 
 pub(crate) fn base_path(_ast: &syn::DeriveInput) -> quote::Tokens {
     quote! {

--- a/gotham_derive/src/lib.rs
+++ b/gotham_derive/src/lib.rs
@@ -5,10 +5,10 @@ extern crate proc_macro;
 extern crate quote;
 extern crate syn;
 
-mod extractors;
 mod extenders;
-mod state;
+mod extractors;
 mod new_middleware;
+mod state;
 
 #[proc_macro_derive(PathExtractor)]
 pub fn base_path_extractor(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/gotham_derive/src/new_middleware.rs
+++ b/gotham_derive/src/new_middleware.rs
@@ -1,5 +1,5 @@
-use syn;
 use quote;
+use syn;
 
 pub(crate) fn new_middleware(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;

--- a/gotham_derive/src/state.rs
+++ b/gotham_derive/src/state.rs
@@ -1,5 +1,5 @@
-use syn;
 use quote;
+use syn;
 
 pub(crate) fn state_data(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;

--- a/middleware/template/src/lib.rs
+++ b/middleware/template/src/lib.rs
@@ -19,9 +19,9 @@ use std::io;
 
 use futures::{future, Future};
 
+use gotham::handler::HandlerFuture;
 use gotham::middleware::{Middleware, NewMiddleware};
 use gotham::state::{request_id, State};
-use gotham::handler::HandlerFuture;
 
 // Example of struct that stores owned data in State
 //

--- a/middleware/under_development/diesel/src/lib.rs
+++ b/middleware/under_development/diesel/src/lib.rs
@@ -27,9 +27,9 @@ use std::process;
 
 use futures::{future, Future};
 
+use gotham::handler::HandlerFuture;
 use gotham::middleware::{Middleware, NewMiddleware};
 use gotham::state::{request_id, State};
-use gotham::handler::HandlerFuture;
 
 use diesel::Connection;
 use r2d2::Pool;

--- a/misc/borrow_bag/src/lib.rs
+++ b/misc/borrow_bag/src/lib.rs
@@ -18,8 +18,8 @@ mod handle;
 mod lookup;
 
 pub use append::Append;
-pub use lookup::Lookup;
 pub use handle::Handle;
+pub use lookup::Lookup;
 
 /// `BorrowBag` allows the storage of any value using `add(T)`, and returns a `Handle` which can be
 /// used to borrow the value back later. As the `BorrowBag` is add-only, `Handle` values remain


### PR DESCRIPTION
As 0.4.1 now ships with nightly rust, we need to update to avoid CI failures.

The changes here shouldn't cause any grief with 0.3.8, since it's just reordering `use` / `mod` statements.

Hopefully once Rust 1.25 ships we can settle on a more stable version of `rustfmt`.