### PR TITLE
`cargo install clippy` should overwrite existing binary (if any)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - SHARD=clippy
         - PATH=$HOME/.cargo/bin/:$PATH
       before_script:
-        - cargo install clippy --version 0.0.211
+        - cargo install clippy --version 0.0.211 --force
       script:
         - echo "Checking Gotham codebase with Clippy release `cargo clippy --version`."
         - cargo clippy --all --profile test


### PR DESCRIPTION
Recently, Clippy was added as a `rustup` component[1]. Hopefully, it will
be available starting with the next stable Rust, and we will use it in
the same way as we currently use `rustfmt`.

[1] https://internals.rust-lang.org/t/clippy-is-available-as-a-rustup-component/7967