### PR TITLE
Add StateMiddleware to simplify shared state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
     ## Examples (these crates are not published)
     "examples/hello_world",
+    "examples/shared_state",
 
     # routing
     "examples/routing/introduction",

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,7 @@ information on functionality and ordering.
 | [Headers](headers) | Working with HTTP Headers. | 1 |
 | [Handlers](handlers) | Developing application logic that responds to web requests. | 4 |
 | [Middleware](middleware) | Developing custom middleware for your application. | 1 |
+| [Shared State](stared_state) | Sharing state across your application. | 1 |
 | [Into Response](into_response) | Implementing the Gotham web framework's `IntoResponse` trait. | 1 |
 
 ^ Gotham web framework examples are under active development.

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -9,9 +9,9 @@ From the `examples/hello_world` directory:
 ```
 Terminal 1:
 $ cargo run
-   Compiling hello_world (file:///.../examples/hello_world)
+   Compiling gotham_examples_hello_world (file:///.../examples/hello_world)
     Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
-     Running `../hello_world`
+     Running `../gotham_examples_hello_world`
   Listening for requests at http://127.0.0.1:7878
 
 Terminal 2:

--- a/examples/shared_state/Cargo.toml
+++ b/examples/shared_state/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gotham_examples_shared_state"
+description = "An introduction to shared state across Gotham handlers"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+gotham = { path = "../../gotham" }
+gotham_derive = { path = "../../gotham_derive" }
+
+hyper = "0.11"
+mime = "0.3"

--- a/examples/shared_state/README.md
+++ b/examples/shared_state/README.md
@@ -1,0 +1,75 @@
+# Shared State
+
+A simple introduction to shared state across Gotham handlers.
+
+## Running
+
+From the `examples/shared_state` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling gotham_examples_shared_state (file:///.../examples/shared_state)
+    Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+     Running `../gotham_examples_shared_state`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+$ curl -v http://127.0.0.1:7878/
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1:7878
+> User-Agent: curl/7.54.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Type: text/plain
+< Content-Length: 22
+< X-Request-ID: b3fd0952-31f9-4872-8bbd-7fd6c07a0589
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 165
+< Date: Sun, 15 Jul 2018 00:39:41 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+Hello from request #1!
+
+$ curl -v http://127.0.0.1:7878/
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1:7878
+> User-Agent: curl/7.54.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Type: text/plain
+< Content-Length: 22
+< X-Request-ID: 546d24e4-d7ad-4d69-be68-4e55cc4b9b96
+< X-Frame-Options: DENY
+< X-XSS-Protection: 1; mode=block
+< X-Content-Type-Options: nosniff
+< X-Runtime-Microseconds: 118
+< Date: Sun, 15 Jul 2018 00:39:44 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+Hello from request #2!
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -1,0 +1,133 @@
+//! An introduction to sharing state across handlers in a safe way.
+//!
+//! This example demonstrates a basic request counter which can be
+//! used across server threads, and be used to track the number of
+//! requests sent to the backend.
+extern crate gotham;
+#[macro_use]
+extern crate gotham_derive;
+extern crate hyper;
+extern crate mime;
+
+use hyper::{Response, StatusCode};
+
+use gotham::helpers::http::response::create_response;
+use gotham::middleware::state::StateMiddleware;
+use gotham::pipeline::single::single_pipeline;
+use gotham::pipeline::single_middleware;
+use gotham::router::builder::*;
+use gotham::router::Router;
+use gotham::state::{FromState, State};
+
+use std::sync::{Arc, Mutex};
+
+/// Request counting struct, used to track the number of requests made.
+///
+/// Due to being shared across many worker threads, the internal counter
+/// is bound inside an `Arc` (to enable sharing) and a `Mutex` (to enable
+/// modification from multiple threads safely).
+///
+/// This struct must implement `Clone` and `StateData` to be applicable
+/// for use with the `StateMiddleware`, and be shared via `Middleware`.
+#[derive(Clone, StateData)]
+struct RequestCounter {
+    inner: Arc<Mutex<usize>>,
+}
+
+/// Counter implementation.
+impl RequestCounter {
+    /// Creates a new request counter, setting the base state to `0`.
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    /// Increments the internal counter state by `1`, and returns the
+    /// new request counter as an atomic operation.
+    fn incr(&self) -> usize {
+        let mut w = self.inner.lock().unwrap();
+        *w += 1;
+        *w
+    }
+}
+
+/// Basic `Handler` to say hello and return the current request count.
+///
+/// The request counter is shared via the state, so we can safely
+/// borrow one from the provided state. As the counter uses locks
+/// internally, we don't have to borrow a mutable reference either!
+fn say_hello(state: State) -> (State, Response) {
+    let message = {
+        // borrow a reference of the counter from the state
+        let counter = RequestCounter::borrow_from(&state);
+
+        // create our message, incrementing our request counter
+        format!("Hello from request #{}!\n", counter.incr())
+    };
+
+    // create the response
+    let res = create_response(
+        &state,
+        StatusCode::Ok,
+        Some((message.into_bytes(), mime::TEXT_PLAIN)),
+    );
+
+    // done!
+    (state, res)
+}
+
+/// Constructs a simple router on `/` to say hello, along with
+/// the current request count.
+fn router() -> Router {
+    // create the counter to share across handlers
+    let counter = RequestCounter::new();
+
+    // create our state middleware to share the counter
+    let middleware = StateMiddleware::with(counter);
+
+    // create a middleware pipeline from our middleware
+    let pipeline = single_middleware(middleware);
+
+    // construct a basic chain from our pipeline
+    let (chain, pipelines) = single_pipeline(pipeline);
+
+    // build a router with the chain & pipeline
+    build_router(chain, pipelines, |route| {
+        route.get("/").to(say_hello);
+    })
+}
+
+/// Start a server and call the `Handler` we've defined above
+/// for each `Request` we receive.
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn receive_incrementing_hello_response() {
+        let test_server = TestServer::new(router()).unwrap();
+
+        for i in 1..6 {
+            let response = test_server
+                .client()
+                .get("http://localhost")
+                .perform()
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::Ok);
+
+            let body = response.read_body().unwrap();
+            let expc = format!("Hello from request #{}!\n", i);
+
+            assert_eq!(&body[..], expc.as_bytes());
+        }
+    }
+}

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -84,7 +84,7 @@ fn router() -> Router {
     let counter = RequestCounter::new();
 
     // create our state middleware to share the counter
-    let middleware = StateMiddleware::with(counter);
+    let middleware = StateMiddleware::new(counter);
 
     // create a middleware pipeline from our middleware
     let pipeline = single_middleware(middleware);

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -9,6 +9,7 @@ use state::State;
 
 pub mod chain;
 pub mod session;
+pub mod state;
 
 /// `Middleware` has the opportunity to provide additional behaviour to the `Request` / `Response`
 /// interaction. For example:

--- a/gotham/src/middleware/state/mod.rs
+++ b/gotham/src/middleware/state/mod.rs
@@ -1,0 +1,68 @@
+//! State driven middleware to enable attachment of values to request state.
+//!
+//! This module provides generics to enable attaching (appropriate) values to
+//! the state of a request, through the use of `Middleware`. Middleware can
+//! be created via `StateMiddleware::with`, with the provided value being the
+//! value to attach to the request state.
+use handler::HandlerFuture;
+use middleware::{Middleware, NewMiddleware};
+use state::{State, StateData};
+use std::io;
+use std::panic::RefUnwindSafe;
+
+/// Middleware binding for generic types to enable easy shared state.
+///
+/// This acts as nothing more than a `Middleware` instance which will
+/// attach a generic type to a request `State`, however it removes a
+/// barrier for users to Gotham who might not know the internals.
+///
+/// The generic types inside this struct can (and will) be cloned
+/// often, so wrap your expensive types in reference counts as needed.
+#[derive(Clone)]
+pub struct StateMiddleware<T>
+where
+    T: Clone + RefUnwindSafe + StateData + Sync,
+{
+    t: T,
+}
+
+/// Main implementation.
+impl<T> StateMiddleware<T>
+where
+    T: Clone + RefUnwindSafe + StateData + Sync,
+{
+    /// Creates a new middleware binding, taking ownership of the state data.
+    pub fn with(t: T) -> Self {
+        Self { t }
+    }
+}
+
+/// `Middleware` trait implementation.
+impl<T> Middleware for StateMiddleware<T>
+where
+    T: Clone + RefUnwindSafe + StateData + Sync,
+{
+    /// Attaches the inner generic value to the request state.
+    ///
+    /// This will enable the `Handler` to borrow the value directly from the state.
+    fn call<Chain>(self, mut state: State, chain: Chain) -> Box<HandlerFuture>
+    where
+        Chain: FnOnce(State) -> Box<HandlerFuture>,
+    {
+        state.put(self.t);
+        chain(state)
+    }
+}
+
+/// `NewMiddleware` trait implementation.
+impl<T> NewMiddleware for StateMiddleware<T>
+where
+    T: Clone + RefUnwindSafe + StateData + Sync,
+{
+    type Instance = Self;
+
+    /// Clones the current middleware to a new instance.
+    fn new_middleware(&self) -> io::Result<Self::Instance> {
+        Ok(self.clone())
+    }
+}

--- a/gotham/src/middleware/state/mod.rs
+++ b/gotham/src/middleware/state/mod.rs
@@ -32,7 +32,7 @@ where
     T: Clone + RefUnwindSafe + StateData + Sync,
 {
     /// Creates a new middleware binding, taking ownership of the state data.
-    pub fn with(t: T) -> Self {
+    pub fn new(t: T) -> Self {
         Self { t }
     }
 }

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -168,6 +168,15 @@ pub fn new_pipeline() -> PipelineBuilder<()> {
     PipelineBuilder { t: () }
 }
 
+/// Constructs a pipeline from a single middleware.
+pub fn single_middleware<M>(m: M) -> Pipeline<(M, ())>
+where
+    M: NewMiddleware,
+    M::Instance: Send + 'static,
+{
+    new_pipeline().add(m).build()
+}
+
 /// Allows a pipeline to be defined by adding `NewMiddleware` values, and building a `Pipeline`.
 ///
 /// # Examples


### PR DESCRIPTION
This PR will add a new `StateMiddleware` which enables attaching generic types to requests easily enough. It masks the `Middleware` requirement needed for state, which is much more familiar to new users. An example is also included!

This will fix #251.

