### PR TITLE
Document new middleware naming conventions

### DIFF
--- a/middleware/template/Cargo.toml
+++ b/middleware/template/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "middleware-template"
+name = "gotham-middleware-template"
 version = "0.0.0"
 authors = ["Shaun Mangelsdorf <s.mangelsdorf@gmail.com>",
            "Bradley Beddoes <bradleybeddoes@gmail.com>"]


### PR DESCRIPTION
This PR introduces the middleware naming convention that was discussed in Gitter. The idea is to create a seamless experience for newcomers who will probably start a project with core middlewares (sessions, workers, diesel, etc.), before quickly progressing to community supported middleware crates.

Introducing the `gotham-middleware-{type}` naming convention allows for middlewares to be easily grouped in search, and directly maps to the slugged URL on crates.io.

Since the cargo manifest format [supports up to 5 identifiers](https://doc.rust-lang.org/cargo/reference/manifest.html) in the `keywords` field, convention is to *also include* `gotham-middleware` as your initial keyword to further aid discoverability. The additional four keywords are entirely up to the author.

Once all documentation has been updated, then we can merge this PR. 