### PR TITLE
Simplify routing logic and builders

### DIFF
--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -7,11 +7,13 @@ use std::fmt::{self, Display};
 use std::marker::PhantomData;
 use std::str::FromStr;
 
-use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, MapAccess,
-                SeqAccess, VariantAccess, Visitor};
+use serde::de::{
+    self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, MapAccess, SeqAccess,
+    VariantAccess, Visitor,
+};
 
 use helpers::http::request::query_string::QueryStringMapping;
-use router::tree::SegmentMapping;
+use router::tree::segment::SegmentMapping;
 
 /// Describes the error cases which can result from deserializing a `ExtractorDeserializer` into a
 /// `PathExtractor` provided by the application.

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -284,7 +284,7 @@ impl IntoHandlerFuture for Box<HandlerFuture> {
 /// # use gotham::pipeline::set::*;
 /// # use gotham::router::Router;
 /// # use gotham::router::route::{RouteImpl, Extractors, Delegation};
-/// # use gotham::router::tree::TreeBuilder;
+/// # use gotham::router::tree::Tree;
 /// # use gotham::router::route::matcher::MethodOnlyRouteMatcher;
 /// # use gotham::router::route::dispatch::DispatcherImpl;
 /// # use gotham::handler::IntoResponse;
@@ -318,15 +318,14 @@ impl IntoHandlerFuture for Box<HandlerFuture> {
 /// }
 ///
 /// # fn main() {
-/// #   let mut tree_builder = TreeBuilder::new();
+/// #   let mut tree = Tree::new();
 /// #   let pipeline_set = finalize_pipeline_set(new_pipeline_set());
 /// #   let finalizer = ResponseFinalizerBuilder::new().finalize();
 /// #   let matcher = MethodOnlyRouteMatcher::new(vec![Method::Get]);
 /// #   let dispatcher = DispatcherImpl::new(|| Ok(handler), (), pipeline_set);
 /// #   let extractors: Extractors<NoopPathExtractor, NoopQueryStringExtractor> = Extractors::new();
 /// #   let route = RouteImpl::new(matcher, Box::new(dispatcher), extractors, Delegation::Internal);
-///     tree_builder.add_route(Box::new(route));
-///     let tree = tree_builder.finalize();
+///     tree.add_route(Box::new(route));
 ///     Router::new(tree, finalizer);
 /// # }
 /// ```

--- a/gotham/src/helpers/http/request/path.rs
+++ b/gotham/src/helpers/http/request/path.rs
@@ -1,7 +1,5 @@
 //! Defines helper functions for processing the request path
 
-use std::iter::once;
-
 use helpers::http::PercentDecoded;
 
 const EXCLUDED_SEGMENTS: [&str; 1] = [""];
@@ -25,8 +23,8 @@ impl RequestPathSegments {
     /// ["/", "some", "path", "to", "my", "handler"]
     /// ```
     pub(crate) fn new<'r>(path: &'r str) -> Self {
-        let segments = once("/")
-            .chain(path.split('/').filter(|s| !EXCLUDED_SEGMENTS.contains(s)))
+        let segments = path.split('/')
+            .filter(|s| !EXCLUDED_SEGMENTS.contains(s))
             .filter_map(PercentDecoded::new)
             .collect();
 
@@ -62,7 +60,7 @@ mod tests {
 
         assert_eq!(
             rps.segments.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
-            vec!["/", "some", "path", "to", "my", "handler"]
+            vec!["some", "path", "to", "my", "handler"]
         );
     }
 }

--- a/gotham/src/helpers/http/request/path.rs
+++ b/gotham/src/helpers/http/request/path.rs
@@ -22,7 +22,7 @@ impl RequestPathSegments {
     /// ```plain
     /// ["/", "some", "path", "to", "my", "handler"]
     /// ```
-    pub(crate) fn new<'r>(path: &'r str) -> Self {
+    pub(crate) fn new(path: &str) -> Self {
         let segments = path.split('/')
             .filter(|s| !EXCLUDED_SEGMENTS.contains(s))
             .filter_map(PercentDecoded::new)
@@ -44,7 +44,7 @@ impl RequestPathSegments {
     ///
     /// The offset starts at 0 meaning all segments of the initial Request path will be provided
     /// until the offset is updated.
-    pub(crate) fn segments<'a>(&'a self) -> &Vec<PercentDecoded> {
+    pub(crate) fn segments(&self) -> &Vec<PercentDecoded> {
         &self.segments
     }
 }

--- a/gotham/src/router/builder/associated.rs
+++ b/gotham/src/router/builder/associated.rs
@@ -7,9 +7,10 @@ use extractor::{PathExtractor, QueryStringExtractor};
 use pipeline::chain::PipelineHandleChain;
 use pipeline::set::PipelineSet;
 use router::builder::SingleRouteBuilder;
-use router::route::matcher::{AndRouteMatcher, AnyRouteMatcher, MethodOnlyRouteMatcher,
-                             RouteMatcher};
-use router::tree::node::NodeBuilder;
+use router::route::matcher::{
+    AndRouteMatcher, AnyRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher,
+};
+use router::tree::node::Node;
 
 pub type AssociatedRouteBuilderMatcher<M, NM> = AndRouteMatcher<M, NM>;
 pub type AssociatedRouteMatcher<M> = AndRouteMatcher<MethodOnlyRouteMatcher, M>;
@@ -29,7 +30,7 @@ where
     PE: PathExtractor + Send + Sync + 'static,
     QSE: QueryStringExtractor + Send + Sync + 'static,
 {
-    node_builder: &'a mut NodeBuilder,
+    node_builder: &'a mut Node,
     matcher: M,
     pipeline_chain: C,
     pipelines: PipelineSet<P>,
@@ -44,11 +45,7 @@ where
     QSE: QueryStringExtractor + Send + Sync + 'static,
 {
     /// Create an instance of AssociatedRouteBuilder
-    pub fn new(
-        node_builder: &'a mut NodeBuilder,
-        pipeline_chain: C,
-        pipelines: PipelineSet<P>,
-    ) -> Self {
+    pub fn new(node_builder: &'a mut Node, pipeline_chain: C, pipelines: PipelineSet<P>) -> Self {
         AssociatedRouteBuilder {
             node_builder,
             matcher: AnyRouteMatcher::new(),

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -18,7 +18,7 @@ use router::response::finalizer::ResponseFinalizerBuilder;
 use router::route::dispatch::DispatcherImpl;
 use router::route::matcher::{AnyRouteMatcher, RouteMatcher};
 use router::route::{Delegation, Extractors, RouteImpl};
-use router::tree::node::NodeBuilder;
+use router::tree::node::Node;
 use router::tree::TreeBuilder;
 use router::Router;
 
@@ -148,7 +148,7 @@ where
     C: PipelineHandleChain<P> + Copy + Send + Sync + 'static,
     P: Send + Sync + 'static,
 {
-    node_builder: &'a mut NodeBuilder,
+    node_builder: &'a mut Node,
     pipeline_chain: C,
     pipelines: PipelineSet<P>,
     response_finalizer_builder: ResponseFinalizerBuilder,
@@ -235,7 +235,7 @@ where
     C: PipelineHandleChain<P> + Copy + Send + Sync + 'static,
     P: Send + Sync + 'static,
 {
-    node_builder: &'a mut NodeBuilder,
+    node_builder: &'a mut Node,
     pipeline_chain: C,
     pipelines: PipelineSet<P>,
 }
@@ -247,7 +247,7 @@ where
     C: PipelineHandleChain<P> + Copy + Send + Sync + 'static,
     P: Send + Sync + 'static,
 {
-    node_builder: &'a mut NodeBuilder,
+    node_builder: &'a mut Node,
     pipeline_chain: C,
     pipelines: PipelineSet<P>,
 }
@@ -283,7 +283,7 @@ where
     PE: PathExtractor + Send + Sync + 'static,
     QSE: QueryStringExtractor + Send + Sync + 'static,
 {
-    node_builder: &'a mut NodeBuilder,
+    node_builder: &'a mut Node,
     matcher: M,
     pipeline_chain: C,
     pipelines: PipelineSet<P>,

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -19,7 +19,7 @@ use router::route::dispatch::DispatcherImpl;
 use router::route::matcher::{AnyRouteMatcher, RouteMatcher};
 use router::route::{Delegation, Extractors, RouteImpl};
 use router::tree::node::Node;
-use router::tree::TreeBuilder;
+use router::tree::Tree;
 use router::Router;
 
 pub use self::associated::{AssociatedRouteBuilder, AssociatedSingleRouteBuilder};
@@ -80,11 +80,11 @@ where
     P: Send + Sync + 'static,
     F: FnOnce(&mut RouterBuilder<C, P>),
 {
-    let mut tree_builder = TreeBuilder::new();
+    let mut tree = Tree::new();
 
     let response_finalizer = {
         let mut builder = RouterBuilder {
-            node_builder: tree_builder.borrow_root_mut(),
+            node_builder: tree.borrow_root_mut(),
             pipeline_chain,
             pipelines,
             response_finalizer_builder: ResponseFinalizerBuilder::internal_new(),
@@ -95,7 +95,7 @@ where
         builder.response_finalizer_builder.finalize()
     };
 
-    Router::internal_new(tree_builder.finalize(), response_finalizer)
+    Router::internal_new(tree, response_finalizer)
 }
 
 /// Builds a `Router` with **no** middleware using the provided closure. Routes are defined using

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -70,7 +70,7 @@ impl Handler for Router {
 
         let future = match state.try_take::<RequestPathSegments>() {
             Some(rps) => {
-                if let Some((_, leaf, sp, sm)) = self.data.tree.traverse(&rps.segments()) {
+                if let Some((leaf, sp, sm)) = self.data.tree.traverse(&rps.segments()) {
                     match leaf.select_route(&state) {
                         Ok(route) => match route.delegation() {
                             Delegation::External => {

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -131,10 +131,10 @@ impl Router {
     }
 
     fn dispatch<'a>(
-        &'a self,
+        &self,
         mut state: State,
         params: SegmentMapping<'a>,
-        route: &'a Box<Route + Send + Sync>,
+        route: &Box<Route + Send + Sync>,
     ) -> Box<HandlerFuture> {
         match route.extract_request_path(&mut state, params) {
             Ok(()) => {

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -57,8 +57,8 @@ pub trait Route: RefUnwindSafe {
 
     /// Extracts dynamic components of the `Request` path and stores the `PathExtractor` in `State`.
     fn extract_request_path<'a>(
-        &'a self,
-        state: &'a mut State,
+        &self,
+        state: &mut State,
         params: SegmentMapping<'a>,
     ) -> Result<(), ExtractorFailed>;
 
@@ -160,8 +160,8 @@ where
     }
 
     fn extract_request_path<'a>(
-        &'a self,
-        state: &'a mut State,
+        &self,
+        state: &mut State,
         params: SegmentMapping<'a>,
     ) -> Result<(), ExtractorFailed> {
         match extractor::internal::from_segment_mapping::<PE>(params) {

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -18,7 +18,7 @@ use helpers::http::request::query_string;
 use router::non_match::RouteNonMatch;
 use router::route::dispatch::Dispatcher;
 use router::route::matcher::RouteMatcher;
-use router::tree::SegmentMapping;
+use router::tree::segment::SegmentMapping;
 use state::{request_id, State};
 
 #[derive(Clone, Copy, PartialEq)]
@@ -56,10 +56,10 @@ pub trait Route: RefUnwindSafe {
     fn delegation(&self) -> Delegation;
 
     /// Extracts dynamic components of the `Request` path and stores the `PathExtractor` in `State`.
-    fn extract_request_path(
-        &self,
-        state: &mut State,
-        segment_mapping: SegmentMapping,
+    fn extract_request_path<'a>(
+        &'a self,
+        state: &'a mut State,
+        params: SegmentMapping<'a>,
     ) -> Result<(), ExtractorFailed>;
 
     /// Extends the `Response` object when the `PathExtractor` fails.
@@ -159,12 +159,12 @@ where
         self.dispatcher.dispatch(state)
     }
 
-    fn extract_request_path(
-        &self,
-        state: &mut State,
-        segment_mapping: SegmentMapping,
+    fn extract_request_path<'a>(
+        &'a self,
+        state: &'a mut State,
+        params: SegmentMapping<'a>,
     ) -> Result<(), ExtractorFailed> {
-        match extractor::internal::from_segment_mapping::<PE>(segment_mapping) {
+        match extractor::internal::from_segment_mapping::<PE>(params) {
             Ok(val) => Ok(state.put(val)),
             Err(e) => {
                 debug!("[{}] path extractor failed: {}", request_id(&state), e);

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -20,10 +20,10 @@ pub struct Tree {
 
 impl Tree {
     /// Attempt to acquire a path from the `Tree` which matches the `Request` path and is routable.
-    pub(crate) fn traverse<'r>(
-        &'r self,
-        req_path_segments: &'r [PercentDecoded],
-    ) -> Option<(&Node, SegmentMapping<'r>, usize)> {
+    pub(crate) fn traverse<'a>(
+        &'a self,
+        req_path_segments: &'a [PercentDecoded],
+    ) -> Option<(&Node, SegmentMapping<'a>, usize)> {
         trace!(" starting tree traversal");
         self.root.match_node(req_path_segments)
     }

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -19,33 +19,27 @@ pub struct Tree {
 }
 
 impl Tree {
-    /// Attempt to acquire a path from the `Tree` which matches the `Request` path and is routable.
-    pub(crate) fn traverse<'a>(
-        &'a self,
-        req_path_segments: &'a [PercentDecoded],
-    ) -> Option<(&Node, SegmentMapping<'a>, usize)> {
-        trace!(" starting tree traversal");
-        self.root.match_node(req_path_segments)
-    }
-}
-
-/// Constructs a `Tree` which is sorted and immutable.
-pub struct TreeBuilder {
-    root: Node,
-}
-
-impl TreeBuilder {
     /// Creates a new `Tree` and root `Node`.
     pub fn new() -> Self {
         trace!(" creating new tree");
-        TreeBuilder {
+        Tree {
             root: Node::new("/", SegmentType::Static),
         }
     }
 
-    /// Adds a direct child to the root of the `TreeBuilder`.
+    /// Adds a direct child to the root of the `Tree`.
     pub fn add_child(&mut self, child: Node) {
         self.root.add_child(child);
+    }
+
+    /// Adds a `Route` be evaluated by the `Router` when the root of the `Tree` is requested.
+    pub fn add_route(&mut self, route: Box<Route + Send + Sync>) {
+        self.root.add_route(route);
+    }
+
+    /// Borrow the root `NodeBuilder` as mutable.
+    pub fn borrow_root_mut(&mut self) -> &mut Node {
+        &mut self.root
     }
 
     /// Determines if a child `Node` representing the exact segment provided exists at the root of
@@ -56,19 +50,13 @@ impl TreeBuilder {
         self.root.has_child(segment, segment_type)
     }
 
-    /// Borrow the root `NodeBuilder` as mutable.
-    pub fn borrow_root_mut(&mut self) -> &mut Node {
-        &mut self.root
-    }
-
-    /// Adds a `Route` be evaluated by the `Router` when the root of the `Tree` is requested.
-    pub fn add_route(&mut self, route: Box<Route + Send + Sync>) {
-        self.root.add_route(route);
-    }
-
-    /// Finalizes and sorts all internal data and creates a Tree for use with a `Router`.
-    pub fn finalize(self) -> Tree {
-        Tree { root: self.root }
+    /// Attempt to acquire a path from the `Tree` which matches the `Request` path and is routable.
+    pub(crate) fn traverse<'a>(
+        &'a self,
+        req_path_segments: &'a [PercentDecoded],
+    ) -> Option<(&Node, SegmentMapping<'a>, usize)> {
+        trace!(" starting tree traversal");
+        self.root.match_node(req_path_segments)
     }
 }
 
@@ -95,7 +83,7 @@ mod tests {
     #[test]
     fn tree_traversal_tests() {
         let pipeline_set = finalize_pipeline_set(new_pipeline_set());
-        let mut tree_builder: TreeBuilder = TreeBuilder::new();
+        let mut tree = Tree::new();
 
         let mut activate_node_builder = Node::new("activate", SegmentType::Static);
 
@@ -112,9 +100,7 @@ mod tests {
         thing_node_builder.add_route(thing_route);
 
         activate_node_builder.add_child(thing_node_builder);
-        tree_builder.add_child(activate_node_builder);
-
-        let tree = tree_builder.finalize();
+        tree.add_child(activate_node_builder);
 
         let request_path_segments = RequestPathSegments::new("/%61ctiv%61te/workflow5");
         match tree.traverse(request_path_segments.segments().as_slice()) {

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -120,7 +120,7 @@ mod tests {
         match tree.traverse(request_path_segments.segments().as_slice()) {
             Some((node, params, processed)) => {
                 assert!(node.is_routable());
-                assert_eq!(processed, 3);
+                assert_eq!(processed, 2);
                 assert_eq!(
                     params.get("thing").unwrap().last().unwrap().as_ref(),
                     "workflow5"

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -9,10 +9,6 @@ use router::tree::node::{Node, NodeBuilder, SegmentType};
 pub mod node;
 pub mod regex;
 
-/// A depth ordered `Vec` of `Node` instances that create a routable path through the `Tree` for the
-/// matched `Request` path.
-type Path<'a> = Vec<&'a Node>;
-
 /// Number of segments from a `Request` path that are considered to have been processed
 /// by an `Router` traversing its `Tree`.
 type SegmentsProcessed = usize;
@@ -34,7 +30,7 @@ impl Tree {
     pub(crate) fn traverse<'r>(
         &'r self,
         req_path_segments: &'r [&PercentDecoded],
-    ) -> Option<(Path<'r>, &Node, SegmentsProcessed, SegmentMapping<'r>)> {
+    ) -> Option<(&Node, SegmentsProcessed, SegmentMapping<'r>)> {
         trace!(" starting tree traversal");
         self.root.traverse(req_path_segments)
     }
@@ -131,9 +127,8 @@ mod tests {
 
         let request_path_segments = RequestPathSegments::new("/%61ctiv%61te/workflow5");
         match tree.traverse(request_path_segments.segments().as_slice()) {
-            Some((path, leaf, segments_processed, segment_mapping)) => {
-                assert!(path.last().unwrap().is_routable());
-                assert_eq!(path.last().unwrap().segment(), leaf.segment());
+            Some((leaf, segments_processed, segment_mapping)) => {
+                assert!(leaf.is_routable());
                 assert_eq!(segments_processed, 2);
                 assert_eq!(
                     segment_mapping

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -1,56 +1,127 @@
-//! Defines `Node` and `SegmentType` for `Tree`
+//! Defines `Node` for `Tree`.
 
 use hyper::StatusCode;
-use std::borrow::Borrow;
-use std::cmp::Ordering;
 
 use helpers::http::PercentDecoded;
 use router::non_match::RouteNonMatch;
 use router::route::{Delegation, Route};
-use router::tree::regex::ConstrainedSegmentRegex;
-use router::tree::{SegmentMapping, SegmentsProcessed};
+use router::tree::segment::{SegmentMapping, SegmentType};
 use state::{request_id, State};
 
-/// Indicates the type of segment which is being represented by this Node.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum SegmentType {
-    /// Is matched exactly (string equality) to the corresponding segment for incoming request paths.
-    ///
-    /// Unlike all other `NodeSegmentTypes` values determined to be associated with this segment
-    /// within a `Request` path are **not** stored within `State`.
-    Static,
+use std::cmp::Ordering;
+use std::collections::HashMap;
 
-    /// Uses the supplied regex to determine match against incoming request paths.
-    Constrained {
-        /// Regex used to match against a single segment of a request path.
-        regex: ConstrainedSegmentRegex,
-    },
+// TODO: SmallVec for routes
+// TODO: Remove leading "/" on paths
+// TODO: Remove has_child function
+// TODO: Shrink all vectors for memory
 
-    /// Matches any corresponding segment for incoming request paths.
-    Dynamic,
-
-    /// Matches multiple path segments until the end of the request path or until a child
-    /// segment of the above defined types is found.
-    Glob,
-}
-
-/// A recursive member of `Tree` representative of segment(s) in a routable path.
+/// A recursive member of `Tree`, representative of segment(s) in a request path.
 ///
-/// Ultimately provides `0..n` `Route` instances which are further evaluated by the `Router` if
-/// the `Node` is determined to be the routable end point for a single path through the tree.
+/// Each node includes `0..n` `Route` instances, which can be further evaluated by the `Router`
+/// based on a match. Every node may also have `0..n` children to provide the recursive tree
+/// representation.
 pub struct Node {
     segment: String,
     segment_type: SegmentType,
-
     routes: Vec<Box<Route + Send + Sync>>,
-
-    delegating: bool,
     children: Vec<Node>,
 }
 
 impl Node {
-    /// Provides the segment this `Node` represents.
-    pub(super) fn segment(&self) -> &str {
+    /// Creates new `Node` for the given segment and type.
+    pub fn new(segment: &str, segment_type: SegmentType) -> Self {
+        Node {
+            segment_type,
+            segment: segment.to_string(),
+            routes: vec![],
+            children: vec![],
+        }
+    }
+
+    /// Adds a new child `Node` instance to this `Node`.
+    pub fn add_child(&mut self, node: Node) -> &mut Self {
+        self.children.push(node);
+        self.children.sort();
+        self
+    }
+
+    /// Adds a `Route` to this `Node`, to be potentially evaluated by the `Router`.
+    pub fn add_route(&mut self, route: Box<Route + Send + Sync>) -> &mut Self {
+        self.routes.push(route);
+        self
+    }
+
+    /// Borrows a child `Node` based on the defined segment bounds.
+    pub fn borrow_child(&self, segment: &str, segment_type: SegmentType) -> Option<&Node> {
+        self.children
+            .iter()
+            .find(|n| n.segment_type == segment_type && n.segment == segment)
+    }
+
+    /// Borrows a mutable child `Node` based on the defined segment bounds.
+    pub fn borrow_child_mut(
+        &mut self,
+        segment: &str,
+        segment_type: SegmentType,
+    ) -> Option<&mut Node> {
+        self.children
+            .iter_mut()
+            .find(|n| n.segment_type == segment_type && n.segment == segment)
+    }
+
+    /// Determines if a child exists based on the defined segment bounds.
+    pub fn has_child(&self, segment: &str, segment_type: SegmentType) -> bool {
+        self.borrow_child(segment, segment_type).is_some()
+    }
+
+    /// Determines if this `Node` has any valid `Route` values attached.
+    pub fn is_routable(&self) -> bool {
+        !self.routes.is_empty()
+    }
+
+    /// Traverses this `Node` and its children, attempting to a locate a path of `Node` instances
+    /// which match all segments of the provided `Request` path. The final `Node` must have at
+    /// least a single `Route` attached in order to be returned.
+    ///
+    /// Only the first matching path is returned from this method, and the value is wrapped in
+    /// an `Option` as there may be no matching node.
+    ///
+    /// Children are searched in a most to least specific order of segments, based on the node
+    /// `SegmentType` value:
+    ///
+    /// 1. Static
+    /// 2. Constrained
+    /// 3. Dynamic
+    /// 4. Glob
+    ///
+    /// This method is a wrapping of an internal recursive implementation to mask the required
+    /// types needed for the recursion.
+    pub fn match_node<'a>(
+        &'a self,
+        segments: &'a [PercentDecoded],
+    ) -> Option<(&'a Node, SegmentMapping<'a>, usize)> {
+        let mut params = HashMap::new();
+        let mut processed = 0;
+
+        // compatibility with previous routing
+        let segments = match segments.first() {
+            Some(segment) if "/" == segment.as_ref().to_string() => {
+                processed += 1;
+                &segments[1..]
+            }
+            _ => segments,
+        };
+
+        // process and map the results through to the required form
+        self.inner_match_node(segments, &mut params, &mut processed)
+            .map(|node| (node, params, processed))
+    }
+
+    /// Retrieves a reference to the contained segment value.
+    ///
+    /// This is required for lifetime related annotations.
+    pub fn segment<'a>(&'a self) -> &'a str {
         &self.segment
     }
 
@@ -65,276 +136,162 @@ impl Node {
     ///
     /// In the situation where all these avenues are exhausted an InternalServerError will be
     /// provided.
-    pub(in router) fn select_route(
-        &self,
-        state: &State,
-    ) -> Result<&Box<Route + Send + Sync>, RouteNonMatch> {
+    pub fn select_route(&self, state: &State) -> Result<&Box<Route + Send + Sync>, RouteNonMatch> {
         let mut err = Ok(());
 
+        // check for matching routes
         for r in self.routes.iter() {
             match r.is_match(state) {
                 Ok(()) => {
                     trace!("[{}] found matching route", request_id(state));
                     return Ok(r);
                 }
-                Err(e) => match err {
-                    Err(e0) => err = Err(e.union(e0)),
-                    Ok(()) => err = Err(e),
-                },
-            }
-        }
-
-        match err {
-            Err(e) => {
-                trace!(
-                    "[{}] no matching route, using error status code from route",
-                    request_id(state)
-                );
-                Err(e)
-            }
-
-            Ok(()) => {
-                trace!(
-                    "[{}] invalid state, no routes. sending internal server error",
-                    request_id(state)
-                );
-                Err(RouteNonMatch::new(StatusCode::InternalServerError))
-            }
-        }
-    }
-
-    /// True is there is a least one `Route` represented by this `Node`, that is it can act as a
-    /// leaf in a single path through the tree.
-    pub(super) fn is_routable(&self) -> bool {
-        !self.routes.is_empty()
-    }
-
-    /// Recursively traverses children attempting to locate a path of nodes which indicate they
-    /// match all segments of the `Request` path and with the final `Node` of the path
-    /// containing `1..n` `Route` instances for further processing by the `Router`.
-    ///
-    /// Only the first fully matching path is returned.
-    ///
-    /// Children are searched in a most to least specific order of contained segment value based on
-    /// the `SegmentType` value held by the `Node`:
-    ///
-    /// 1. Static
-    /// 2. Constrained
-    /// 3. Dynamic
-    /// 4. Glob
-    pub(super) fn traverse<'r>(
-        &'r self,
-        req_path_segments: &'r [&PercentDecoded],
-    ) -> Option<(&Node, SegmentsProcessed, SegmentMapping<'r>)> {
-        self.inner_traverse(req_path_segments, vec![])
-    }
-
-    #[allow(unknown_lints, type_complexity)]
-    fn inner_traverse<'r>(
-        &'r self,
-        req_path_segments: &'r [&PercentDecoded],
-        mut consumed_segments: Vec<&'r PercentDecoded>,
-    ) -> Option<(&Node, SegmentsProcessed, SegmentMapping<'r>)> {
-        match req_path_segments.split_first() {
-            Some((x, xs)) if self.is_delegating(x) || self.is_leaf(x, xs) => {
-                trace!(" found delegating/leaf node `{}`", self.segment);
-
-                let mut sm = SegmentMapping::new();
-                if self.segment_type != SegmentType::Static {
-                    consumed_segments.push(x);
-                    sm.insert(self.segment(), consumed_segments);
-                };
-
-                Some((self, 0, sm))
-            }
-            Some((x, xs)) if self.is_match(x) => {
-                trace!(" found node `{}`", self.segment);
-
-                let child = self.children
-                    .iter()
-                    .filter_map(|c| c.inner_traverse(xs, vec![]))
-                    .next();
-
-                match child {
-                    Some((leaf, sp, mut sm)) => {
-                        if self.segment_type != SegmentType::Static {
-                            consumed_segments.push(x);
-                            sm.insert(&self.segment, consumed_segments);
-                        }
-
-                        Some((leaf, sp + 1, sm))
-                    }
-
-                    // If we're in a Glob consume segment and continue
-                    // otherwise we've failed to find a suitable way
-                    // forward.
-                    None => {
-                        if self.segment_type != SegmentType::Glob {
-                            return None;
-                        }
-
-                        trace!(" continuing with glob match for segment `{}`", self.segment);
-                        consumed_segments.push(x);
-                        match self.inner_traverse(xs, consumed_segments) {
-                            Some((n, sp, sm)) => Some((n, sp + 1, sm)),
-                            None => None,
-                        }
+                Err(e) => {
+                    // concat errors
+                    err = match err {
+                        Err(e0) => Err(e.union(e0)),
+                        Ok(()) => Err(e),
                     }
                 }
             }
-            _ => None,
         }
-    }
 
-    fn is_delegating(&self, req_path_segment: &PercentDecoded) -> bool {
-        self.delegating && self.is_match(req_path_segment)
-    }
-
-    fn is_match(&self, req_path_segment: &PercentDecoded) -> bool {
-        match self.segment_type {
-            SegmentType::Static => self.segment == req_path_segment.as_ref(),
-            SegmentType::Constrained { ref regex } => regex.is_match(req_path_segment.as_ref()),
-            SegmentType::Dynamic | SegmentType::Glob => true,
-        }
-    }
-
-    fn is_leaf(&self, s: &PercentDecoded, rs: &[&PercentDecoded]) -> bool {
-        rs.is_empty() && self.is_routable() && self.is_match(s)
-    }
-}
-
-/// Constructs a `Node` which is sorted and immutable.
-pub struct NodeBuilder {
-    segment: String,
-    segment_type: SegmentType,
-    routes: Vec<Box<Route + Send + Sync>>,
-
-    delegating: bool,
-    children: Vec<NodeBuilder>,
-}
-
-impl NodeBuilder {
-    /// Creates new `NodeBuilder` for the given segment.
-    pub fn new<S>(segment: S, segment_type: SegmentType) -> Self
-    where
-        S: Borrow<str>,
-    {
-        let segment = segment.borrow().to_owned();
-        NodeBuilder {
-            segment,
-            segment_type,
-            routes: vec![],
-            children: vec![],
-            delegating: false,
-        }
-    }
-
-    /// Access the segment name of the `Node` under construction
-    pub fn segment(&self) -> &str {
-        &self.segment
-    }
-
-    /// Adds a `Route` be evaluated by the `Router` when the built `Node` is acting as a leaf in a
-    /// single path through the `Tree`.
-    pub(in router) fn add_route(&mut self, route: Box<Route + Send + Sync>) {
-        if route.delegation() == Delegation::External {
-            if !self.routes.is_empty() {
-                panic!("Node which is externally delegating must have single Route");
-            }
-
-            if !self.children.is_empty() {
-                panic!("Node which is externally delegating must not have existing children");
-            }
-
-            self.delegating = true;
-        };
-
-        trace!(" adding route to `{}`", self.segment());
-        self.routes.push(route);
-    }
-
-    /// Adds a new child to this sub-tree structure
-    pub(in router) fn add_child(&mut self, child: NodeBuilder) {
-        if self.delegating {
-            panic!("Node which is externally delegating must not have existing children")
+        // unpack required for types
+        if let Err(e) = err {
+            trace!(
+                "[{}] no matching route, using error status code from route",
+                request_id(state)
+            );
+            return Err(e);
         }
 
         trace!(
-            " adding child `{}` to `{}`",
-            child.segment(),
-            self.segment()
+            "[{}] invalid state, no routes. sending internal server error",
+            request_id(state)
         );
-        self.children.push(child);
+
+        // error because we shouldn't arrive here due to match_node/1
+        Err(RouteNonMatch::new(StatusCode::InternalServerError))
     }
 
-    /// Determines if a child representing the exact segment provided exists.
-    pub(in router) fn has_child(&self, segment: &str, segment_type: SegmentType) -> bool {
-        self.borrow_child(segment, segment_type).is_some()
-    }
+    /// Recursive implementation of `match_route` to populate parameters and keep
+    /// track of the number of visited nodes.
+    ///
+    /// There's space for optimizations in here (perhaps), but it seems to perform
+    /// faster than the previous implementation of the router, so all is well for now.
+    fn inner_match_node<'a>(
+        &'a self,
+        segments: &'a [PercentDecoded],
+        params: &mut SegmentMapping<'a>,
+        processed: &mut usize,
+    ) -> Option<&'a Node> {
+        let next_segment = segments.split_first();
 
-    /// Borrow a child that represents the exact segment provided here.
-    pub(in router) fn borrow_child(
-        &self,
-        segment: &str,
-        segment_type: SegmentType,
-    ) -> Option<&NodeBuilder> {
-        self.children
-            .iter()
-            .find(|n| n.segment_type == segment_type && n.segment == segment)
-    }
-
-    /// Mutably borrow a child that represents the exact segment provided here.
-    pub(in router) fn borrow_mut_child(
-        &mut self,
-        segment: &str,
-        segment_type: SegmentType,
-    ) -> Option<&mut NodeBuilder> {
-        self.children
-            .iter_mut()
-            .find(|n| n.segment_type == segment_type && n.segment == segment)
-    }
-
-    /// Finalizes and sorts all internal data, including all children.
-    pub(in router) fn finalize(mut self) -> Node {
-        self.children.sort();
-
-        let mut children = self.children
-            .drain(..)
-            .map(|c| c.finalize())
-            .collect::<Vec<Node>>();
-
-        children.shrink_to_fit();
-        self.routes.shrink_to_fit();
-
-        Node {
-            segment: self.segment,
-            segment_type: self.segment_type,
-            routes: self.routes,
-            delegating: self.delegating,
-            children,
+        // stop if we're done
+        if let None = next_segment {
+            if !self.is_routable() {
+                return None;
+            }
+            return Some(self);
         }
+
+        // check for external delegates, and stop
+        if let Some(route) = self.routes.first() {
+            if route.delegation() == Delegation::External {
+                return Some(self);
+            }
+        }
+
+        let (segment, remaining) = next_segment.unwrap();
+
+        *processed += 1;
+
+        // check all children first
+        for child in &self.children {
+            match child.segment_type {
+                // Globbing matches everything, so we append the segment value
+                // to the parameters against the child segment name.
+                SegmentType::Glob => {
+                    params
+                        .entry(&child.segment)
+                        .or_insert_with(|| vec![])
+                        .push(&segment);
+                }
+
+                // Static matches based on a raw string match, so we simply
+                // compare the value of the current segment with that of the
+                // child node we're currently iterating.
+                SegmentType::Static => {
+                    // check for raw string match
+                    if child.segment != segment.as_ref() {
+                        continue;
+                    }
+                }
+
+                // Constrained matches are based on a contained pattern the
+                // segment value must match. If the segment matches, we need
+                // to make sure to store the value inside the parameters map.
+                SegmentType::Constrained { ref regex } => {
+                    // check for regex matching
+                    if !regex.is_match(&segment.as_ref()) {
+                        continue;
+                    }
+                    // if there's a match, store the value
+                    params.insert(&child.segment, vec![&segment]);
+                }
+
+                // Dynamic matches match every value, so we just attach the
+                // segment value to the parameters list (just like with the
+                // constrained type).
+                SegmentType::Dynamic => {
+                    // if there's a match, store the value
+                    params.insert(&child.segment, vec![&segment]);
+                }
+            };
+
+            // If we hit this point, we've determined that the child node is
+            // the correct node to delegate to, so we continue the recursion
+            // on the child node, passing in the same parameters.
+            return child.inner_match_node(remaining, params, processed);
+        }
+
+        // If there are no children, but this is a globbing node, then we can
+        // continue the nesting by just shifting the path segments and calling
+        // `inner_match_node` on ourself again (to simulate wildcards).
+        if let SegmentType::Glob = self.segment_type {
+            // push the segment to the parameters of the glob
+            if let Some(path) = params.get_mut(self.segment()) {
+                path.push(&segment);
+            }
+            // call again, but after shifting the segments to the next
+            return self.inner_match_node(remaining, params, processed);
+        }
+
+        None
     }
 }
 
-impl Ord for NodeBuilder {
-    fn cmp(&self, other: &NodeBuilder) -> Ordering {
+impl Eq for Node {}
+impl PartialEq for Node {
+    /// Compares two `Node` values for equality based on the segments they represent.
+    fn eq(&self, other: &Node) -> bool {
+        self.segment == other.segment && self.segment_type == other.segment_type
+    }
+}
+
+impl Ord for Node {
+    /// Compares two `Node` values to determine an appropriate `Ordering`.
+    fn cmp(&self, other: &Node) -> Ordering {
         (&self.segment_type, &self.segment).cmp(&(&other.segment_type, &other.segment))
     }
 }
 
-impl PartialOrd for NodeBuilder {
-    fn partial_cmp(&self, other: &NodeBuilder) -> Option<Ordering> {
+impl PartialOrd for Node {
+    /// Compares two `Node` values to determine an appropriate `Ordering`.
+    fn partial_cmp(&self, other: &Node) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-
-impl PartialEq for NodeBuilder {
-    fn eq(&self, other: &NodeBuilder) -> bool {
-        (&self.segment_type, &self.segment) == (&other.segment_type, &other.segment)
-    }
-}
-
-impl Eq for NodeBuilder {}
 
 #[cfg(test)]
 mod tests {
@@ -346,10 +303,12 @@ mod tests {
 
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
     use helpers::http::request::path::RequestPathSegments;
+    use helpers::http::PercentDecoded;
     use pipeline::set::*;
     use router::route::dispatch::DispatcherImpl;
     use router::route::matcher::MethodOnlyRouteMatcher;
-    use router::route::{Extractors, Route, RouteImpl};
+    use router::route::{Delegation, Extractors, Route, RouteImpl};
+    use router::tree::regex::ConstrainedSegmentRegex;
     use state::{set_request_id, State};
 
     fn handler(state: State) -> (State, Response) {
@@ -373,30 +332,13 @@ mod tests {
         Box::new(route)
     }
 
-    fn get_delegated_route<P>(pipeline_set: PipelineSet<P>) -> Box<Route + Send + Sync>
-    where
-        P: Send + Sync + RefUnwindSafe + 'static,
-    {
-        let methods = vec![Method::Get];
-        let matcher = MethodOnlyRouteMatcher::new(methods);
-        let dispatcher = DispatcherImpl::new(|| Ok(handler), (), pipeline_set);
-        let extractors: Extractors<NoopPathExtractor, NoopQueryStringExtractor> = Extractors::new();
-        let route = RouteImpl::new(
-            matcher,
-            Box::new(dispatcher),
-            extractors,
-            Delegation::External,
-        );
-        Box::new(route)
-    }
-
-    fn test_structure() -> NodeBuilder {
-        let mut root: NodeBuilder = NodeBuilder::new("/", SegmentType::Static);
+    fn test_structure() -> Node {
+        let mut root = Node::new("/", SegmentType::Static);
         let pipeline_set = finalize_pipeline_set(new_pipeline_set());
 
         // Two methods, same path, same handler
         // [Get|Head]: /seg1
-        let mut seg1 = NodeBuilder::new("seg1", SegmentType::Static);
+        let mut seg1 = Node::new("seg1", SegmentType::Static);
         let methods = vec![Method::Get, Method::Head];
         let matcher = MethodOnlyRouteMatcher::new(methods);
         let dispatcher = DispatcherImpl::new(|| Ok(handler), (), pipeline_set.clone());
@@ -412,7 +354,7 @@ mod tests {
 
         // Two methods, same path, different handlers
         // Post: /seg2
-        let mut seg2 = NodeBuilder::new("seg2", SegmentType::Static);
+        let mut seg2 = Node::new("seg2", SegmentType::Static);
         let methods = vec![Method::Post];
         let matcher = MethodOnlyRouteMatcher::new(methods);
         let dispatcher = DispatcherImpl::new(|| Ok(handler), (), pipeline_set.clone());
@@ -441,8 +383,8 @@ mod tests {
 
         // Ensure basic traversal
         // Get: /seg3/seg4
-        let mut seg3 = NodeBuilder::new("seg3", SegmentType::Static);
-        let mut seg4 = NodeBuilder::new("seg4", SegmentType::Static);
+        let mut seg3 = Node::new("seg3", SegmentType::Static);
+        let mut seg4 = Node::new("seg4", SegmentType::Static);
         seg4.add_route(get_route(pipeline_set.clone()));
         seg3.add_child(seg4);
         root.add_child(seg3);
@@ -450,8 +392,8 @@ mod tests {
         // Ensure regex matching works and that it's anchored to the segment and does not allow for
         // overzealous matching
         // GET: /resource/<id> where id: [0-9]+
-        let mut seg_resource = NodeBuilder::new("resource", SegmentType::Static);
-        let mut seg_id = NodeBuilder::new(
+        let mut seg_resource = Node::new("resource", SegmentType::Static);
+        let mut seg_id = Node::new(
             "id",
             SegmentType::Constrained {
                 regex: ConstrainedSegmentRegex::new("[0-9]+"),
@@ -467,113 +409,87 @@ mod tests {
         //
         // Get /seg5/:segdyn1/seg7
         // Get /seg5/seg6
-        let mut seg5 = NodeBuilder::new("seg5", SegmentType::Static);
-        let mut seg6 = NodeBuilder::new("seg6", SegmentType::Static);
+        let mut seg5 = Node::new("seg5", SegmentType::Static);
+        let mut seg6 = Node::new("seg6", SegmentType::Static);
         seg6.add_route(get_route(pipeline_set.clone()));
 
-        let mut segdyn1 = NodeBuilder::new(":segdyn1", SegmentType::Dynamic);
-        let mut seg7 = NodeBuilder::new("seg7", SegmentType::Static);
+        let mut segdyn1 = Node::new(":segdyn1", SegmentType::Dynamic);
+        let mut seg7 = Node::new("seg7", SegmentType::Static);
         seg7.add_route(get_route(pipeline_set.clone()));
 
         // Ensure traversal will respect Globs
-        let mut seg8 = NodeBuilder::new("seg8", SegmentType::Glob);
-        let mut seg9 = NodeBuilder::new("seg9", SegmentType::Static);
+        let mut seg8 = Node::new("seg8", SegmentType::Glob);
+        let mut seg9 = Node::new("seg9", SegmentType::Static);
 
-        let mut seg10 = NodeBuilder::new(String::from("seg10"), SegmentType::Glob);
+        let mut seg10 = Node::new("seg10", SegmentType::Glob);
         seg10.add_route(get_route(pipeline_set.clone()));
+
+        segdyn1.add_child(seg7);
+        seg5.add_child(seg6);
+        seg5.add_child(segdyn1);
+        root.add_child(seg5);
 
         seg9.add_child(seg10);
         seg8.add_child(seg9);
         root.add_child(seg8);
 
-        segdyn1.add_child(seg7);
-        seg5.add_child(segdyn1);
-        seg5.add_child(seg6);
-        root.add_child(seg5);
-
         root
     }
 
     #[test]
-    fn manages_children() {
-        let root_node_builder = test_structure();
-
-        assert!(
-            root_node_builder
-                .borrow_child("seg1", SegmentType::Static)
-                .is_some()
-        );
-        assert!(
-            root_node_builder
-                .borrow_child("seg2", SegmentType::Static)
-                .is_some()
-        );
-        assert!(
-            root_node_builder
-                .borrow_child("seg1", SegmentType::Dynamic)
-                .is_none()
-        );
-        assert!(
-            root_node_builder
-                .borrow_child("seg0", SegmentType::Static)
-                .is_none()
-        );
-    }
-
-    #[test]
     fn traverses_children() {
-        let root = test_structure().finalize();
+        let root = test_structure();
 
         // GET /seg3/seg4
         let rs = RequestPathSegments::new("/seg3/seg4");
-        match root.traverse(&rs.segments()) {
-            Some((leaf, sp, _)) => {
-                assert_eq!(leaf.segment(), "seg4");
-                assert_eq!(sp, 2);
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, processed)) => {
+                assert_eq!(node.segment, "seg4");
+                assert_eq!(processed, 3);
             }
             None => panic!("traversal should have succeeded here"),
         }
 
         // GET /seg3/seg4/seg5
         let rs = RequestPathSegments::new("/seg3/seg4/seg5");
-        assert!(root.traverse(&rs.segments()).is_none());
+        assert!(root.match_node(&rs.segments()).is_none());
 
         // GET /seg5/seg6
         let rs = RequestPathSegments::new("/seg5/seg6");
-        match root.traverse(&rs.segments()) {
-            Some((leaf, sp, _)) => {
-                assert_eq!(leaf.segment(), "seg6");
-                assert_eq!(sp, 2);
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, processed)) => {
+                assert_eq!(node.segment, "seg6");
+                assert_eq!(processed, 3);
             }
             None => panic!("traversal should have succeeded here"),
         }
 
         // GET /seg5/someval/seg7
         let rs = RequestPathSegments::new("/seg5/someval/seg7");
-        match root.traverse(&rs.segments()) {
-            Some((leaf, sp, _)) => {
-                assert_eq!(leaf.segment(), "seg7");
-                assert_eq!(sp, 3);
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, processed)) => {
+                assert_eq!(node.segment, "seg7");
+                assert_eq!(processed, 4);
             }
             None => panic!("traversal should have succeeded here"),
         }
 
         // GET /some/path/seg9/another/path
         let rs = RequestPathSegments::new("/some/path/seg9/another/branch");
-        match root.traverse(&rs.segments()) {
-            Some((leaf, sp, _)) => {
-                assert_eq!(leaf.segment(), "seg10");
-                assert_eq!(sp, 5);
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, processed)) => {
+                assert_eq!(node.segment, "seg10");
+                assert_eq!(processed, 6);
             }
             None => panic!("traversal should have succeeded here"),
         }
 
         let rs = RequestPathSegments::new("/resource/5001");
         let expected_segment = "id";
-        match root.traverse(&rs.segments()) {
-            Some((leaf, sp, _)) => {
-                assert_eq!(leaf.segment(), expected_segment);
-                assert_eq!(sp, 2);
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, processed)) => {
+                assert_eq!(node.segment, expected_segment);
+                assert_eq!(processed, 3);
             }
             None => panic!("traversal should have succeeded here"),
         }
@@ -581,7 +497,7 @@ mod tests {
 
     #[test]
     fn non_matching_routes_allow_list_tests() {
-        let root = test_structure().finalize();
+        let root = test_structure();
 
         let mut state = State::new();
         state.put(Method::Options);
@@ -589,8 +505,8 @@ mod tests {
         set_request_id(&mut state);
 
         let rs = RequestPathSegments::new("/seg2");
-        match root.traverse(&rs.segments()) {
-            Some((node, _, _)) => match node.select_route(&state) {
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, _processed)) => match node.select_route(&state) {
                 Err(e) => {
                     let (status, mut allow_list) = e.deconstruct();
                     assert_eq!(status, StatusCode::MethodNotAllowed);
@@ -603,8 +519,8 @@ mod tests {
         }
 
         let rs = RequestPathSegments::new("/resource/100");
-        match root.traverse(&rs.segments()) {
-            Some((node, _, _)) => match node.select_route(&state) {
+        match root.match_node(&rs.segments()) {
+            Some((node, _params, _processed)) => match node.select_route(&state) {
                 Err(e) => {
                     let (status, mut allow_list) = e.deconstruct();
                     assert_eq!(status, StatusCode::MethodNotAllowed);
@@ -618,48 +534,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Node which is externally delegating must not have existing children"
-    )]
-    fn panics_when_delegated_node_adds_children() {
-        let pipeline_set = finalize_pipeline_set(new_pipeline_set());
-        let mut seg1 = NodeBuilder::new("seg1", SegmentType::Static);
-        let seg2 = NodeBuilder::new("seg2", SegmentType::Static);
-
-        seg1.add_route(get_delegated_route(pipeline_set));
-        seg1.add_child(seg2);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Node which is externally delegating must not have existing children"
-    )]
-    fn panics_when_node_with_children_is_provided_delegated_route() {
-        let pipeline_set = finalize_pipeline_set(new_pipeline_set());
-        let mut seg1 = NodeBuilder::new("seg1", SegmentType::Static);
-        let seg2 = NodeBuilder::new("seg2", SegmentType::Static);
-
-        seg1.add_child(seg2);
-        seg1.add_route(get_delegated_route(pipeline_set));
-    }
-
-    #[test]
-    #[should_panic(expected = "Node which is externally delegating must have single Route")]
-    fn panics_when_node_with_a_route_adds_another() {
-        let pipeline_set = finalize_pipeline_set(new_pipeline_set());
-        let mut seg1 = NodeBuilder::new("seg1", SegmentType::Static);
-
-        seg1.add_route(get_delegated_route(pipeline_set.clone()));
-        seg1.add_route(get_delegated_route(pipeline_set));
-    }
-
-    #[test]
     fn node_traversal_tests() {
         let pipeline_set = finalize_pipeline_set(new_pipeline_set());
-        let mut root_node_builder = NodeBuilder::new("/", SegmentType::Static);
-        let mut activate_node_builder = NodeBuilder::new("activate", SegmentType::Static);
+        let mut root_node_builder = Node::new("/", SegmentType::Static);
+        let mut activate_node_builder = Node::new("activate", SegmentType::Static);
 
-        let mut workflow_node = NodeBuilder::new("workflow", SegmentType::Static);
+        let mut workflow_node = Node::new("workflow", SegmentType::Static);
         let route = {
             let methods = vec![Method::Get];
             let matcher = MethodOnlyRouteMatcher::new(methods);
@@ -674,15 +554,15 @@ mod tests {
         activate_node_builder.add_child(workflow_node);
         root_node_builder.add_child(activate_node_builder);
 
-        let root_node = root_node_builder.finalize();
-        match root_node.traverse(&[
-            &PercentDecoded::new("/").unwrap(),
-            &PercentDecoded::new("activate").unwrap(),
-            &PercentDecoded::new("workflow").unwrap(),
+        let root_node = root_node_builder;
+        match root_node.match_node(&[
+            PercentDecoded::new("/").unwrap(),
+            PercentDecoded::new("activate").unwrap(),
+            PercentDecoded::new("workflow").unwrap(),
         ]) {
-            Some((leaf, segments_processed, _segment_mapping)) => {
-                assert!(leaf.is_routable());
-                assert_eq!(segments_processed, 2);
+            Some((node, _params, processed)) => {
+                assert!(node.is_routable());
+                assert_eq!(processed, 3)
             }
             None => panic!(),
         }

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -11,10 +11,6 @@ use state::{request_id, State};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-// TODO: SmallVec for routes
-// TODO: Remove has_child function
-// TODO: Shrink all vectors for memory
-
 /// A recursive member of `Tree`, representative of segment(s) in a request path.
 ///
 /// Each node includes `0..n` `Route` instances, which can be further evaluated by the `Router`
@@ -425,6 +421,16 @@ mod tests {
         root.add_child(seg8);
 
         root
+    }
+
+    #[test]
+    fn manages_children() {
+        let root = test_structure();
+
+        assert!(root.borrow_child("seg1", SegmentType::Static).is_some());
+        assert!(root.borrow_child("seg2", SegmentType::Static).is_some());
+        assert!(root.borrow_child("seg1", SegmentType::Dynamic).is_none());
+        assert!(root.borrow_child("seg0", SegmentType::Static).is_none());
     }
 
     #[test]

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -12,7 +12,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 // TODO: SmallVec for routes
-// TODO: Remove leading "/" on paths
 // TODO: Remove has_child function
 // TODO: Shrink all vectors for memory
 
@@ -101,17 +100,9 @@ impl Node {
         &'a self,
         segments: &'a [PercentDecoded],
     ) -> Option<(&'a Node, SegmentMapping<'a>, usize)> {
+        // accumulators for recursion
         let mut params = HashMap::new();
         let mut processed = 0;
-
-        // compatibility with previous routing
-        let segments = match segments.first() {
-            Some(segment) if "/" == segment.as_ref().to_string() => {
-                processed += 1;
-                &segments[1..]
-            }
-            _ => segments,
-        };
 
         // process and map the results through to the required form
         self.inner_match_node(segments, &mut params, &mut processed)
@@ -445,7 +436,7 @@ mod tests {
         match root.match_node(&rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg4");
-                assert_eq!(processed, 3);
+                assert_eq!(processed, 2);
             }
             None => panic!("traversal should have succeeded here"),
         }
@@ -459,7 +450,7 @@ mod tests {
         match root.match_node(&rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg6");
-                assert_eq!(processed, 3);
+                assert_eq!(processed, 2);
             }
             None => panic!("traversal should have succeeded here"),
         }
@@ -469,7 +460,7 @@ mod tests {
         match root.match_node(&rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg7");
-                assert_eq!(processed, 4);
+                assert_eq!(processed, 3);
             }
             None => panic!("traversal should have succeeded here"),
         }
@@ -479,7 +470,7 @@ mod tests {
         match root.match_node(&rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg10");
-                assert_eq!(processed, 6);
+                assert_eq!(processed, 5);
             }
             None => panic!("traversal should have succeeded here"),
         }
@@ -489,7 +480,7 @@ mod tests {
         match root.match_node(&rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, expected_segment);
-                assert_eq!(processed, 3);
+                assert_eq!(processed, 2);
             }
             None => panic!("traversal should have succeeded here"),
         }
@@ -556,13 +547,12 @@ mod tests {
 
         let root_node = root_node_builder;
         match root_node.match_node(&[
-            PercentDecoded::new("/").unwrap(),
             PercentDecoded::new("activate").unwrap(),
             PercentDecoded::new("workflow").unwrap(),
         ]) {
             Some((node, _params, processed)) => {
                 assert!(node.is_routable());
-                assert_eq!(processed, 3)
+                assert_eq!(processed, 2)
             }
             None => panic!(),
         }

--- a/gotham/src/router/tree/regex.rs
+++ b/gotham/src/router/tree/regex.rs
@@ -22,7 +22,7 @@ impl ConstrainedSegmentRegex {
     /// intended.
     pub fn new(regex: &str) -> Self {
         ConstrainedSegmentRegex {
-            regex: AssertUnwindSafe(Regex::new(&format!("^{pattern}$", pattern = regex)).unwrap()),
+            regex: AssertUnwindSafe(Regex::new(&format!("^{}$", regex)).unwrap()),
         }
     }
 

--- a/gotham/src/router/tree/segment.rs
+++ b/gotham/src/router/tree/segment.rs
@@ -1,0 +1,31 @@
+//! Defines `SegmentType` for `Tree`.
+use std::collections::HashMap;
+
+use helpers::http::PercentDecoded;
+use router::tree::regex::ConstrainedSegmentRegex;
+
+/// Mapping of segment names into the collection of values for that segment.
+pub type SegmentMapping<'r> = HashMap<&'r str, Vec<&'r PercentDecoded>>;
+
+/// Indicates the type of segment which is being represented by this Node.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum SegmentType {
+    /// Is matched exactly (string equality) to the segment for incoming request paths.
+    ///
+    /// Unlike all other `SegmentTypes`, values determined to be associated with this segment
+    /// within a `Request` path are **not** stored within `State`.
+    Static,
+
+    /// Uses the supplied regex to determine match against incoming request paths.
+    Constrained {
+        /// Regex used to match against a single segment of a request path.
+        regex: ConstrainedSegmentRegex,
+    },
+
+    /// Matches any corresponding segment for incoming request paths.
+    Dynamic,
+
+    /// Matches multiple path segments until the end of the request path or until a child
+    /// segment of the above defined types is found.
+    Glob,
+}


### PR DESCRIPTION
This PR will refactor the main routing logic to make it a little easier to understand. How it works is almost identical at a higher level, but there has been a large reduction in the number of allocations required - mainly due to how path segments are moved. 

There are other improvements we should make in time; perhaps `SmallVec` for the parameters on a route (for example). But this is a start!