### PR TITLE
Remove a need to allocate a Vec on response bodies

### DIFF
--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -35,10 +35,7 @@ fn handler(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((
-                format!("Hello {} visitor\n", adjective).as_bytes().to_vec(),
-                mime::TEXT_PLAIN,
-            )),
+            Some((format!("Hello {} visitor\n", adjective), mime::TEXT_PLAIN)),
         )
     };
     {

--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -35,7 +35,7 @@ fn handler(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((format!("Hello {} visitor\n", adjective), mime::TEXT_PLAIN)),
+            (format!("Hello {} visitor\n", adjective), mime::TEXT_PLAIN),
         )
     };
     {

--- a/examples/example_contribution_template/name/src/main.rs
+++ b/examples/example_contribution_template/name/src/main.rs
@@ -24,7 +24,7 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use gotham::helpers::http::response::create_response;
+use gotham::helpers::http::response::create_empty_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
@@ -32,7 +32,7 @@ use hyper::{Body, Response, StatusCode};
 
 /// Create a `Handler` that ...
 pub fn well_named_function(state: State) -> (State, Response<Body>) {
-    let res = create_response(&state, StatusCode::OK, None);
+    let res = create_empty_response(&state, StatusCode::OK);
     (state, res)
 }
 

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -19,9 +19,9 @@ use hyper::{Client, Uri};
 
 use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::helpers::http::response::create_response;
-use gotham::router::Router;
-use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::builder::DefineSingleRoute;
+use gotham::router::builder::{build_simple_router, DrawRoutes};
+use gotham::router::Router;
 use gotham::state::{FromState, State};
 
 use tokio_core::reactor::Handle;

--- a/examples/handlers/request_data/src/main.rs
+++ b/examples/handlers/request_data/src/main.rs
@@ -9,7 +9,7 @@ use futures::{future, Future, Stream};
 use hyper::{Body, HeaderMap, Method, Response, StatusCode, Uri, Version};
 
 use gotham::handler::{HandlerFuture, IntoHandlerError};
-use gotham::helpers::http::response::create_response;
+use gotham::helpers::http::response::create_empty_response;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
@@ -35,7 +35,7 @@ fn post_handler(mut state: State) -> Box<HandlerFuture> {
             Ok(valid_body) => {
                 let body_content = String::from_utf8(valid_body.to_vec()).unwrap();
                 println!("Body: {}", body_content);
-                let res = create_response(&state, StatusCode::OK, None);
+                let res = create_empty_response(&state, StatusCode::OK);
                 future::ok((state, res))
             }
             Err(e) => return future::err((state, e.into_handler_error())),
@@ -47,7 +47,7 @@ fn post_handler(mut state: State) -> Box<HandlerFuture> {
 /// Show the GET request components by printing them.
 fn get_handler(state: State) -> (State, Response<Body>) {
     print_request_elements(&state);
-    let res = create_response(&state, StatusCode::OK, None);
+    let res = create_empty_response(&state, StatusCode::OK);
 
     (state, res)
 }

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -85,7 +85,7 @@ fn sleep_handler(mut state: State) -> Box<HandlerFuture> {
     // IntoHandlerError.
     Box::new(sleep_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, Some((data, mime::TEXT_PLAIN)));
+            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
             println!("sleep for {} seconds once: finished", seconds);
             Ok((state, res))
         }
@@ -119,7 +119,7 @@ fn loop_handler(mut state: State) -> Box<HandlerFuture> {
     // This bit is the same as the bit in the first example.
     Box::new(sleep_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, Some((data, mime::TEXT_PLAIN)));
+            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
             println!("sleep for one second {} times: finished", seconds);
             Ok((state, res))
         }

--- a/examples/handlers/stateful/src/main.rs
+++ b/examples/handlers/stateful/src/main.rs
@@ -56,13 +56,7 @@ impl Handler for CountingHandler {
             visits
         );
 
-        let res = {
-            create_response(
-                &state,
-                StatusCode::OK,
-                Some((response_text, mime::TEXT_PLAIN)),
-            )
-        };
+        let res = { create_response(&state, StatusCode::OK, (response_text, mime::TEXT_PLAIN)) };
         Box::new(future::ok((state, res)))
     }
 }

--- a/examples/handlers/stateful/src/main.rs
+++ b/examples/handlers/stateful/src/main.rs
@@ -60,7 +60,7 @@ impl Handler for CountingHandler {
             create_response(
                 &state,
                 StatusCode::OK,
-                Some((response_text.into_bytes(), mime::TEXT_PLAIN)),
+                Some((response_text, mime::TEXT_PLAIN)),
             )
         };
         Box::new(future::ok((state, res)))

--- a/examples/headers/setting/src/main.rs
+++ b/examples/headers/setting/src/main.rs
@@ -4,7 +4,7 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use gotham::helpers::http::response::create_response;
+use gotham::helpers::http::response::create_empty_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
@@ -12,7 +12,7 @@ use hyper::{Body, Response, StatusCode};
 
 /// Create a `Handler` that adds a custom header.
 pub fn handler(state: State) -> (State, Response<Body>) {
-    let mut res = create_response(&state, StatusCode::OK, None);
+    let mut res = create_empty_response(&state, StatusCode::OK);
     {
         let headers = res.headers_mut();
         headers.insert("x-gotham", "Hello World!".parse().unwrap());

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -9,6 +9,8 @@ use hyper::{Body, Response, StatusCode};
 use gotham::helpers::http::response::create_response;
 use gotham::state::State;
 
+const HELLO_WORLD: &'static str = "Hello World!";
+
 /// Create a `Handler` which is invoked when responding to a `Request`.
 ///
 /// How does a function become a `Handler`?.
@@ -18,7 +20,7 @@ pub fn say_hello(state: State) -> (State, Response<Body>) {
     let res = create_response(
         &state,
         StatusCode::OK,
-        Some((String::from("Hello World!").into_bytes(), mime::TEXT_PLAIN)),
+        Some((HELLO_WORLD, mime::TEXT_PLAIN)),
     );
 
     (state, res)

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -17,11 +17,7 @@ const HELLO_WORLD: &'static str = "Hello World!";
 /// We've simply implemented the `Handler` trait, for functions that match the signature used here,
 /// within Gotham itself.
 pub fn say_hello(state: State) -> (State, Response<Body>) {
-    let res = create_response(
-        &state,
-        StatusCode::OK,
-        Some((HELLO_WORLD, mime::TEXT_PLAIN)),
-    );
+    let res = create_response(&state, StatusCode::OK, (HELLO_WORLD, mime::TEXT_PLAIN));
 
     (state, res)
 }

--- a/examples/into_response/introduction/src/main.rs
+++ b/examples/into_response/introduction/src/main.rs
@@ -36,9 +36,7 @@ impl IntoResponse<Body> for Product {
             state,
             StatusCode::OK,
             Some((
-                serde_json::to_string(&self)
-                    .expect("serialized product")
-                    .into_bytes(),
+                serde_json::to_string(&self).expect("serialized product"),
                 mime::APPLICATION_JSON,
             )),
         )

--- a/examples/into_response/introduction/src/main.rs
+++ b/examples/into_response/introduction/src/main.rs
@@ -35,10 +35,10 @@ impl IntoResponse<Body> for Product {
         create_response(
             state,
             StatusCode::OK,
-            Some((
+            (
                 serde_json::to_string(&self).expect("serialized product"),
                 mime::APPLICATION_JSON,
-            )),
+            ),
         )
     }
 }

--- a/examples/middleware/introduction/src/main.rs
+++ b/examples/middleware/introduction/src/main.rs
@@ -9,7 +9,7 @@ extern crate mime;
 
 use futures::{future, Future};
 use gotham::handler::HandlerFuture;
-use gotham::helpers::http::response::create_response;
+use gotham::helpers::http::response::create_empty_response;
 use gotham::middleware::Middleware;
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
@@ -115,7 +115,7 @@ pub fn middleware_reliant_handler(mut state: State) -> (State, Response<Body>) {
     };
 
     // Finally we create a basic Response to complete our handling of the Request.
-    let res = create_response(&state, StatusCode::OK, None);
+    let res = create_empty_response(&state, StatusCode::OK);
     (state, res)
 }
 

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -38,11 +38,7 @@ fn parts_handler(state: State) -> (State, Response<Body>) {
             response_string.push_str(&part);
         }
 
-        create_response(
-            &state,
-            StatusCode::OK,
-            Some((response_string, mime::TEXT_PLAIN)),
-        )
+        create_response(&state, StatusCode::OK, (response_string, mime::TEXT_PLAIN))
     };
 
     (state, res)

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -41,7 +41,7 @@ fn parts_handler(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((response_string.into_bytes(), mime::TEXT_PLAIN)),
+            Some((response_string, mime::TEXT_PLAIN)),
         )
     };
 

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -59,7 +59,7 @@ fn get_product_handler(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((format!("Product: {}", product.name), mime::TEXT_PLAIN)),
+            (format!("Product: {}", product.name), mime::TEXT_PLAIN),
         )
     };
 

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -59,10 +59,7 @@ fn get_product_handler(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((
-                format!("Product: {}", product.name).into_bytes(),
-                mime::TEXT_PLAIN,
-            )),
+            Some((format!("Product: {}", product.name), mime::TEXT_PLAIN)),
         )
     };
 

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -30,7 +30,7 @@ pub fn greet_user(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((response_string.into_bytes(), mime::TEXT_PLAIN)),
+            Some((response_string, mime::TEXT_PLAIN)),
         )
     };
 

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -27,11 +27,7 @@ pub fn greet_user(state: State) -> (State, Response<Body>) {
         let path = PathExtractor::borrow_from(&state);
         let response_string = format!("Hello, User {}!", &path.id);
 
-        create_response(
-            &state,
-            StatusCode::OK,
-            Some((response_string, mime::TEXT_PLAIN)),
-        )
+        create_response(&state, StatusCode::OK, (response_string, mime::TEXT_PLAIN))
     };
 
     (state, res)

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -77,10 +77,10 @@ fn get_product_handler(mut state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((
+            (
                 serde_json::to_vec(&product).expect("serialized product"),
                 mime::APPLICATION_JSON,
-            )),
+            ),
         )
     };
     (state, res)

--- a/examples/routing/associations/src/handlers.rs
+++ b/examples/routing/associations/src/handlers.rs
@@ -14,7 +14,7 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                Some((stringify!($t), mime::TEXT_PLAIN)),
+                (stringify!($t), mime::TEXT_PLAIN),
             );
 
             (state, res)

--- a/examples/routing/associations/src/handlers.rs
+++ b/examples/routing/associations/src/handlers.rs
@@ -14,7 +14,7 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                Some((String::from(stringify!($t)).into_bytes(), mime::TEXT_PLAIN)),
+                Some((stringify!($t), mime::TEXT_PLAIN)),
             );
 
             (state, res)

--- a/examples/routing/http_verbs/src/handlers.rs
+++ b/examples/routing/http_verbs/src/handlers.rs
@@ -14,7 +14,7 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                Some((stringify!($t), mime::TEXT_PLAIN)),
+                (stringify!($t), mime::TEXT_PLAIN),
             );
 
             (state, res)

--- a/examples/routing/http_verbs/src/handlers.rs
+++ b/examples/routing/http_verbs/src/handlers.rs
@@ -14,7 +14,7 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                Some((String::from(stringify!($t)).into_bytes(), mime::TEXT_PLAIN)),
+                Some((stringify!($t), mime::TEXT_PLAIN)),
             );
 
             (state, res)

--- a/examples/routing/introduction/src/main.rs
+++ b/examples/routing/introduction/src/main.rs
@@ -11,12 +11,14 @@ use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
 
+const HELLO_ROUTER: &'static str = "Hello Router!";
+
 /// Create a `Handler` that is invoked for requests to the path "/"
 pub fn say_hello(state: State) -> (State, Response<Body>) {
     let res = create_response(
         &state,
         StatusCode::OK,
-        Some((String::from("Hello Router!").into_bytes(), mime::TEXT_PLAIN)),
+        Some((HELLO_ROUTER, mime::TEXT_PLAIN)),
     );
 
     (state, res)

--- a/examples/routing/introduction/src/main.rs
+++ b/examples/routing/introduction/src/main.rs
@@ -15,11 +15,7 @@ const HELLO_ROUTER: &'static str = "Hello Router!";
 
 /// Create a `Handler` that is invoked for requests to the path "/"
 pub fn say_hello(state: State) -> (State, Response<Body>) {
-    let res = create_response(
-        &state,
-        StatusCode::OK,
-        Some((HELLO_ROUTER, mime::TEXT_PLAIN)),
-    );
+    let res = create_response(&state, StatusCode::OK, (HELLO_ROUTER, mime::TEXT_PLAIN));
 
     (state, res)
 }

--- a/examples/routing/scopes/src/handlers.rs
+++ b/examples/routing/scopes/src/handlers.rs
@@ -14,7 +14,7 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                Some((stringify!($t), mime::TEXT_PLAIN)),
+                (stringify!($t), mime::TEXT_PLAIN),
             );
 
             (state, res)

--- a/examples/routing/scopes/src/handlers.rs
+++ b/examples/routing/scopes/src/handlers.rs
@@ -14,7 +14,7 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                Some((String::from(stringify!($t)).into_bytes(), mime::TEXT_PLAIN)),
+                Some((stringify!($t), mime::TEXT_PLAIN)),
             );
 
             (state, res)

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -45,7 +45,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         ),
         &None => "You have never visited this page before.\n".to_owned(),
     };
-    let res = { create_response(&state, StatusCode::OK, Some((body, mime::TEXT_PLAIN))) };
+    let res = { create_response(&state, StatusCode::OK, (body, mime::TEXT_PLAIN)) };
     {
         let visit_data: &mut Option<VisitData> =
             SessionData::<Option<VisitData>>::borrow_mut_from(&mut state);

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -45,13 +45,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         ),
         &None => "You have never visited this page before.\n".to_owned(),
     };
-    let res = {
-        create_response(
-            &state,
-            StatusCode::OK,
-            Some((body.as_bytes().to_vec(), mime::TEXT_PLAIN)),
-        )
-    };
+    let res = { create_response(&state, StatusCode::OK, Some((body, mime::TEXT_PLAIN))) };
     {
         let visit_data: &mut Option<VisitData> =
             SessionData::<Option<VisitData>>::borrow_mut_from(&mut state);

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -33,10 +33,10 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            Some((
+            (
                 format!("You have visited this page {} time(s) before\n", visits),
                 mime::TEXT_PLAIN,
-            )),
+            ),
         )
     };
     {

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -34,9 +34,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
             &state,
             StatusCode::OK,
             Some((
-                format!("You have visited this page {} time(s) before\n", visits)
-                    .as_bytes()
-                    .to_vec(),
+                format!("You have visited this page {} time(s) before\n", visits),
                 mime::TEXT_PLAIN,
             )),
         )

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -67,7 +67,7 @@ fn say_hello(state: State) -> (State, Response<Body>) {
     };
 
     // create the response
-    let body = Some((message, mime::TEXT_PLAIN));
+    let body = (message, mime::TEXT_PLAIN);
     let res = create_response(&state, StatusCode::OK, body);
 
     // done!

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -67,11 +67,8 @@ fn say_hello(state: State) -> (State, Response<Body>) {
     };
 
     // create the response
-    let res = create_response(
-        &state,
-        StatusCode::OK,
-        Some((message.into_bytes(), mime::TEXT_PLAIN)),
-    );
+    let body = Some((message, mime::TEXT_PLAIN));
+    let res = create_response(&state, StatusCode::OK, body);
 
     // done!
     (state, res)

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -29,7 +29,7 @@ pub fn say_hello(state: State) -> (State, Response<Body>) {
     context.add("user", "Gotham");
     let rendered = TERA.render("example.html.tera", &context).unwrap();
 
-    let res = create_response(&state, StatusCode::OK, Some((rendered, mime::TEXT_HTML)));
+    let res = create_response(&state, StatusCode::OK, (rendered, mime::TEXT_HTML));
 
     (state, res)
 }

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -29,11 +29,7 @@ pub fn say_hello(state: State) -> (State, Response<Body>) {
     context.add("user", "Gotham");
     let rendered = TERA.render("example.html.tera", &context).unwrap();
 
-    let res = create_response(
-        &state,
-        StatusCode::OK,
-        Some((rendered.into_bytes(), mime::TEXT_HTML)),
-    );
+    let res = create_response(&state, StatusCode::OK, Some((rendered, mime::TEXT_HTML)));
 
     (state, res)
 }

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -48,7 +48,7 @@ use state::{State, StateData};
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         Some((body.into_bytes(), mime::TEXT_PLAIN)),
+///         (body, mime::TEXT_PLAIN),
 ///     );
 ///
 ///     (state, response)

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -56,7 +56,7 @@ use state::{State, StateData};
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         Some((body.into_bytes(), mime::TEXT_PLAIN)),
+///         (body, mime::TEXT_PLAIN),
 ///     );
 ///
 ///     (state, response)

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use hyper::{Body, Response, StatusCode};
 
 use handler::IntoResponse;
-use helpers::http::response::create_response;
+use helpers::http::response::create_empty_response;
 use state::{request_id, State};
 
 /// Describes an error which occurred during handler execution, and allows the creation of a HTTP
@@ -139,6 +139,6 @@ impl IntoResponse<Body> for HandlerError {
             self.cause().map(|e| e.description()).unwrap_or("(none)"),
         );
 
-        create_response(state, self.status_code, None)
+        create_empty_response(state, self.status_code)
     }
 }

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -43,7 +43,7 @@ const XCTO_VALUE: &'static str = "nosniff";
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         Some((BODY.to_vec(), mime::TEXT_PLAIN)),
+///         (BODY, mime::TEXT_PLAIN),
 ///     );
 ///
 ///     (state, response)
@@ -74,13 +74,10 @@ const XCTO_VALUE: &'static str = "nosniff";
 pub fn create_response<B: Into<Body>>(
     state: &State,
     status: StatusCode,
-    data: Option<(B, Mime)>,
+    data: (B, Mime),
 ) -> Response<Body> {
-    let (body, mime) = data
-        .map(|(body, mime)| (Some(body), Some(mime)))
-        .unwrap_or_else(|| (None, None));
-
-    construct_response(state, status, mime, body)
+    let (body, mime) = data;
+    construct_response(state, status, Some(body), Some(mime))
 }
 
 /// Produces a simple empty `Response` with a provided status.
@@ -509,8 +506,8 @@ pub fn set_redirect_headers<B, L: Into<Cow<'static, str>>>(
 fn construct_response<B: Into<Body>>(
     state: &State,
     status: StatusCode,
-    mime: Option<Mime>,
     body: Option<B>,
+    mime: Option<Mime>,
 ) -> Response<Body> {
     let mut builder = Response::builder();
 

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -71,10 +71,10 @@ const XCTO_VALUE: &'static str = "nosniff";
 /// #     );
 /// # }
 /// ```
-pub fn create_response(
+pub fn create_response<B: Into<Body>>(
     state: &State,
     status: StatusCode,
-    body: Option<(Vec<u8>, Mime)>,
+    body: Option<(B, Mime)>,
 ) -> Response<Body> {
     let mut builder = Response::builder();
 
@@ -91,7 +91,39 @@ pub fn create_response(
         builder.body(Body::empty())
     };
 
-    built.expect("Response built from a compatible byte vector (Vec<u8>)")
+    built.expect("Response built from a compatible type")
+}
+
+/// Produces a simple empty `Response` with a provided status.
+///
+/// # Examples
+///
+/// ```rust
+/// # extern crate gotham;
+/// # extern crate hyper;
+/// #
+/// # use hyper::{Body, Response, StatusCode};
+/// # use gotham::state::State;
+/// # use gotham::helpers::http::response::create_empty_response;
+/// # use gotham::test::TestServer;
+/// fn handler(state: State) -> (State, Response<Body>) {
+///     let resp = create_empty_response(&state, StatusCode::NO_CONTENT);
+///
+///     (state, resp)
+/// }
+/// # fn main() {
+/// #     let test_server = TestServer::new(|| Ok(handler)).unwrap();
+/// #     let response = test_server
+/// #         .client()
+/// #         .get("http://example.com/")
+/// #         .perform()
+/// #         .unwrap();
+/// #
+/// #     assert_eq!(response.status(), StatusCode::NO_CONTENT);
+/// # }
+/// ```
+pub fn create_empty_response(state: &State, status: StatusCode) -> Response<Body> {
+    create_response::<&str>(state, status, None)
 }
 
 /// Produces a simple empty `Response` with a `Location` header and a 301

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -206,7 +206,7 @@ pub mod state;
 /// #
 /// # use hyper::{Body, Response, Method, StatusCode};
 /// # use futures::future;
-/// # use gotham::helpers::http::response::create_response;
+/// # use gotham::helpers::http::response::create_empty_response;
 /// # use gotham::handler::HandlerFuture;
 /// # use gotham::middleware::Middleware;
 /// # use gotham::pipeline::*;
@@ -225,7 +225,7 @@ pub mod state;
 ///         if *Method::borrow_from(&state) == Method::GET {
 ///             chain(state)
 ///         } else {
-///             let response = create_response(&state, StatusCode::METHOD_NOT_ALLOWED, None);
+///             let response = create_empty_response(&state, StatusCode::METHOD_NOT_ALLOWED);
 ///             Box::new(future::ok((state, response)))
 ///         }
 ///     }

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -217,12 +217,12 @@ impl SessionCookieConfig {
 ///     // active for this handler.
 ///     let body = {
 ///         let session = SessionData::<MySessionType>::borrow_from(&state);
-///         format!("{:?}", session.items).into_bytes()
+///         format!("{:?}", session.items)
 ///     };
 ///
 ///     let response = create_response(&state,
 ///                                    StatusCode::OK,
-///                                    Some((body, mime::TEXT_PLAIN)));
+///                                    (body, mime::TEXT_PLAIN));
 ///
 ///     (state, response)
 /// }

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -92,7 +92,7 @@ use state::{request_id, State};
 ///
 ///     let res = create_response(&state,
 ///                               StatusCode::OK,
-///                               Some((body.into_bytes(), mime::TEXT_PLAIN)));
+///                               (body, mime::TEXT_PLAIN));
 ///
 ///     (state, res)
 /// }

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -954,7 +954,7 @@ mod tests {
     use hyper::{Body, Response, StatusCode};
 
     use handler::HandlerFuture;
-    use helpers::http::response::create_response;
+    use helpers::http::response::create_empty_response;
     use middleware::{Middleware, NewMiddleware};
     use pipeline::single::*;
     use pipeline::*;
@@ -991,7 +991,7 @@ mod tests {
     }
 
     fn test_handler(state: State) -> (State, Response<Body>) {
-        let response = create_response(&state, StatusCode::ACCEPTED, None);
+        let response = create_empty_response(&state, StatusCode::ACCEPTED);
         (state, response)
     }
 

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -15,7 +15,7 @@ use hyper::{Body, Response, StatusCode};
 use error::*;
 use handler::{Handler, HandlerFuture, IntoResponse, NewHandler};
 use helpers::http::request::path::RequestPathSegments;
-use helpers::http::response::create_response;
+use helpers::http::response::create_empty_response;
 use router::response::finalizer::ResponseFinalizer;
 use router::route::{Delegation, Route};
 use router::tree::segment::SegmentMapping;
@@ -89,7 +89,7 @@ impl Handler for Router {
                             let (status, allow) = non_match.deconstruct();
 
                             trace!("[{}] responding with error status", request_id(&state));
-                            let mut res = create_response(&state, status, None);
+                            let mut res = create_empty_response(&state, status);
                             if let StatusCode::METHOD_NOT_ALLOWED = status {
                                 for allowed in allow {
                                     res.headers_mut().append(
@@ -103,13 +103,13 @@ impl Handler for Router {
                     }
                 } else {
                     trace!("[{}] did not find routable node", request_id(&state));
-                    let res = create_response(&state, StatusCode::NOT_FOUND, None);
+                    let res = create_empty_response(&state, StatusCode::NOT_FOUND);
                     Box::new(future::ok((state, res)))
                 }
             }
             None => {
                 trace!("[{}] invalid request path segments", request_id(&state));
-                let res = create_response(&state, StatusCode::INTERNAL_SERVER_ERROR, None);
+                let res = create_empty_response(&state, StatusCode::INTERNAL_SERVER_ERROR);
                 Box::new(future::ok((state, res)))
             }
         };

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -225,7 +225,7 @@ mod tests {
 
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
     use helpers::http::request::path::RequestPathSegments;
-    use helpers::http::response::create_response;
+    use helpers::http::response::create_empty_response;
     use pipeline::set::*;
     use router::builder::*;
     use router::route::dispatch::DispatcherImpl;
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn internal_route_tests() {
         fn handler(state: State) -> (State, Response<Body>) {
-            let res = create_response(&state, StatusCode::ACCEPTED, None);
+            let res = create_empty_response(&state, StatusCode::ACCEPTED);
             (state, res)
         }
 
@@ -263,7 +263,7 @@ mod tests {
     #[test]
     fn external_route_tests() {
         fn handler(state: State) -> (State, Response<Body>) {
-            let res = create_response(&state, StatusCode::ACCEPTED, None);
+            let res = create_empty_response(&state, StatusCode::ACCEPTED);
             (state, res)
         }
 

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -67,7 +67,7 @@ mod tests {
 
     use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
     use helpers::http::request::path::RequestPathSegments;
-    use helpers::http::response::create_response;
+    use helpers::http::response::create_empty_response;
     use pipeline::set::*;
     use router::route::dispatch::DispatcherImpl;
     use router::route::matcher::MethodOnlyRouteMatcher;
@@ -77,7 +77,7 @@ mod tests {
     use super::*;
 
     fn handler(state: State) -> (State, Response<Body>) {
-        let res = create_response(&state, StatusCode::OK, None);
+        let res = create_empty_response(&state, StatusCode::OK);
         (state, res)
     }
 

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -110,12 +110,12 @@ mod tests {
 
     use hyper::{Body, StatusCode};
 
-    use helpers::http::response::create_response;
+    use helpers::http::response::create_empty_response;
     use router::builder::*;
     use state::State;
 
     fn handler(state: State) -> (State, Response<Body>) {
-        let res = create_response(&state, StatusCode::ACCEPTED, None);
+        let res = create_empty_response(&state, StatusCode::ACCEPTED);
         (state, res)
     }
 

--- a/gotham/src/service/trap.rs
+++ b/gotham/src/service/trap.rs
@@ -202,14 +202,14 @@ mod tests {
     use hyper::{HeaderMap, Method, StatusCode};
 
     use handler::{HandlerFuture, IntoHandlerError};
-    use helpers::http::response::create_response;
+    use helpers::http::response::create_empty_response;
     use state::set_request_id;
 
     #[test]
     fn success() {
         let new_handler = || {
             Ok(|state| {
-                let res = create_response(&state, StatusCode::ACCEPTED, None);
+                let res = create_empty_response(&state, StatusCode::ACCEPTED);
                 (state, res)
             })
         };
@@ -229,7 +229,7 @@ mod tests {
         let new_handler = || {
             Ok(|state| {
                 let f = future::lazy(move || {
-                    let res = create_response(&state, StatusCode::ACCEPTED, None);
+                    let res = create_empty_response(&state, StatusCode::ACCEPTED);
                     future::ok((state, res))
                 });
 

--- a/gotham/src/state/client_addr.rs
+++ b/gotham/src/state/client_addr.rs
@@ -35,7 +35,7 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         Some((body.into_bytes(), mime::TEXT_PLAIN)),
+///         (body, mime::TEXT_PLAIN),
 ///     );
 ///
 ///     (state, response)

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -343,10 +343,10 @@ trait BodyReader {
 /// # use hyper::{Body, Response, StatusCode};
 /// #
 /// # fn my_handler(state: State) -> (State, Response<Body>) {
-/// #   let body = "This is the body content.".to_string().into_bytes();;
+/// #   let body = "This is the body content.".to_string();
 /// #   let response = create_response(&state,
 /// #                                  StatusCode::OK,
-/// #                                  Some((body, mime::TEXT_PLAIN)));
+/// #                                  (body, mime::TEXT_PLAIN));
 /// #
 /// #   (state, response)
 /// # }
@@ -572,11 +572,8 @@ mod tests {
                 .then(move |full_body| match full_body {
                     Ok(body) => {
                         let resp_data = body.to_vec();
-                        let res = create_response(
-                            &state,
-                            StatusCode::OK,
-                            Some((resp_data, mime::TEXT_PLAIN)),
-                        );
+                        let res =
+                            create_response(&state, StatusCode::OK, (resp_data, mime::TEXT_PLAIN));
                         future::ok((state, res))
                     }
 


### PR DESCRIPTION
This fixes #244.

This PR removes the need to allocate a `Vec` every time you want to return a body, rather opting for anything that Hyper can turn into a `Body`. 

The changes to signatures are designed to reduce friction for developers due to the generics involved. It is a breaking signature change, but it's easily fixable and the signature has already broken due to the Hyper 0.12 migration anyway.

I imagine this will be iterated on prior to being released, so I don't expect this to be the final set of signatures (for example, there's really no point providing a `(body, mime)` vs `body, mime`).