### PR TITLE
Implement run_until() similar to hyper's run_until()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ addons:
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable && "$SHARD" != rustfmt ]]; then
     bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
-    cargo tarpaulin --all --out Xml
+    cargo tarpaulin --all --forward --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
     ## Examples (these crates are not published)
     "examples/hello_world",
+    "examples/hello_world_until",
 
     # routing
     "examples/routing/introduction",

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,7 @@ information on functionality and ordering.
 | Functionality | Description | Count^ |
 | --- | --- | ---:|
 | [Hello World](hello_world) | The famous Hello World example application. | 1 |
+| [Hello World with shutdown](hello_world_until) | Hello World application with graceful shutdown using `run_until()`. | 1 |
 | [Routing](routing) | Dispatching `Requests` to functionality provided by your application. | 4 |
 | [Path](path) | Extracting data from the `Request` path ensuring type safety. | 2 |
 | [Query String](query_string) | Extracting data from the `Request` query string whilst ensuring type safety. | 1 |

--- a/examples/hello_world_until/Cargo.toml
+++ b/examples/hello_world_until/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
-name = "gotham_examples_hello_world"
-description = "A Hello World example application for working with Gotham."
+name = "gotham_examples_hello_world_until"
+description = "A Hello World example application for working with Gotham. With graceful shutdown."
 version = "0.0.0"
 publish = false
 
 [dependencies]
 gotham = { path = "../../gotham" }
 
+futures = "0.1"
 hyper = "0.11"
 mime = "0.3"
+tokio-core = "0.1"
+tokio-signal = "0.1"
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = "0.10"

--- a/examples/hello_world_until/Cargo.toml
+++ b/examples/hello_world_until/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "gotham_examples_hello_world"
+description = "A Hello World example application for working with Gotham."
+version = "0.0.0"
+publish = false
+
+[dependencies]
+gotham = { path = "../../gotham" }
+
+hyper = "0.11"
+mime = "0.3"

--- a/examples/hello_world_until/README.md
+++ b/examples/hello_world_until/README.md
@@ -1,0 +1,53 @@
+# Hello World
+
+A simple introduction to working with Gotham.
+
+## Running
+
+From the `examples/hello_world` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling hello_world (file:///.../examples/hello_world)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../hello_world`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+$ curl -v http://127.0.0.1:7878/
+*  Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1:7878
+> User-Agent: curl/7.54.1
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Length: 12
+< Content-Type: text/plain
+< X-Request-ID: 88ec311c-fc77-4d2e-b302-b1ba38718d96
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 51
+< Date: Fri, 05 Jan 2018 06:25:00 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+Hello World!%
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/hello_world_until/README.md
+++ b/examples/hello_world_until/README.md
@@ -1,10 +1,11 @@
 # Hello World
 
-A simple introduction to working with Gotham.
+Example of how to use `run_until()` to implement graceful shutdown for the web
+service.
 
 ## Running
 
-From the `examples/hello_world` directory:
+From the `examples/hello_world_until` directory:
 
 ```
 Terminal 1:
@@ -13,6 +14,7 @@ $ cargo run
     Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
      Running `../hello_world`
   Listening for requests at http://127.0.0.1:7878
+  Press Ctrl+C to exit
 
 Terminal 2:
 $ curl -v http://127.0.0.1:7878/
@@ -36,6 +38,11 @@ $ curl -v http://127.0.0.1:7878/
 <
 * Connection #0 to host 127.0.0.1 left intact
 Hello World!%
+
+Terminal 1 again:
+<press Ctrl+C>
+  Ctrl+C pressed
+  Shutting down gracefully
 ```
 
 ## License

--- a/examples/hello_world_until/src/main.rs
+++ b/examples/hello_world_until/src/main.rs
@@ -1,10 +1,23 @@
 //! A Hello World example application for working with Gotham.
+//! Supports graceful shutdown on Ctrl+C.
 
+extern crate futures;
 extern crate gotham;
 extern crate hyper;
 extern crate mime;
+extern crate tokio_core;
+extern crate tokio_signal;
 
+#[cfg(all(test, unix))]
+extern crate nix;
+
+use std::thread;
+use std::time::Duration;
+
+use futures::sync::oneshot;
+use futures::{Future, Stream};
 use hyper::{Response, StatusCode};
+use tokio_core::reactor::Core;
 
 use gotham::helpers::http::response::create_response;
 use gotham::state::State;
@@ -27,14 +40,79 @@ pub fn say_hello(state: State) -> (State, Response) {
 /// Start a server and call the `Handler` we've defined above for each `Request` we receive.
 pub fn main() {
     let addr = "127.0.0.1:7878";
-    println!("Listening for requests at http://{}", addr);
-    gotham::start(addr, || Ok(say_hello))
+
+    // Channel used by main thread to shut down Gotham thread.
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    // Channel used by Gotham thread to signal main thread about panic in Gotham thread.
+    let (panic_tx, panic_rx) = oneshot::channel();
+
+    // Gotham thread. gotham::run_until() will block this thread. Also, gotham::run_until() may spawn additional
+    // threads depending on number of available CPU cores. Also see gotham::run_with_num_threads_until().
+    let gotham_thread = thread::spawn(move || {
+        println!("Listening for requests at http://{}", addr);
+        println!("Press Ctrl+C to exit");
+        gotham::run_until(
+            addr,
+            || Ok(say_hello),
+            shutdown_rx.map_err(|error| panic!("Shutdown signal sender was dropped ({}).", error)),
+            Duration::from_secs(5),
+        );
+    });
+
+    // Second thread which is used to catch possible panic in the first thread (gotham_thread).
+    // One also may try to use std::panic::catch_unwind() instead of creating additional thread.
+    let catch_panic_thread = thread::spawn(move || {
+        if let Err(panic) = gotham_thread.join() {
+            if panic_tx.send(()).is_err() {
+                eprintln!("Failed to propagate panic from thread: receiver dropped");
+            };
+            // Propagate panic further to the main thread.
+            Err(panic)
+        } else {
+            Ok(())
+        }
+    });
+
+    let mut core = Core::new().expect("Failed to create reactor::Core");
+    let handle = core.handle();
+
+    // Future to wait for Ctrl+C.
+    let signal = tokio_signal::ctrl_c(&handle)
+        .flatten_stream()
+        .map_err(|error| panic!("Error listening for signal: {}", error))
+        .take(1)
+        .for_each(|()| {
+            println!("Ctrl+C pressed");
+            Ok(())
+        });
+
+    let panic_rx = panic_rx.map_err(|error| panic!("Panic sender was dropped ({}).", error));
+    // Wait for either Ctrl+C or panic in Gotham thread.
+    // `let _ = ...` drops unfinished future.
+    let _ = core.run(signal.select(panic_rx))
+        .map_err(|(error, _)| error)
+        .unwrap();
+
+    // Send shutdown signal to the Gotham thread.
+    shutdown_tx.send(()).unwrap();
+
+    // Wait for the last thread.
+    catch_panic_thread
+        .join()
+        .unwrap()
+        .expect("Late panic in the Gotham thread");
+
+    println!("Shutting down gracefully");
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    #[cfg(unix)]
+    use hyper::Client;
+    #[cfg(unix)]
+    use nix::sys::signal::{kill, Signal};
 
     #[test]
     fn receive_hello_world_response() {
@@ -49,5 +127,44 @@ mod tests {
 
         let body = response.read_body().unwrap();
         assert_eq!(&body[..], b"Hello World!");
+    }
+
+    #[cfg(unix)]
+    fn try_request() -> bool {
+        let mut core = Core::new().unwrap();
+        let client = Client::new(&core.handle());
+
+        let uri = "http://127.0.0.1:7878/";
+        let uri_parsed = uri.parse().unwrap();
+        let work = client.get(uri_parsed).map(|res| {
+            assert_eq!(res.status(), StatusCode::Ok);
+        });
+
+        match core.run(work) {
+            Ok(_) => true,
+
+            Err(error) => {
+                eprintln!("Unable to get \"{}\": {}", uri, error);
+                false
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_self() {
+        let thread_handle = thread::spawn(|| main());
+
+        // Wait until server will be able to answer.
+        let mut max_retries = 25;
+        while (max_retries != 0) && !try_request() {
+            max_retries -= 1;
+            thread::sleep(Duration::from_millis(200));
+        }
+        assert_ne!(max_retries, 0);
+
+        // Send SIGINT to self.
+        kill(nix::unistd::getpid(), Signal::SIGINT).unwrap();
+        thread_handle.join().unwrap();
     }
 }

--- a/examples/hello_world_until/src/main.rs
+++ b/examples/hello_world_until/src/main.rs
@@ -1,0 +1,53 @@
+//! A Hello World example application for working with Gotham.
+
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+
+use hyper::{Response, StatusCode};
+
+use gotham::helpers::http::response::create_response;
+use gotham::state::State;
+
+/// Create a `Handler` which is invoked when responding to a `Request`.
+///
+/// How does a function become a `Handler`?.
+/// We've simply implemented the `Handler` trait, for functions that match the signature used here,
+/// within Gotham itself.
+pub fn say_hello(state: State) -> (State, Response) {
+    let res = create_response(
+        &state,
+        StatusCode::Ok,
+        Some((String::from("Hello World!").into_bytes(), mime::TEXT_PLAIN)),
+    );
+
+    (state, res)
+}
+
+/// Start a server and call the `Handler` we've defined above for each `Request` we receive.
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, || Ok(say_hello))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn receive_hello_world_response() {
+        let test_server = TestServer::new(|| Ok(say_hello)).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::Ok);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(&body[..], b"Hello World!");
+    }
+}

--- a/gotham/src/os/mod.rs
+++ b/gotham/src/os/mod.rs
@@ -7,3 +7,201 @@ pub use self::unix as current;
 pub mod windows;
 #[cfg(windows)]
 pub use self::windows as current;
+
+use std::cell::RefCell;
+use std::fmt::Debug;
+use std::io;
+use std::rc::{Rc, Weak};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use futures::{task, Async, Future, Poll};
+use futures::sync::oneshot;
+use hyper::server::Service;
+use tokio_core::reactor::{Core, Timeout};
+
+pub(crate) struct ConnectionCounter {
+    connections: usize,
+    blocker: Option<task::Task>,
+}
+
+impl ConnectionCounter {
+    fn new() -> Self {
+        Self {
+            connections: 0,
+            blocker: None,
+        }
+    }
+}
+
+pub(crate) struct CountedConnection<S> {
+    counter: Weak<RefCell<ConnectionCounter>>,
+    service: S,
+}
+
+impl<S> CountedConnection<S> {
+    fn new(counter: &Rc<RefCell<ConnectionCounter>>, service: S) -> Self {
+        {
+            let mut counter = counter.borrow_mut();
+            counter.connections += 1;
+            trace!(
+                "Connection created ({} connections total)",
+                counter.connections
+            );
+        }
+        Self {
+            counter: Rc::downgrade(counter),
+            service,
+        }
+    }
+}
+
+impl<S> Drop for CountedConnection<S> {
+    fn drop(&mut self) {
+        let counter = match self.counter.upgrade() {
+            Some(counter) => counter,
+            None => return,
+        };
+        let mut counter = counter.borrow_mut();
+        counter.connections -= 1;
+        trace!(
+            "Connection destroyed ({} connections left)",
+            counter.connections
+        );
+        if counter.connections == 0 {
+            if let Some(task) = counter.blocker.take() {
+                task.notify();
+            }
+        }
+    }
+}
+
+impl<S> Service for CountedConnection<S>
+where
+    S: Service,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        self.service.call(req)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct WaitUntilZeroConnections(Rc<RefCell<ConnectionCounter>>);
+
+impl WaitUntilZeroConnections {
+    pub(crate) fn new() -> Self {
+        WaitUntilZeroConnections(Rc::new(RefCell::new(ConnectionCounter::new())))
+    }
+
+    pub(crate) fn count_connection<S>(&self, service: S) -> CountedConnection<S> {
+        CountedConnection::new(&self.0, service)
+    }
+
+    pub(crate) fn num_connections(&self) -> usize {
+        self.0.borrow().connections
+    }
+}
+
+impl Future for WaitUntilZeroConnections {
+    type Item = ();
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<(), io::Error> {
+        let mut counter = self.0.borrow_mut();
+        if counter.connections == 0 {
+            Ok(().into())
+        } else {
+            counter.blocker = Some(task::current());
+            Ok(Async::NotReady)
+        }
+    }
+}
+
+pub(crate) fn propagate_shutdown_signal<'a, F>(
+    shutdown_signal: F,
+    threads_shutdown_tx: Vec<oneshot::Sender<()>>,
+) -> Box<'a + Future<Item = (), Error = io::Error>>
+where
+    F: 'a + Future<Item = (), Error = ()>,
+{
+    // Accept either value (both Ok or Err) as a valid signal.
+    Box::new(shutdown_signal.then(|_| {
+        threads_shutdown_tx.into_iter().for_each(|shutdown_tx| {
+            shutdown_tx.send(()).unwrap_or_else(|_| {
+                warn!("Receiver of shutdown signal for child thread was dropped")
+            });
+        });
+        Ok(())
+    }))
+}
+
+pub(crate) fn run_until_shutdown<E, F, SE, SF>(
+    core: &mut Core,
+    srv: F,
+    shutdown_signal: SF,
+    expect_msg: &str,
+) where
+    E: Debug,
+    F: Future<Item = (), Error = E>,
+    SE: Debug,
+    SF: Future<Item = (), Error = SE>,
+{
+    let shutdown_signal =
+        shutdown_signal.map_err(|_| panic!("Sender of shutdown signal was dropped"));
+    match core.run(shutdown_signal.select(srv)) {
+        Ok(((), _)) => Ok(()),
+        Err((error, _)) => Err(error),
+    }.expect(expect_msg);
+}
+
+pub(crate) fn maybe_wait_for_remaining_connections(
+    mut core: Core,
+    wait_until_zero_connections: &WaitUntilZeroConnections,
+    shutdown_timeout: Duration,
+) {
+    if shutdown_timeout == Duration::default() {
+        debug!(
+            target: "gotham::start",
+            "Shutting down immediately, without waiting for remaining connections \
+            (connections left: {})",
+            wait_until_zero_connections.num_connections(),
+        );
+    } else {
+        let handle = core.handle();
+
+        // Wait for remaining active connections.
+        debug!(
+            target: "gotham::start",
+            "Shutting down and waiting for remaining active connections \
+            (connections left: {}, timeout: {:?})",
+            wait_until_zero_connections.num_connections(),
+            shutdown_timeout,
+        );
+
+        let timeout = Timeout::new(shutdown_timeout, &handle).expect("unable to set the timeout");
+        match core.run(wait_until_zero_connections.clone().select(timeout)) {
+            Ok(_) => Ok(()),
+            Err((error, _)) => Err(error),
+        }.expect("unable to wait for remaining active connections");
+
+        debug!(
+            target: "gotham::start",
+            "Done waiting for remaining active connections (connections left: {})",
+            wait_until_zero_connections.num_connections(),
+        );
+    }
+}
+
+pub(crate) fn join_threads<T>(threads_handles: Vec<JoinHandle<T>>) {
+    threads_handles.into_iter().for_each(|thread| {
+        thread
+            .join()
+            .map(|_| ())
+            .unwrap_or_else(|error| warn!("Unable to join child thread: {:?}", error))
+    });
+}

--- a/gotham/src/os/unix.rs
+++ b/gotham/src/os/unix.rs
@@ -2,20 +2,36 @@ use std::io;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::thread;
 use std::sync::Arc;
+use std::time::Duration;
+use std::fmt::Debug;
 
 use hyper::server::Http;
 use tokio_core;
 use tokio_core::reactor::{Core, Handle};
-use futures::{Future, Stream};
+use futures::{future, Future, Stream};
+use futures::sync::oneshot;
 
 use handler::NewHandler;
 use service::GothamService;
+use os::{join_threads, maybe_wait_for_remaining_connections, propagate_shutdown_signal,
+         run_until_shutdown, WaitUntilZeroConnections};
 
-/// Starts a Gotham application, with the given number of threads.
-pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
-where
+/// Starts a Gotham application, with the given number of threads and ability to gracefully shut down.
+///
+/// This function blocks current thread until `shutdown_signal` resolved or panic occur.
+///
+/// When `shutdown_timeout` is not equal to `Duration::default()`, function waits for remaining open connections to
+/// finish for specified time.
+pub fn run_with_num_threads_until<NH, A, F>(
+    addr: A,
+    threads: usize,
+    new_handler: NH,
+    shutdown_signal: F,
+    shutdown_timeout: Duration,
+) where
     NH: NewHandler + 'static,
     A: ToSocketAddrs,
+    F: Future<Item = (), Error = ()>,
 {
     let (listener, addr) = ::tcp_listener(addr);
 
@@ -29,27 +45,92 @@ where
         threads,
     );
 
+    let mut threads_shutdown_tx = Vec::new();
+    let mut threads_handles = Vec::new();
     for thread_n in 0..threads - 1 {
         let listener = listener.try_clone().expect("unable to clone TCP listener");
         let protocol = protocol.clone();
         let new_handler = new_handler.clone();
-        thread::Builder::new()
-            .name(format!("gotham-{}", thread_n))
-            .spawn(move || start_core(listener, &addr, &protocol, new_handler))
-            .expect("unable to spawn thread");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        threads_shutdown_tx.push(shutdown_tx);
+        threads_handles.push(
+            thread::Builder::new()
+                .name(format!("gotham-{}", thread_n))
+                .spawn(move || {
+                    start_core(
+                        listener,
+                        &addr,
+                        &protocol,
+                        new_handler,
+                        shutdown_rx,
+                        shutdown_timeout,
+                    )
+                })
+                .expect("unable to spawn thread"),
+        );
     }
 
-    start_core(listener, &addr, &protocol, new_handler);
+    let shutdown_signal = propagate_shutdown_signal(shutdown_signal, threads_shutdown_tx);
+    start_core(
+        listener,
+        &addr,
+        &protocol,
+        new_handler,
+        shutdown_signal,
+        shutdown_timeout,
+    );
+    join_threads(threads_handles);
 }
 
-fn start_core<NH>(listener: TcpListener, addr: &SocketAddr, protocol: &Http, new_handler: Arc<NH>)
+/// Starts a Gotham application, with the given number of threads.
+///
+/// This function never return but may panic because of errors.
+pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
 where
     NH: NewHandler + 'static,
+    A: ToSocketAddrs,
+{
+    run_with_num_threads_until(
+        addr,
+        threads,
+        new_handler,
+        future::empty(),
+        Duration::default(),
+    )
+}
+
+fn start_core<NH, E, F>(
+    listener: TcpListener,
+    addr: &SocketAddr,
+    protocol: &Http,
+    new_handler: Arc<NH>,
+    shutdown_signal: F,
+    shutdown_timeout: Duration,
+) where
+    NH: NewHandler + 'static,
+    E: Debug,
+    F: Future<Item = (), Error = E>,
 {
     let mut core = Core::new().expect("unable to spawn tokio reactor");
     let handle = core.handle();
-    core.run(serve(listener, addr, protocol, new_handler, &handle))
-        .expect("unable to run reactor over listener");
+
+    let wait_until_zero_connections = WaitUntilZeroConnections::new();
+
+    let srv = serve(
+        listener,
+        addr,
+        protocol,
+        new_handler,
+        &handle,
+        &wait_until_zero_connections,
+    );
+    run_until_shutdown(
+        &mut core,
+        srv,
+        shutdown_signal,
+        "unable to run reactor over listener",
+    );
+    maybe_wait_for_remaining_connections(core, &wait_until_zero_connections, shutdown_timeout);
 }
 
 fn serve<'a, NH>(
@@ -58,6 +139,7 @@ fn serve<'a, NH>(
     protocol: &'a Http,
     new_handler: Arc<NH>,
     handle: &'a Handle,
+    wait_until_zero_connections: &'a WaitUntilZeroConnections,
 ) -> Box<Future<Item = (), Error = io::Error> + 'a>
 where
     NH: NewHandler + 'static,
@@ -69,7 +151,12 @@ where
 
     Box::new(listener.incoming().for_each(move |(socket, addr)| {
         let service = gotham_service.connect(addr);
-        let f = protocol.serve_connection(socket, service).then(|_| Ok(()));
+        let f = protocol
+            .serve_connection(
+                socket,
+                wait_until_zero_connections.count_connection(service),
+            )
+            .then(|_| Ok(()));
 
         handle.spawn(f);
         Ok(())

--- a/gotham/src/os/windows.rs
+++ b/gotham/src/os/windows.rs
@@ -2,15 +2,20 @@ use std::io;
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::thread;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use std::fmt::Debug;
 
 use hyper::server::Http;
 use tokio_core;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::{Core, Handle};
 use futures::{future, task, Async, Future, Poll, Stream};
+use futures::sync::oneshot;
 
 use handler::NewHandler;
 use service::GothamService;
+use os::{join_threads, maybe_wait_for_remaining_connections, propagate_shutdown_signal,
+         run_until_shutdown, WaitUntilZeroConnections};
 
 use crossbeam::sync::SegQueue;
 
@@ -40,15 +45,26 @@ impl Stream for SocketQueue {
     }
 }
 
-/// Starts a Gotham application, with the given number of threads.
+/// Starts a Gotham application, with the given number of threads and ability to gracefully shut down.
+///
+/// This function blocks current thread until `shutdown_signal` resolved or panic occur.
+///
+/// When `shutdown_timeout` is not equal to `Duration::default()`, function waits for remaining open connections to
+/// finish for specified time.
 ///
 /// ## Windows
 ///
 /// An additional thread is used on Windows to accept connections.
-pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
-where
+pub fn run_with_num_threads_until<NH, A, F>(
+    addr: A,
+    threads: usize,
+    new_handler: NH,
+    shutdown_signal: F,
+    shutdown_timeout: Duration,
+) where
     NH: NewHandler + 'static,
     A: ToSocketAddrs,
+    F: Future<Item = (), Error = ()>,
 {
     let (listener, addr) = ::tcp_listener(addr);
 
@@ -57,12 +73,19 @@ where
 
     let queue = SocketQueue::new();
 
+    let mut threads_shutdown_tx = Vec::new();
+    let mut threads_handles = Vec::new();
+
     {
         let queue = queue.clone();
-        thread::Builder::new()
-            .name("gotham-listener".into())
-            .spawn(move || start_listen_core(listener, addr, queue))
-            .expect("unable to spawn thread");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        threads_shutdown_tx.push(shutdown_tx);
+        threads_handles.push(
+            thread::Builder::new()
+                .name("gotham-listener".into())
+                .spawn(move || start_listen_core(listener, addr, queue, shutdown_rx))
+                .expect("unable to spawn thread"),
+        );
     }
 
     info!(
@@ -76,20 +99,68 @@ where
         let protocol = protocol.clone();
         let queue = queue.clone();
         let new_handler = new_handler.clone();
-        thread::Builder::new()
-            .name(format!("gotham-{}", thread_n))
-            .spawn(move || start_serve_core(queue, &protocol, new_handler))
-            .expect("unable to spawn thread");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        threads_shutdown_tx.push(shutdown_tx);
+        threads_handles.push(
+            thread::Builder::new()
+                .name(format!("gotham-{}", thread_n))
+                .spawn(move || {
+                    start_serve_core(queue, &protocol, new_handler, shutdown_rx, shutdown_timeout)
+                })
+                .expect("unable to spawn thread"),
+        );
     }
 
-    start_serve_core(queue, &protocol, new_handler);
+    let shutdown_signal = propagate_shutdown_signal(shutdown_signal, threads_shutdown_tx);
+    start_serve_core(
+        queue,
+        &protocol,
+        new_handler,
+        shutdown_signal,
+        shutdown_timeout,
+    );
+    join_threads(threads_handles);
 }
 
-fn start_listen_core(listener: TcpListener, addr: SocketAddr, queue: SocketQueue) {
+/// Starts a Gotham application, with the given number of threads.
+///
+/// This function never return but may panic because of errors.
+///
+/// ## Windows
+///
+/// An additional thread is used on Windows to accept connections.
+pub fn start_with_num_threads<NH, A>(addr: A, threads: usize, new_handler: NH)
+where
+    NH: NewHandler + 'static,
+    A: ToSocketAddrs,
+{
+    run_with_num_threads_until(
+        addr,
+        threads,
+        new_handler,
+        future::empty(),
+        Duration::default(),
+    )
+}
+
+fn start_listen_core<E, F>(
+    listener: TcpListener,
+    addr: SocketAddr,
+    queue: SocketQueue,
+    shutdown_signal: F,
+) where
+    E: Debug,
+    F: Future<Item = (), Error = E>,
+{
     let mut core = Core::new().expect("unable to spawn tokio reactor");
     let handle = core.handle();
-    core.run(listen(listener, addr, queue, &handle))
-        .expect("unable to run reactor over listener");
+    let srv = listen(listener, addr, queue, &handle);
+    run_until_shutdown(
+        &mut core,
+        srv,
+        shutdown_signal,
+        "unable to run reactor over listener",
+    );
 }
 
 fn listen(
@@ -116,14 +187,36 @@ fn listen(
     }))
 }
 
-fn start_serve_core<NH>(queue: SocketQueue, protocol: &Http, new_handler: Arc<NH>)
-where
+fn start_serve_core<NH, E, F>(
+    queue: SocketQueue,
+    protocol: &Http,
+    new_handler: Arc<NH>,
+    shutdown_signal: F,
+    shutdown_timeout: Duration,
+) where
     NH: NewHandler + 'static,
+    E: Debug,
+    F: Future<Item = (), Error = E>,
 {
     let mut core = Core::new().expect("unable to spawn tokio reactor");
     let handle = core.handle();
-    core.run(serve(queue, protocol, new_handler, &handle))
-        .expect("unable to run reactor for work stealing");
+
+    let wait_until_zero_connections = WaitUntilZeroConnections::new();
+
+    let srv = serve(
+        queue,
+        protocol,
+        new_handler,
+        &handle,
+        &wait_until_zero_connections,
+    );
+    run_until_shutdown(
+        &mut core,
+        srv,
+        shutdown_signal,
+        "unable to run reactor for work stealing",
+    );
+    maybe_wait_for_remaining_connections(core, &wait_until_zero_connections, shutdown_timeout);
 }
 
 fn serve<'a, NH>(
@@ -131,6 +224,7 @@ fn serve<'a, NH>(
     protocol: &'a Http,
     new_handler: Arc<NH>,
     handle: &'a Handle,
+    wait_until_zero_connections: &'a WaitUntilZeroConnections,
 ) -> Box<Future<Item = (), Error = ()> + 'a>
 where
     NH: NewHandler + 'static,
@@ -148,7 +242,12 @@ where
         }).and_then(move |_| {
             queue.for_each(move |(socket, addr)| {
                 let service = gotham_service.connect(addr);
-                let f = protocol.serve_connection(socket, service).then(|_| Ok(()));
+                let f = protocol
+                    .serve_connection(
+                        socket,
+                        wait_until_zero_connections.count_connection(service),
+                    )
+                    .then(|_| Ok(()));
 
                 handle.spawn(f);
                 Ok(())


### PR DESCRIPTION
This adds the ability to gracefully shut down the event loop using special signaling future.

Fixes gotham-rs/gotham#220.