### PR TITLE
Refactor test requests to remove unnecessary bindings

### DIFF
--- a/gotham/src/router/builder/associated.rs
+++ b/gotham/src/router/builder/associated.rs
@@ -653,7 +653,7 @@ where
     /// # extern crate gotham;
     /// # extern crate hyper;
     /// #
-    /// # use hyper::{Body, Method, Request, Response, StatusCode};
+    /// # use hyper::{Body, Response, StatusCode};
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
     /// # use gotham::state::State;
@@ -675,11 +675,10 @@ where
     /// #
     /// # fn main() {
     /// #   let test_server = TestServer::new(router()).unwrap();
-    /// #   let request = Request::builder()
-    /// #      .method(Method::OPTIONS)
-    /// #      .uri("https://example.com/resource")
-    /// #      .body(Body::empty()).unwrap();
-    /// #   let response = test_server.client().perform(request).unwrap();
+    /// #   let response = test_server.client()
+    /// #       .options("https://example.com/resource")
+    /// #       .perform()
+    /// #       .unwrap();
     /// #   assert_eq!(response.status(), StatusCode::ACCEPTED);
     /// # }
     /// ```

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -325,7 +325,7 @@ where
     /// # extern crate gotham;
     /// # extern crate hyper;
     /// #
-    /// # use hyper::{Body, Method, Request, Response, StatusCode};
+    /// # use hyper::{Body, Response, StatusCode};
     /// # use gotham::state::State;
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
@@ -343,11 +343,10 @@ where
     /// #
     /// # fn main() {
     /// #   let test_server = TestServer::new(router()).unwrap();
-    /// #   let request = Request::builder()
-    /// #     .method(Method::OPTIONS)
-    /// #     .uri("https://example.com/request/path")
-    /// #     .body(Body::empty()).unwrap();
-    /// #   let response = test_server.client().perform(request).unwrap();
+    /// #   let response = test_server.client()
+    /// #       .options("https://example.com/request/path")
+    /// #       .perform()
+    /// #       .unwrap();
     /// #   assert_eq!(response.status(), StatusCode::ACCEPTED);
     /// # }
     /// ```


### PR DESCRIPTION
This fixes #243.

This PR replaces some unnecessary bindings in the test client based on requests, instead opting for using Hyper requests. `TestRequest` dereferences to `Request<Body>`, allowing you to customize the Hyper request directly. I kept the outer structure in case we want to add helpers in future (for example, `with_header` is much easier than the alternative). 

I also removed the `*_uri` functions from the client in favour of accepting `Uri: HttpTryFrom<U>` which reduces a bunch of bloat too.