### PR TITLE
Update the async_handlers example to function with Hyper 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ members = [
     "examples/handlers/request_data",
     "examples/handlers/stateful",
     "examples/handlers/simple_async_handlers",
-    # "examples/handlers/async_handlers",
+    "examples/handlers/async_handlers",
 
     # static_assets
     "examples/static_assets",


### PR DESCRIPTION
This fixes #267.

This PR updates the `async_handlers` example to be compatible with both Gotham and its dependencies. It also reintroduces `examples/handlers/async_handlers` to the workspace.