### PR TITLE
Refactor default headers to be an optional middleware

### DIFF
--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -1,21 +1,12 @@
 //! Helpers for HTTP response generation
 
-use http::response;
-use hyper::header::{
-    HeaderMap, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, X_CONTENT_TYPE_OPTIONS,
-    X_FRAME_OPTIONS, X_XSS_PROTECTION,
-};
+use hyper::header::{CONTENT_TYPE, LOCATION};
 use hyper::{Body, Method, Response, StatusCode};
 use mime::Mime;
 use std::borrow::Cow;
 
 use helpers::http::header::X_REQUEST_ID;
 use state::{request_id, FromState, State};
-
-// constant strings to be used as header values
-const XFO_VALUE: &'static str = "DENY";
-const XXP_VALUE: &'static str = "1; mode=block";
-const XCTO_VALUE: &'static str = "nosniff";
 
 /// Creates a `Response` object and populates it with a set of default headers that help to improve
 /// security and conformance to best practice.
@@ -151,7 +142,8 @@ pub fn create_permanent_redirect<L: Into<Cow<'static, str>>>(
     location: L,
 ) -> Response<Body> {
     let mut res = create_empty_response(state, StatusCode::PERMANENT_REDIRECT);
-    set_redirect_headers(state, &mut res, location);
+    res.headers_mut()
+        .insert(LOCATION, location.into().to_string().parse().unwrap());
     res
 }
 
@@ -194,312 +186,9 @@ pub fn create_temporary_redirect<L: Into<Cow<'static, str>>>(
     location: L,
 ) -> Response<Body> {
     let mut res = create_empty_response(state, StatusCode::TEMPORARY_REDIRECT);
-    set_redirect_headers(state, &mut res, location);
+    res.headers_mut()
+        .insert(LOCATION, location.into().to_string().parse().unwrap());
     res
-}
-
-/// Extends a `response::Builder` struct with an optional body and set of default headers that help to
-/// improve security and conformance to best practice.
-///
-/// `extend_response` delegates to `set_headers` for setting security headers. See `set_headers`
-/// for information about the headers which are populated.
-///
-/// # Examples
-///
-/// ```rust
-/// # extern crate gotham;
-/// # extern crate hyper;
-/// # extern crate mime;
-/// #
-/// # use hyper::{Body, Response, StatusCode};
-/// # use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE};
-/// # use gotham::state::State;
-/// # use gotham::helpers::http::header::X_REQUEST_ID;
-/// # use gotham::helpers::http::response::extend_response;
-/// # use gotham::test::TestServer;
-/// #
-/// static BODY: &'static [u8] = b"Hello, world!";
-///
-/// fn handler(state: State) -> (State, Response<Body>) {
-///     let mut response = Response::builder();
-///
-///     extend_response(
-///         &state,
-///         StatusCode::OK,
-///         &mut response,
-///         Some(mime::TEXT_PLAIN),
-///     );
-///
-///     (state, response.body(BODY.into()).unwrap())
-/// }
-/// #
-/// # fn main() {
-/// #     let test_server = TestServer::new(|| Ok(handler)).unwrap();
-/// #     let response = test_server
-/// #         .client()
-/// #         .get("http://example.com/")
-/// #         .perform()
-/// #         .unwrap();
-/// #
-/// #     assert_eq!(response.status(), StatusCode::OK);
-/// #     assert!(response.headers().get(X_REQUEST_ID).is_some());
-/// #
-/// #     assert_eq!(
-/// #         *response.headers().get(CONTENT_TYPE).unwrap(),
-/// #         mime::TEXT_PLAIN.to_string()
-/// #     );
-/// #
-/// #     assert_eq!(
-/// #         *response.headers().get(CONTENT_LENGTH).unwrap(),
-/// #         format!("{}", BODY.len() as u64)
-/// #     );
-/// # }
-/// ```
-pub fn extend_response(
-    state: &State,
-    status: StatusCode,
-    builder: &mut response::Builder,
-    mime: Option<Mime>,
-) {
-    if usize::max_value() > u64::max_value() as usize {
-        error!(
-            "[{}] unable to handle content_length of response, outside u64 bounds",
-            request_id(state)
-        );
-        panic!(
-            "[{}] unable to handle content_length of response, outside u64 bounds",
-            request_id(state)
-        );
-    }
-
-    let builder = if let Some(mime) = mime {
-        builder.header(CONTENT_TYPE, mime.as_ref())
-    } else {
-        builder
-    };
-
-    builder
-        .header(X_REQUEST_ID, request_id(state))
-        .status(status);
-}
-
-/// Sets a number of default headers in a `Response` that ensure security and conformance to
-/// best practice.
-///
-/// # Examples
-///
-/// When `Content-Type` and `Content-Length` are not provided, only the security headers are set on
-/// the response.
-///
-/// ```rust
-/// # extern crate gotham;
-/// # extern crate hyper;
-/// # extern crate mime;
-/// #
-/// # use hyper::{Body, Response, StatusCode};
-/// # use hyper::header::{X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
-/// # use gotham::state::State;
-/// # use gotham::helpers::http::header::X_REQUEST_ID;
-/// # use gotham::helpers::http::response::set_headers;
-/// # use gotham::test::TestServer;
-/// #
-/// fn handler(state: State) -> (State, Response<Body>) {
-///     let mut response = Response::builder().status(StatusCode::ACCEPTED).body(Body::empty()).unwrap();
-///
-///     set_headers(
-///         &state,
-///         &mut response,
-///         None,
-///         None,
-///     );
-///
-///     (state, response)
-/// }
-///
-/// # fn main() {
-/// // Demonstrate the returned headers by making a request to the handler.
-/// let test_server = TestServer::new(|| Ok(handler)).unwrap();
-/// let response = test_server
-///     .client()
-///     .get("http://example.com/")
-///     .perform()
-///     .unwrap();
-///
-/// assert_eq!(response.status(), StatusCode::ACCEPTED);
-///
-/// // e.g.:
-/// // X-Request-Id: 848c651a-fdd8-4859-b671-3f221895675e
-/// # assert!(response.headers().get(X_REQUEST_ID).is_some());
-///
-/// // X-Frame-Options: DENY
-/// assert_eq!(
-///     *response.headers().get(X_FRAME_OPTIONS).unwrap(),
-///     "DENY"
-/// );
-///
-/// // X-XSS-Protection: 1; mode=block
-/// assert_eq!(
-///     *response.headers().get(X_XSS_PROTECTION).unwrap(),
-///     "1; mode=block"
-/// );
-///
-/// // X-Content-Type-Options: nosniff
-/// assert_eq!(
-///     *response.headers().get(X_CONTENT_TYPE_OPTIONS).unwrap(),
-///     "nosniff"
-/// );
-/// # }
-/// ```
-///
-/// When the `Content-Type` and `Content-Length` are included, the headers are set in addition to
-/// the security headers.
-///
-/// ```rust
-/// # extern crate gotham;
-/// # extern crate hyper;
-/// # extern crate mime;
-/// #
-/// # use hyper::{Body, Response, StatusCode};
-/// # use hyper::header::{X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION, CONTENT_LENGTH, CONTENT_TYPE};
-/// # use gotham::state::State;
-/// # use gotham::helpers::http::header::X_REQUEST_ID;
-/// # use gotham::helpers::http::response::set_headers;
-/// # use gotham::test::TestServer;
-/// #
-/// static BODY: &'static [u8] = b"Hello, world!";
-///
-/// fn handler(state: State) -> (State, Response<Body>) {
-///     let mut response = Response::builder().status(StatusCode::OK).body(BODY.into()).unwrap();
-///
-///     set_headers(
-///         &state,
-///         &mut response,
-///         Some(mime::TEXT_PLAIN),
-///         Some(BODY.len() as u64),
-///     );
-///
-///     (state, response)
-/// }
-///
-/// # fn main() {
-/// // Demonstrate the returned headers by making a request to the handler.
-/// let test_server = TestServer::new(|| Ok(handler)).unwrap();
-/// let response = test_server
-///     .client()
-///     .get("http://example.com/")
-///     .perform()
-///     .unwrap();
-///
-/// assert_eq!(response.status(), StatusCode::OK);
-///
-/// assert_eq!(
-///     *response.headers().get(CONTENT_TYPE).unwrap(),
-///     mime::TEXT_PLAIN.to_string()
-/// );
-///
-/// assert_eq!(
-///     *response.headers().get(CONTENT_LENGTH).unwrap(),
-///     format!("{}", BODY.len() as u64)
-/// );
-/// #
-/// # // e.g.:
-/// # // X-Request-Id: 848c651a-fdd8-4859-b671-3f221895675e
-/// # assert!(response.headers().get(X_REQUEST_ID).is_some());
-/// #
-/// # // X-Frame-Options: DENY
-/// # assert_eq!(
-/// #     *response.headers().get(X_FRAME_OPTIONS).unwrap(),
-/// #     "DENY"
-/// # );
-/// #
-/// # // X-XSS-Protection: 1; mode=block
-/// # assert_eq!(
-/// #     *response.headers().get(X_XSS_PROTECTION).unwrap(),
-/// #     "1; mode=block"
-/// # );
-/// #
-/// # // X-Content-Type-Options: nosniff
-/// # assert_eq!(
-/// #     *response.headers().get(X_CONTENT_TYPE_OPTIONS).unwrap(),
-/// #     "nosniff"
-/// # );
-/// # }
-/// ```
-pub fn set_headers<B>(
-    state: &State,
-    res: &mut Response<B>,
-    mime: Option<Mime>,
-    length: Option<u64>,
-) {
-    let headers = res.headers_mut();
-    let content_length = length.unwrap_or(0).to_string();
-
-    headers.insert(CONTENT_LENGTH, content_length.parse().unwrap());
-
-    if let Some(mime) = mime {
-        headers.insert(CONTENT_TYPE, mime.to_string().parse().unwrap());
-    }
-
-    set_request_id(state, headers);
-
-    headers.insert(X_FRAME_OPTIONS, HeaderValue::from_static(XFO_VALUE));
-    headers.insert(X_XSS_PROTECTION, HeaderValue::from_static(XXP_VALUE));
-    headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static(XCTO_VALUE));
-}
-
-/// Sets redirect headers on a given `Response`.
-///
-/// # Examples
-///
-/// ```rust
-/// # extern crate gotham;
-/// # extern crate hyper;
-/// # extern crate mime;
-/// #
-/// # use hyper::{Body, Response, StatusCode};
-/// # use hyper::header::LOCATION;
-/// # use gotham::state::State;
-/// # use gotham::helpers::http::header::X_REQUEST_ID;
-/// # use gotham::helpers::http::response::set_redirect_headers;
-/// # use gotham::test::TestServer;
-/// fn handler(state: State) -> (State, Response<Body>) {
-///     let mut response = Response::builder().status(StatusCode::PERMANENT_REDIRECT).body(Body::empty()).unwrap();
-///
-///     set_redirect_headers(
-///         &state,
-///         &mut response,
-///         "http://example.com/somewhere-else"
-///     );
-///
-///     (state, response)
-/// }
-///
-/// # fn main() {
-/// // Demonstrate the returned headers by making a request to the handler.
-/// let test_server = TestServer::new(|| Ok(handler)).unwrap();
-/// let response = test_server
-///     .client()
-///     .get("http://example.com/")
-///     .perform()
-///     .unwrap();
-///
-/// assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
-///
-/// assert_eq!(
-///     *response.headers().get(LOCATION).unwrap(),
-///     "http://example.com/somewhere-else"
-/// );
-/// # assert!(response.headers().get(X_REQUEST_ID).is_some());
-/// # }
-/// ```
-pub fn set_redirect_headers<B, L: Into<Cow<'static, str>>>(
-    state: &State,
-    res: &mut Response<B>,
-    location: L,
-) {
-    let headers = res.headers_mut();
-    set_request_id(state, headers);
-    headers.insert(LOCATION, location.into().to_string().parse().unwrap());
 }
 
 /// Simple response construction.
@@ -511,18 +200,22 @@ fn construct_response<B: Into<Body>>(
 ) -> Response<Body> {
     let mut builder = Response::builder();
 
-    extend_response(state, status, &mut builder, mime);
+    // always add status and req-id
+    builder.status(status);
+    builder.header(X_REQUEST_ID, request_id(state));
 
+    // attach mime type when available
+    if let Some(mime) = mime {
+        builder.header(CONTENT_TYPE, mime.as_ref());
+    }
+
+    // attach body when available, but not on HEAD requests (which have no content)
     let built = if body.is_some() && Method::borrow_from(state) != Method::HEAD {
         builder.body(body.unwrap().into())
     } else {
         builder.body(Body::empty())
     };
 
+    // this expect should be safe due to generic bounds
     built.expect("Response built from a compatible type")
-}
-
-/// Sets the request id inside a given `HeaderMap`.
-fn set_request_id(state: &State, headers: &mut HeaderMap) {
-    headers.insert(X_REQUEST_ID, request_id(state).parse().unwrap());
 }

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -8,6 +8,7 @@ use handler::HandlerFuture;
 use state::State;
 
 pub mod chain;
+pub mod security;
 pub mod session;
 pub mod state;
 

--- a/gotham/src/middleware/security/mod.rs
+++ b/gotham/src/middleware/security/mod.rs
@@ -1,0 +1,64 @@
+//! Security based middleware to handle security based sanitizations.
+//!
+//! Prior to v0.3, this middleware was baked into responses by default. It has
+//! now been separated to allow optional usage. You can attach as a middleware
+//! at startup to include behaviour as was present before.
+//!
+//! Currently this middleware will set the following headers:
+//!
+//! - X-CONTENT-TYPE-OPTIONS: "nosniff"
+//! - X-FRAME-OPTIONS: "DENY"
+//! - X-XSS-PROTECTION: "1; mode=block"
+//!
+//! More may be added in future, but these headers provide compatibility with
+//! previous versions of Gotham.
+use futures::{future, Future};
+use handler::HandlerFuture;
+use hyper::header::{HeaderValue, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
+use middleware::{Middleware, NewMiddleware};
+use state::State;
+use std::io;
+
+// constant strings to be used as header values
+const XFO_VALUE: &'static str = "DENY";
+const XXP_VALUE: &'static str = "1; mode=block";
+const XCTO_VALUE: &'static str = "nosniff";
+
+/// Middleware binding for the Gotham security handlers.
+///
+/// This acts as nothing more than a trait implementation for the time
+/// being; there are no fields on the struct in use (yet).
+#[derive(Clone)]
+pub struct SecurityMiddleware;
+
+/// `Middleware` trait implementation.
+impl Middleware for SecurityMiddleware {
+    /// Attaches security headers to the response.
+    fn call<Chain>(self, state: State, chain: Chain) -> Box<HandlerFuture>
+    where
+        Chain: FnOnce(State) -> Box<HandlerFuture>,
+    {
+        let f = chain(state).and_then(|(state, mut response)| {
+            {
+                let headers = response.headers_mut();
+
+                headers.insert(X_FRAME_OPTIONS, HeaderValue::from_static(XFO_VALUE));
+                headers.insert(X_XSS_PROTECTION, HeaderValue::from_static(XXP_VALUE));
+                headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static(XCTO_VALUE));
+            }
+            future::ok((state, response))
+        });
+
+        Box::new(f)
+    }
+}
+
+/// `NewMiddleware` trait implementation.
+impl NewMiddleware for SecurityMiddleware {
+    type Instance = Self;
+
+    /// Clones the current middleware to a new instance.
+    fn new_middleware(&self) -> io::Result<Self::Instance> {
+        Ok(self.clone())
+    }
+}


### PR DESCRIPTION
This fixes #269.

This PR will split out the default headers into a `SecurityMiddleware` that users can attach to optionally use security headers. Whilst in the past the headers were enabled by default, there is no way to disable them so I believe this makes a lot of sense.

It also removes a chunk of unnecessary functions from the helper API, instead including some more general helpers. The removed functions were a bit too low-level and prone to change to keep in the public API. 