### PR TITLE
Remove AsciiExt inclusions in headers

### DIFF
--- a/gotham/src/helpers/http/header/x_content_type_options.rs
+++ b/gotham/src/helpers/http/header/x_content_type_options.rs
@@ -1,9 +1,6 @@
 //! Define the X-Content-Type-Options header.
 
 use std::fmt;
-// TODO: Remove when this import isn't required in stable anymore.
-#[allow(deprecated, unused_imports)]
-use std::ascii::AsciiExt;
 
 use hyper;
 use hyper::header::{parsing, Formatter, Header, Raw};

--- a/gotham/src/helpers/http/header/x_frame_options.rs
+++ b/gotham/src/helpers/http/header/x_frame_options.rs
@@ -2,9 +2,6 @@
 
 use std::fmt;
 use std::str::FromStr;
-// TODO: Remove when this import isn't required in stable anymore.
-#[allow(deprecated, unused_imports)]
-use std::ascii::AsciiExt;
 
 use hyper;
 use hyper::header::{Formatter, Header, Raw};


### PR DESCRIPTION
This fixes #236.

Appears that 1.26 removed the need of this inclusion, so this just removes it.