### PR TITLE
Re-introduce the headers helper for internal headers

### DIFF
--- a/gotham/src/helpers/http/header/mod.rs
+++ b/gotham/src/helpers/http/header/mod.rs
@@ -1,0 +1,8 @@
+//! Headers recognised by Gotham which do not exist in the standard headers
+//! provided by the Hyper library.
+
+/// Marks the identifier of a request to a Gotham server.
+pub const X_REQUEST_ID: &'static str = "x-request-id";
+
+/// Marks the execution time of a Gotham request in microseconds.
+pub const X_RUNTIME_MICROSECONDS: &'static str = "x-runtime-microseconds";

--- a/gotham/src/helpers/http/mod.rs
+++ b/gotham/src/helpers/http/mod.rs
@@ -1,5 +1,6 @@
 //! Helpers for HTTP request handling and response generation
 
+pub mod header;
 pub mod request;
 pub mod response;
 

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -2,7 +2,7 @@
 
 use http::response;
 use hyper::header::{
-    HeaderMap, HeaderName, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, X_CONTENT_TYPE_OPTIONS,
+    HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, X_CONTENT_TYPE_OPTIONS,
     X_FRAME_OPTIONS, X_XSS_PROTECTION,
 };
 use hyper::{Body, Method, Response, StatusCode};
@@ -11,6 +11,11 @@ use std::borrow::Cow;
 
 use helpers::http::header::X_REQUEST_ID;
 use state::{request_id, FromState, State};
+
+// constant strings to be used as header values
+const XFO_VALUE: &'static str = "DENY";
+const XXP_VALUE: &'static str = "1; mode=block";
+const XCTO_VALUE: &'static str = "nosniff";
 
 /// Creates a `Response` object and populates it with a set of default headers that help to improve
 /// security and conformance to best practice.
@@ -425,9 +430,9 @@ pub fn set_headers<B>(
 
     set_request_id(state, headers);
 
-    headers.insert(X_FRAME_OPTIONS, "DENY".parse().unwrap());
-    headers.insert(X_XSS_PROTECTION, "1; mode=block".parse().unwrap());
-    headers.insert(X_CONTENT_TYPE_OPTIONS, "nosniff".parse().unwrap());
+    headers.insert(X_FRAME_OPTIONS, HeaderValue::from_static(XFO_VALUE));
+    headers.insert(X_XSS_PROTECTION, HeaderValue::from_static(XXP_VALUE));
+    headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static(XCTO_VALUE));
 }
 
 /// Sets redirect headers on a given `Response`.

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -9,6 +9,7 @@ use hyper::{Body, Method, Response, StatusCode};
 use mime::Mime;
 use std::borrow::Cow;
 
+use helpers::http::header::X_REQUEST_ID;
 use state::{request_id, FromState, State};
 
 /// Creates a `Response` object and populates it with a set of default headers that help to improve
@@ -27,6 +28,7 @@ use state::{request_id, FromState, State};
 /// # use hyper::{Body, Response, StatusCode};
 /// # use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE};
 /// # use gotham::state::State;
+/// # use gotham::helpers::http::header::X_REQUEST_ID;
 /// # use gotham::helpers::http::response::create_response;
 /// # use gotham::test::TestServer;
 /// #
@@ -51,7 +53,7 @@ use state::{request_id, FromState, State};
 /// #         .unwrap();
 /// #
 /// #     assert_eq!(response.status(), StatusCode::OK);
-/// #     assert!(response.headers().get("x-request-id").is_some());
+/// #     assert!(response.headers().get(X_REQUEST_ID).is_some());
 /// #
 /// #     assert_eq!(
 /// #         *response.headers().get(CONTENT_TYPE).unwrap(),
@@ -195,6 +197,7 @@ pub fn create_temporary_redirect<B: Default, L: Into<Cow<'static, str>>>(
 /// # use hyper::{Body, Response, StatusCode};
 /// # use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE};
 /// # use gotham::state::State;
+/// # use gotham::helpers::http::header::X_REQUEST_ID;
 /// # use gotham::helpers::http::response::extend_response;
 /// # use gotham::test::TestServer;
 /// #
@@ -222,7 +225,7 @@ pub fn create_temporary_redirect<B: Default, L: Into<Cow<'static, str>>>(
 /// #         .unwrap();
 /// #
 /// #     assert_eq!(response.status(), StatusCode::OK);
-/// #     assert!(response.headers().get("x-request-id").is_some());
+/// #     assert!(response.headers().get(X_REQUEST_ID).is_some());
 /// #
 /// #     assert_eq!(
 /// #         *response.headers().get(CONTENT_TYPE).unwrap(),
@@ -258,10 +261,9 @@ pub fn extend_response(
         builder
     };
 
-    let id_header = HeaderName::from_lowercase(b"x-request-id")
-        .expect("Header name built from a constant string");
-
-    builder.header(id_header, request_id(state)).status(status);
+    builder
+        .header(X_REQUEST_ID, request_id(state))
+        .status(status);
 }
 
 /// Sets a number of default headers in a `Response` that ensure security and conformance to
@@ -280,6 +282,7 @@ pub fn extend_response(
 /// # use hyper::{Body, Response, StatusCode};
 /// # use hyper::header::{X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
 /// # use gotham::state::State;
+/// # use gotham::helpers::http::header::X_REQUEST_ID;
 /// # use gotham::helpers::http::response::set_headers;
 /// # use gotham::test::TestServer;
 /// #
@@ -309,7 +312,7 @@ pub fn extend_response(
 ///
 /// // e.g.:
 /// // X-Request-Id: 848c651a-fdd8-4859-b671-3f221895675e
-/// # assert!(response.headers().get( "x-request-id" ).is_some());
+/// # assert!(response.headers().get(X_REQUEST_ID).is_some());
 ///
 /// // X-Frame-Options: DENY
 /// assert_eq!(
@@ -342,6 +345,7 @@ pub fn extend_response(
 /// # use hyper::{Body, Response, StatusCode};
 /// # use hyper::header::{X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION, CONTENT_LENGTH, CONTENT_TYPE};
 /// # use gotham::state::State;
+/// # use gotham::helpers::http::header::X_REQUEST_ID;
 /// # use gotham::helpers::http::response::set_headers;
 /// # use gotham::test::TestServer;
 /// #
@@ -383,7 +387,7 @@ pub fn extend_response(
 /// #
 /// # // e.g.:
 /// # // X-Request-Id: 848c651a-fdd8-4859-b671-3f221895675e
-/// # assert!(response.headers().get("x-request-id").is_some());
+/// # assert!(response.headers().get(X_REQUEST_ID).is_some());
 /// #
 /// # // X-Frame-Options: DENY
 /// # assert_eq!(
@@ -438,6 +442,7 @@ pub fn set_headers<B>(
 /// # use hyper::{Body, Response, StatusCode};
 /// # use hyper::header::LOCATION;
 /// # use gotham::state::State;
+/// # use gotham::helpers::http::header::X_REQUEST_ID;
 /// # use gotham::helpers::http::response::set_redirect_headers;
 /// # use gotham::test::TestServer;
 /// fn handler(state: State) -> (State, Response<Body>) {
@@ -467,7 +472,7 @@ pub fn set_headers<B>(
 ///     *response.headers().get(LOCATION).unwrap(),
 ///     "http://example.com/somewhere-else"
 /// );
-/// # assert!(response.headers().get("x-request-id").is_some());
+/// # assert!(response.headers().get(X_REQUEST_ID).is_some());
 /// # }
 /// ```
 pub fn set_redirect_headers<B, L: Into<Cow<'static, str>>>(
@@ -482,8 +487,5 @@ pub fn set_redirect_headers<B, L: Into<Cow<'static, str>>>(
 
 /// Sets the request id inside a given `HeaderMap`.
 fn set_request_id(state: &State, headers: &mut HeaderMap) {
-    headers.insert(
-        HeaderName::from_lowercase(b"x-request-id").unwrap(),
-        request_id(state).parse().unwrap(),
-    );
+    headers.insert(X_REQUEST_ID, request_id(state).parse().unwrap());
 }

--- a/gotham/src/service/timing.rs
+++ b/gotham/src/service/timing.rs
@@ -3,9 +3,9 @@
 use std::fmt::{self, Display, Formatter};
 
 use chrono::prelude::*;
-use hyper::header::HeaderValue;
 use hyper::Response;
 
+use helpers::http::header::X_RUNTIME_MICROSECONDS;
 use state::{request_id, State};
 
 /// Used by `GothamService` to time requests. The `elapsed` function returns the elapsed time
@@ -60,10 +60,9 @@ impl Timing {
     /// included (assuming the time elapsed was able to be measured).
     pub(super) fn add_to_response<B>(&self, mut response: Response<B>) -> Response<B> {
         if let Timing::Microseconds(i) = *self {
-            response.headers_mut().insert(
-                "X-Runtime-Microseconds",
-                HeaderValue::from_str(&i.to_string()).unwrap(),
-            );
+            response
+                .headers_mut()
+                .insert(X_RUNTIME_MICROSECONDS, i.to_string().parse().unwrap());
         }
         response
     }

--- a/gotham_derive/src/extenders.rs
+++ b/gotham_derive/src/extenders.rs
@@ -12,8 +12,8 @@ pub(crate) fn bad_request_static_response_extender(ast: &syn::DeriveInput) -> qu
             type ResBody = ::hyper::body::Body;
 
             fn extend(state: &mut ::gotham::state::State, res: &mut ::hyper::Response<Self::ResBody>) {
-                res.headers_mut().insert("x-request-id",
-                                         ::hyper::header::HeaderValue::from_str(::gotham::state::request_id(state)).unwrap());
+                res.headers_mut().insert(::gotham::helpers::http::header::X_REQUEST_ID,
+                                         ::gotham::state::request_id(state).parse().unwrap());
                 *res.status_mut() = ::hyper::StatusCode::BAD_REQUEST;
             }
         }


### PR DESCRIPTION
When Hyper 0.12 was adopted in #246, we removed `::gotham::helpers::http::header` as it basically broke compatibility completely. Several of the previously exposed headers are now available via the `http` crate and/or `hyper`. However Gotham still uses two of the previous headers in `x-request-id` and `x-runtime-microseconds`. 

In the adoption PR these headers are dealt with using strings directly, but this PR re-introduces the helper to make them public as `&'static str`. Whilst this is not as efficient as exposing `HeaderName` values, you can drop them directly into Hyper calls and it'll work just fine:

```rust
res.header_mut().insert(X_REQUEST_ID, "blah".parse().unwrap());
```

This is not only better for compile time checking, but it's also a little more performant as (in theory) Hyper can avoid copying the values due to them being static. I did the same for the built-in headers that are always attached to responses, too.

This would fix #263. 