### PR TITLE
Add an example of matching Regex patterns in routes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     # path
     "examples/path/introduction",
     "examples/path/globs",
+    "examples/path/regex",
 
     # query_string
     "examples/query_string/introduction",

--- a/examples/path/README.md
+++ b/examples/path/README.md
@@ -10,6 +10,7 @@ We recommend reviewing our request path examples in the order shown below:
 1. [Introduction](introduction) - Introduces having the Gotham web framework Router extract request
                                   path segments, in a type safe way, for use in your application.
 2. [Glob matching](globs) - Shows how to match arbitrarily many path segments.
+2. [Regex matching](regex) - Shows how to match against Regex patterns in path segments.
 
 ## Help
 

--- a/examples/path/regex/Cargo.toml
+++ b/examples/path/regex/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gotham_examples_path_regex"
+description = "Shows how to match against Regex patterns in path segments."
+version = "0.0.0"
+publish = false
+
+[dependencies]
+gotham = { path = "../../../gotham" }
+gotham_derive = { path = "../../../gotham_derive" }
+
+hyper = "0.11"
+mime = "0.3"
+serde = "1"
+serde_derive = "1"

--- a/examples/path/regex/README.md
+++ b/examples/path/regex/README.md
@@ -1,0 +1,74 @@
+# Path extraction using Regex
+
+Shows how to match against Regex patterns in path segments.
+
+## Running
+
+From the `examples/path/regex` directory:
+
+```
+Terminal 1:
+
+   Compiling gotham_examples_path_regex v0.0.0 (file://.../examples/path/regex)
+    Finished dev [unoptimized + debuginfo] target(s) in 2.57 secs
+     Running `.../target/debug/gotham_examples_path_regex`
+Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+
+  $ curl -v http://127.0.0.1:7878/user/123
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+  > GET /user/123 HTTP/1.1
+  > Host: 127.0.0.1:7878
+  > User-Agent: curl/7.54.0
+  > Accept: */*
+  >
+  < HTTP/1.1 200 OK
+  < Content-Length: 16
+  < Content-Type: text/plain
+  < X-Request-ID: a678159d-d1d8-4cf5-92e9-675cb581b347
+  < X-Frame-Options: DENY
+  < X-XSS-Protection: 1; mode=block
+  < X-Content-Type-Options: nosniff
+  < X-Runtime-Microseconds: 322
+  < Date: Thu, 19 Apr 2018 23:51:33 GMT
+  <
+  * Connection #0 to host 127.0.0.1 left intact
+  Hello, User 123!
+
+  $ curl -v http://127.0.0.1:7878/user/abc
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+  > GET /user/abc HTTP/1.1
+  > Host: 127.0.0.1:7878
+  > User-Agent: curl/7.54.0
+  > Accept: */*
+  >
+  < HTTP/1.1 404 Not Found
+  < Content-Length: 0
+  < X-Request-ID: 58c302a8-80d7-4b6a-8d7c-5a01b5c587c1
+  < X-Frame-Options: DENY
+  < X-XSS-Protection: 1; mode=block
+  < X-Content-Type-Options: nosniff
+  < X-Runtime-Microseconds: 264
+  < Date: Thu, 19 Apr 2018 23:52:12 GMT
+  <
+  * Connection #0 to host 127.0.0.1 left intact
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../../CODE_OF_CONDUCT.md)
+* [Contributing](../../../CONTRIBUTING.md)

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -25,11 +25,7 @@ struct PathExtractor {
 pub fn greet_user(state: State) -> (State, Response) {
     let res = {
         let path = PathExtractor::borrow_from(&state);
-
-        let response_string = format!(
-            "Hello, User {}!",
-            &path.id,
-        );
+        let response_string = format!("Hello, User {}!", &path.id);
 
         create_response(
             &state,

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -1,0 +1,102 @@
+//! An example of the Gotham web framework `Router` that shows how to use Regex patterns in path segments.
+
+extern crate gotham;
+#[macro_use]
+extern crate gotham_derive;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+
+use hyper::{Response, StatusCode};
+
+use gotham::http::response::create_response;
+use gotham::router::Router;
+use gotham::router::builder::*;
+use gotham::state::{FromState, State};
+
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct PathExtractor {
+    id: usize,
+}
+
+/// Create a `Handler` that is invoked for requests using a numeric identifier.
+pub fn greet_user(state: State) -> (State, Response) {
+    let res = {
+        let path = PathExtractor::borrow_from(&state);
+
+        let response_string = format!(
+            "Hello, User {}!",
+            &path.id,
+        );
+
+        create_response(
+            &state,
+            StatusCode::Ok,
+            Some((response_string.into_bytes(), mime::TEXT_PLAIN)),
+        )
+    };
+
+    (state, res)
+}
+
+/// Create a `Router`
+///
+/// Provides tree of routes with only a single top level entry that looks like:
+///
+/// /user/:id:[0-9]+                     --> GET
+///
+/// If no match for a request is found a 404 will be returned. Both the HTTP verb and the request
+/// path are considered when determining if the request matches a defined route.
+fn router() -> Router {
+    build_simple_router(|route| {
+        route
+            // The pattern here will enforce the :id segment is numeric.
+            .get("/user/:id:[0-9]+")
+            .with_path_extractor::<PathExtractor>()
+            .to(greet_user);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+
+    // All incoming requests are delegated to the router for further analysis and dispatch
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn receive_hello_router_response() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/user/123")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"Hello, User 123!");
+    }
+
+    #[test]
+    fn receive_missing_route_response() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/user/abc")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NotFound);
+    }
+}

--- a/examples/routing/introduction/README.md
+++ b/examples/routing/introduction/README.md
@@ -4,7 +4,7 @@ An introduction to fundamental `Router` and `Router Builder` concepts to create 
 
 ## Running
 
-From the `examples/introduction` directory:
+From the `examples/routing/introduction` directory:
 
 ```
 Terminal 1:


### PR DESCRIPTION
Based on a conversation in Gitter, there isn't any documentation around Regex patterns that I can see, and it's not particularly obvious. This will add an example to cover at least the basic use cases.