### PR TITLE
Update various dependencies to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 sudo: required
 dist: trusty
-cache: cargo
 env:
   - PATH=$HOME/.cargo/bin:$PATH
 script:

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -12,24 +12,24 @@ categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "framework", "blockchain"]
 
 [dependencies]
-log = "0.4.1"
-hyper = { version = "0.11.25", features = [] }
-serde = "1"
-serde_derive = "1"
-bincode = "1"
+log = "0.4"
+hyper = "0.11"
+serde = "1.0"
+serde_derive = "1.0"
+bincode = "1.0"
 mime = "0.3"
 futures = "0.1"
 tokio = "0.1"
-tokio-core = "0.1.13"
+tokio-core = "0.1"
 mio = "0.6"
-borrow-bag = "1"
-url = "1"
+borrow-bag = "1.0"
+url = "1.7"
 uuid = { version = "0.6", features = ["v4"] }
 chrono = "0.4"
 base64 = "0.9"
-rand = "0.4"
+rand = "0.5"
 linked-hash-map = "0.5"
-num_cpus = "1.2"
+num_cpus = "1.8"
 crossbeam = "0.3"
 regex = "1.0"
 

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -12,7 +12,7 @@ use futures::{future, Future};
 use hyper::header::{Cookie, Headers, SetCookie};
 use hyper::server::Response;
 use hyper::StatusCode;
-use rand::Rng;
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
 use super::{Middleware, NewMiddleware};

--- a/gotham/src/middleware/session/rng.rs
+++ b/gotham/src/middleware/session/rng.rs
@@ -1,24 +1,14 @@
-use rand::chacha::ChaChaRng;
-use rand::reseeding::{Reseeder, ReseedingRng};
-use rand::{OsRng, Rng, SeedableRng};
-
-pub(super) struct OsRngReseeder {
-    os_rng: OsRng,
-}
-
-impl Reseeder<ChaChaRng> for OsRngReseeder {
-    fn reseed(&mut self, rng: &mut ChaChaRng) {
-        let bytes: Vec<u32> = self.os_rng.gen_iter::<u32>().take(8).collect();
-        rng.reseed(&bytes[..]);
-    }
-}
+use rand::prng::chacha::ChaChaCore;
+use rand::rngs::adapter::ReseedingRng;
+use rand::rngs::OsRng;
+use rand::FromEntropy;
 
 // A `ChaChaRng` which is periodically reseeded from an `OsRng`. This was originally using an
 // `OsRng`, but sourcing entropy from the kernel was measured to be a performance bottleneck.
 // Conventional wisdom seems to be that a securely seeded ChaCha20 PRNG is secure enough for
 // cryptographic purposes, so it's certainly secure enough for generating unpredictable session
 // identifiers.
-pub(super) type SessionIdentifierRng = ReseedingRng<ChaChaRng, OsRngReseeder>;
+pub(super) type SessionIdentifierRng = ReseedingRng<ChaChaCore, OsRng>;
 
 pub(super) fn session_identifier_rng() -> SessionIdentifierRng {
     let os_rng = match OsRng::new() {
@@ -33,10 +23,8 @@ pub(super) fn session_identifier_rng() -> SessionIdentifierRng {
         }
     };
 
-    let mut rng = ChaChaRng::new_unseeded();
-    let mut reseeder = OsRngReseeder { os_rng };
-    reseeder.reseed(&mut rng);
+    let rng = ChaChaCore::from_entropy();
 
     // Reseed every 32KiB.
-    ReseedingRng::new(rng, 32_768, reseeder)
+    ReseedingRng::new(rng, 32_768, os_rng)
 }


### PR DESCRIPTION
This PR will update all dependencies to latest (except Hyper).

The only thing really notable is that `rand` has some backwards incompatible changes, but migration seems simple enough and all tests still pass. 

Seeing as this is so straightforward, I'll probably merge pending a passing CI build.