### PR TITLE
Stop using skeptic in borrow_bag

### DIFF
--- a/misc/borrow_bag/Cargo.toml
+++ b/misc/borrow_bag/Cargo.toml
@@ -4,15 +4,6 @@ version = "1.0.0"
 authors = ["Shaun Mangelsdorf <s.mangelsdorf@gmail.com>",
            "Bradley Beddoes <bradleybeddoes@gmail.com>"]
 description = "A type-safe, heterogeneous collection with zero-cost add and borrow"
-build = "build.rs"
 license = "MIT/Apache-2.0"
 homepage = "https://gotham.rs"
 repository = "https://github.com/gotham-rs/gotham"
-
-[dependencies]
-
-[build-dependencies]
-skeptic = "0.13"
-
-[dev-dependencies]
-skeptic = "0.13"

--- a/misc/borrow_bag/README.md
+++ b/misc/borrow_bag/README.md
@@ -17,31 +17,6 @@ back later after moving the collection.
 The Gotham project extracted the implementation into this crate for use in other contexts and
 continues to maintain it.
 
-## Example
-
-```rust
-extern crate borrow_bag;
-
-use borrow_bag::BorrowBag;
-
-struct X(u8);
-struct Y(u8);
-
-fn main() {
-    let bag = BorrowBag::new();
-    let (bag, x_handle) = bag.add(X(1));
-    let (bag, y_handle) = bag.add(Y(2));
-
-    let x: &X = bag.borrow(x_handle);
-    assert_eq!(x.0, 1);
-
-    // Type annotations aren't necessary, the `Handle` carries the necessary
-    // type information.
-    let y = bag.borrow(y_handle);
-    assert_eq!(y.0, 2);
-}
-```
-
 ## License
 
 Licensed under your option of:

--- a/misc/borrow_bag/build.rs
+++ b/misc/borrow_bag/build.rs
@@ -1,5 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/misc/borrow_bag/src/lib.rs
+++ b/misc/borrow_bag/src/lib.rs
@@ -28,6 +28,8 @@ pub use handle::Handle;
 /// After being added, the `Handle` can be passed to `borrow(Handle)`, which will return a
 /// reference to the value.
 ///
+/// ## Example
+///
 /// ```rust
 /// use borrow_bag::BorrowBag;
 ///
@@ -56,6 +58,7 @@ pub use handle::Handle;
 /// let x: &X = bag.borrow(x_handle);
 /// assert_eq!(x, &X);
 /// ```
+
 pub struct BorrowBag<V> {
     v: V,
 }

--- a/misc/borrow_bag/tests/skeptic.rs
+++ b/misc/borrow_bag/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This was causing CI issues and wasn't really adding any value.

The test case removed by this commit is actually already served by an inline example that already flows out to documentation so I've not migrated it across.

Closes #208.