### PR TITLE
Implement IntoResponse for more type combinations

### DIFF
--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -31,13 +31,13 @@ fn handler(state: State) -> (State, Response<Body>) {
             .unwrap_or_else(|| "first time".to_string())
     };
 
-    let mut response = {
-        create_response(
-            &state,
-            StatusCode::OK,
-            (format!("Hello {} visitor\n", adjective), mime::TEXT_PLAIN),
-        )
-    };
+    let mut response = create_response(
+        &state,
+        StatusCode::OK,
+        mime::TEXT_PLAIN,
+        format!("Hello {} visitor\n", adjective),
+    );
+
     {
         let cookie = Cookie::build("adjective", "repeat")
             .http_only(true)
@@ -46,6 +46,7 @@ fn handler(state: State) -> (State, Response<Body>) {
             .headers_mut()
             .append(SET_COOKIE, cookie.to_string().parse().unwrap());
     }
+
     (state, response)
 }
 

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -111,7 +111,7 @@ fn series_handler(mut state: State) -> Box<HandlerFuture> {
     // All we do is move `state` in, to return it, and convert any errors that we have.
     Box::new(data_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("series length: {} finished", length);
             Ok((state, res))
         }
@@ -161,7 +161,7 @@ fn loop_handler(mut state: State) -> Box<HandlerFuture> {
 
     Box::new(data_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("loop length: {} finished", length);
             Ok((state, res))
         }
@@ -225,7 +225,7 @@ fn parallel_handler(mut state: State) -> Box<HandlerFuture> {
 
     Box::new(data_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("parallel length: {} finished", length);
             Ok((state, res))
         }

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -85,7 +85,7 @@ fn sleep_handler(mut state: State) -> Box<HandlerFuture> {
     // IntoHandlerError.
     Box::new(sleep_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("sleep for {} seconds once: finished", seconds);
             Ok((state, res))
         }
@@ -119,7 +119,7 @@ fn loop_handler(mut state: State) -> Box<HandlerFuture> {
     // This bit is the same as the bit in the first example.
     Box::new(sleep_future.then(move |result| match result {
         Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, (data, mime::TEXT_PLAIN));
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("sleep for one second {} times: finished", seconds);
             Ok((state, res))
         }

--- a/examples/handlers/stateful/src/main.rs
+++ b/examples/handlers/stateful/src/main.rs
@@ -6,13 +6,11 @@ extern crate hyper;
 extern crate mime;
 
 use futures::future;
-use hyper::StatusCode;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use gotham::error::Result;
-use gotham::handler::{Handler, HandlerFuture, NewHandler};
-use gotham::helpers::http::response::create_response;
+use gotham::handler::{Handler, HandlerFuture, IntoResponse, NewHandler};
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
@@ -56,8 +54,9 @@ impl Handler for CountingHandler {
             visits
         );
 
-        let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, response_text);
-        Box::new(future::ok((state, res)))
+        let response = response_text.into_response(&state);
+
+        Box::new(future::ok((state, response)))
     }
 }
 
@@ -85,6 +84,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn counter_increments_per_request() {

--- a/examples/handlers/stateful/src/main.rs
+++ b/examples/handlers/stateful/src/main.rs
@@ -56,7 +56,7 @@ impl Handler for CountingHandler {
             visits
         );
 
-        let res = { create_response(&state, StatusCode::OK, (response_text, mime::TEXT_PLAIN)) };
+        let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, response_text);
         Box::new(future::ok((state, res)))
     }
 }

--- a/examples/headers/setting/src/main.rs
+++ b/examples/headers/setting/src/main.rs
@@ -13,6 +13,7 @@ use hyper::{Body, Response, StatusCode};
 /// Create a `Handler` that adds a custom header.
 pub fn handler(state: State) -> (State, Response<Body>) {
     let mut res = create_empty_response(&state, StatusCode::OK);
+
     {
         let headers = res.headers_mut();
         headers.insert("x-gotham", "Hello World!".parse().unwrap());

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -4,9 +4,6 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::state::State;
 
 const HELLO_WORLD: &'static str = "Hello World!";
@@ -31,6 +28,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn receive_hello_world_response() {

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -17,7 +17,7 @@ const HELLO_WORLD: &'static str = "Hello World!";
 /// We've simply implemented the `Handler` trait, for functions that match the signature used here,
 /// within Gotham itself.
 pub fn say_hello(state: State) -> (State, Response<Body>) {
-    let res = create_response(&state, StatusCode::OK, (HELLO_WORLD, mime::TEXT_PLAIN));
+    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, HELLO_WORLD);
 
     (state, res)
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -16,10 +16,8 @@ const HELLO_WORLD: &'static str = "Hello World!";
 /// How does a function become a `Handler`?.
 /// We've simply implemented the `Handler` trait, for functions that match the signature used here,
 /// within Gotham itself.
-pub fn say_hello(state: State) -> (State, Response<Body>) {
-    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, HELLO_WORLD);
-
-    (state, res)
+pub fn say_hello(state: State) -> (State, &'static str) {
+    (state, HELLO_WORLD)
 }
 
 /// Start a server and call the `Handler` we've defined above for each `Request` we receive.

--- a/examples/into_response/introduction/src/main.rs
+++ b/examples/into_response/introduction/src/main.rs
@@ -30,15 +30,13 @@ struct Product {
 /// This trait implementation uses the Serde project when generating responses. You don't need to
 /// know about Serde in order to understand the response that is being created here but if you're
 /// interested you can learn more at `http://serde.rs`.
-impl IntoResponse<Body> for Product {
+impl IntoResponse for Product {
     fn into_response(self, state: &State) -> Response<Body> {
         create_response(
             state,
             StatusCode::OK,
-            (
-                serde_json::to_string(&self).expect("serialized product"),
-                mime::APPLICATION_JSON,
-            ),
+            mime::APPLICATION_JSON,
+            serde_json::to_string(&self).expect("serialized product"),
         )
     }
 }

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -38,7 +38,7 @@ fn parts_handler(state: State) -> (State, Response<Body>) {
             response_string.push_str(&part);
         }
 
-        create_response(&state, StatusCode::OK, (response_string, mime::TEXT_PLAIN))
+        create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, response_string)
     };
 
     (state, res)

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -9,9 +9,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
@@ -24,7 +21,7 @@ struct PathExtractor {
     parts: Vec<String>,
 }
 
-fn parts_handler(state: State) -> (State, Response<Body>) {
+fn parts_handler(state: State) -> (State, String) {
     let res = {
         let path = PathExtractor::borrow_from(&state);
 
@@ -33,12 +30,13 @@ fn parts_handler(state: State) -> (State, Response<Body>) {
             path.parts.len(),
             if path.parts.len() == 1 { "" } else { "s" }
         );
+
         for part in path.parts.iter() {
             response_string.push_str("\n");
             response_string.push_str(&part);
         }
 
-        create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, response_string)
+        response_string
     };
 
     (state, res)
@@ -64,6 +62,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn empty_glob_does_not_match() {

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -10,9 +10,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
@@ -47,8 +44,8 @@ struct PathExtractor {
 }
 
 /// Handler function for `GET` requests directed to `/products/:name`
-fn get_product_handler(state: State) -> (State, Response<Body>) {
-    let res = {
+fn get_product_handler(state: State) -> (State, String) {
+    let message = {
         // Access the `PathExtractor` instance from `state` which was put there for us by the
         // `Router` during request evaluation.
         //
@@ -56,15 +53,10 @@ fn get_product_handler(state: State) -> (State, Response<Body>) {
         // struct automatically gains the `borrow_from` method and a number of other methods
         // via the `gotham::state::FromState` trait.
         let product = PathExtractor::borrow_from(&state);
-        create_response(
-            &state,
-            StatusCode::OK,
-            mime::TEXT_PLAIN,
-            format!("Product: {}", product.name),
-        )
+        format!("Product: {}", product.name)
     };
 
-    (state, res)
+    (state, message)
 }
 
 /// Create a `Router`
@@ -94,6 +86,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn product_name_is_extracted() {

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -59,7 +59,8 @@ fn get_product_handler(state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            (format!("Product: {}", product.name), mime::TEXT_PLAIN),
+            mime::TEXT_PLAIN,
+            format!("Product: {}", product.name),
         )
     };
 

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -22,15 +22,13 @@ struct PathExtractor {
 }
 
 /// Create a `Handler` that is invoked for requests using a numeric identifier.
-pub fn greet_user(state: State) -> (State, Response<Body>) {
-    let res = {
+pub fn greet_user(state: State) -> (State, String) {
+    let message = {
         let path = PathExtractor::borrow_from(&state);
-        let response_string = format!("Hello, User {}!", &path.id);
-
-        create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, response_string)
+        format!("Hello, User {}!", &path.id)
     };
 
-    (state, res)
+    (state, message)
 }
 
 /// Create a `Router`

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -27,7 +27,7 @@ pub fn greet_user(state: State) -> (State, Response<Body>) {
         let path = PathExtractor::borrow_from(&state);
         let response_string = format!("Hello, User {}!", &path.id);
 
-        create_response(&state, StatusCode::OK, (response_string, mime::TEXT_PLAIN))
+        create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, response_string)
     };
 
     (state, res)

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -9,9 +9,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
@@ -62,6 +59,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn receive_hello_router_response() {

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -11,9 +11,6 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
@@ -108,6 +105,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn product_name_is_extracted() {

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -77,10 +77,8 @@ fn get_product_handler(mut state: State) -> (State, Response<Body>) {
         create_response(
             &state,
             StatusCode::OK,
-            (
-                serde_json::to_vec(&product).expect("serialized product"),
-                mime::APPLICATION_JSON,
-            ),
+            mime::APPLICATION_JSON,
+            serde_json::to_vec(&product).expect("serialized product"),
         )
     };
     (state, res)

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -58,7 +58,7 @@ struct Product {
 /// This handler uses the Serde project when generating responses. You don't need to
 /// know about Serde in order to understand the response that is being created here but if you're
 /// interested you can learn more at `http://serde.rs`.
-fn get_product_handler(mut state: State) -> (State, Response<Body>) {
+fn get_product_handler(mut state: State) -> (State, (mime::Mime, Vec<u8>)) {
     let res = {
         // Access the `QueryStringExtractor` instance from `state` which was put there for us by the
         // `Router` during request evaluation.
@@ -74,9 +74,8 @@ fn get_product_handler(mut state: State) -> (State, Response<Body>) {
         let product = Product {
             name: query_param.name,
         };
-        create_response(
-            &state,
-            StatusCode::OK,
+
+        (
             mime::APPLICATION_JSON,
             serde_json::to_vec(&product).expect("serialized product"),
         )

--- a/examples/routing/associations/src/handlers.rs
+++ b/examples/routing/associations/src/handlers.rs
@@ -3,22 +3,13 @@
 //! We've used a macro here for brevity but this is NOT how you would implement a handler in
 //! a real world application.
 
-use gotham::helpers::http::response::create_response;
+use gotham::handler::IntoResponse;
 use gotham::state::State;
-use hyper::{Body, Response, StatusCode};
-use mime;
 
 macro_rules! generic_handler {
     ($($t:ident),*) => { $(
-        pub fn $t(state: State) -> (State, Response<Body>) {
-            let res = create_response(
-                &state,
-                StatusCode::OK,
-                mime::TEXT_PLAIN,
-                stringify!($t),
-            );
-
-            (state, res)
+        pub fn $t(state: State) -> (State, impl IntoResponse) {
+            (state, stringify!($t))
         }
     )+ }}
 

--- a/examples/routing/associations/src/handlers.rs
+++ b/examples/routing/associations/src/handlers.rs
@@ -14,7 +14,8 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                (stringify!($t), mime::TEXT_PLAIN),
+                mime::TEXT_PLAIN,
+                stringify!($t),
             );
 
             (state, res)

--- a/examples/routing/http_verbs/src/handlers.rs
+++ b/examples/routing/http_verbs/src/handlers.rs
@@ -3,22 +3,13 @@
 //! We've used a macro here for brevity but this is NOT how you would implement a handler in
 //! a real world application.
 
-use gotham::helpers::http::response::create_response;
+use gotham::handler::IntoResponse;
 use gotham::state::State;
-use hyper::{Body, Response, StatusCode};
-use mime;
 
 macro_rules! generic_handler {
     ($($t:ident),*) => { $(
-        pub fn $t(state: State) -> (State, Response<Body>) {
-            let res = create_response(
-                &state,
-                StatusCode::OK,
-                mime::TEXT_PLAIN,
-                stringify!($t),
-            );
-
-            (state, res)
+        pub fn $t(state: State) -> (State, impl IntoResponse) {
+            (state, stringify!($t))
         }
     )+ }}
 

--- a/examples/routing/http_verbs/src/handlers.rs
+++ b/examples/routing/http_verbs/src/handlers.rs
@@ -14,7 +14,8 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                (stringify!($t), mime::TEXT_PLAIN),
+                mime::TEXT_PLAIN,
+                stringify!($t),
             );
 
             (state, res)

--- a/examples/routing/introduction/src/main.rs
+++ b/examples/routing/introduction/src/main.rs
@@ -6,7 +6,6 @@ extern crate mime;
 
 use hyper::{Body, Response, StatusCode};
 
-use gotham::helpers::http::response::create_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
@@ -14,10 +13,8 @@ use gotham::state::State;
 const HELLO_ROUTER: &'static str = "Hello Router!";
 
 /// Create a `Handler` that is invoked for requests to the path "/"
-pub fn say_hello(state: State) -> (State, Response<Body>) {
-    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, HELLO_ROUTER);
-
-    (state, res)
+pub fn say_hello(state: State) -> (State, &'static str) {
+    (state, HELLO_ROUTER)
 }
 
 /// Create a `Router`

--- a/examples/routing/introduction/src/main.rs
+++ b/examples/routing/introduction/src/main.rs
@@ -4,8 +4,6 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Body, Response, StatusCode};
-
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
@@ -45,6 +43,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn receive_hello_router_response() {

--- a/examples/routing/introduction/src/main.rs
+++ b/examples/routing/introduction/src/main.rs
@@ -15,7 +15,7 @@ const HELLO_ROUTER: &'static str = "Hello Router!";
 
 /// Create a `Handler` that is invoked for requests to the path "/"
 pub fn say_hello(state: State) -> (State, Response<Body>) {
-    let res = create_response(&state, StatusCode::OK, (HELLO_ROUTER, mime::TEXT_PLAIN));
+    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, HELLO_ROUTER);
 
     (state, res)
 }

--- a/examples/routing/scopes/src/handlers.rs
+++ b/examples/routing/scopes/src/handlers.rs
@@ -3,22 +3,13 @@
 //! We've used a macro here for brevity but this is NOT how you would implement a handler in
 //! a real world application.
 
-use gotham::helpers::http::response::create_response;
+use gotham::handler::IntoResponse;
 use gotham::state::State;
-use hyper::{Body, Response, StatusCode};
-use mime;
 
 macro_rules! generic_handler {
     ($($t:ident),*) => { $(
-        pub fn $t(state: State) -> (State, Response<Body>) {
-            let res = create_response(
-                &state,
-                StatusCode::OK,
-                mime::TEXT_PLAIN,
-                stringify!($t),
-            );
-
-            (state, res)
+        pub fn $t(state: State) -> (State, impl IntoResponse) {
+            (state, stringify!($t))
         }
     )+ }}
 

--- a/examples/routing/scopes/src/handlers.rs
+++ b/examples/routing/scopes/src/handlers.rs
@@ -14,7 +14,8 @@ macro_rules! generic_handler {
             let res = create_response(
                 &state,
                 StatusCode::OK,
-                (stringify!($t), mime::TEXT_PLAIN),
+                mime::TEXT_PLAIN,
+                stringify!($t),
             );
 
             (state, res)

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -45,7 +45,9 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         ),
         &None => "You have never visited this page before.\n".to_owned(),
     };
-    let res = { create_response(&state, StatusCode::OK, (body, mime::TEXT_PLAIN)) };
+
+    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, body);
+
     {
         let visit_data: &mut Option<VisitData> =
             SessionData::<Option<VisitData>>::borrow_mut_from(&mut state);
@@ -55,6 +57,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
             last_visit: format!("{}", time::now().rfc3339()),
         });
     }
+
     (state, res)
 }
 

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -12,9 +12,6 @@ extern crate serde_derive;
 extern crate cookie;
 extern crate time;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
@@ -32,7 +29,7 @@ struct VisitData {
 /// Handler function for `GET` requests directed to `/`
 ///
 /// Each request made will update state about your recent visits, and report it back.
-fn get_handler(mut state: State) -> (State, Response<Body>) {
+fn get_handler(mut state: State) -> (State, String) {
     let maybe_visit_data = {
         let visit_data: &Option<VisitData> = SessionData::<Option<VisitData>>::borrow_from(&state);
         visit_data.clone()
@@ -46,8 +43,6 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         &None => "You have never visited this page before.\n".to_owned(),
     };
 
-    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, body);
-
     {
         let visit_data: &mut Option<VisitData> =
             SessionData::<Option<VisitData>>::borrow_mut_from(&mut state);
@@ -58,7 +53,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         });
     }
 
-    (state, res)
+    (state, body)
 }
 
 /// Create a `Router`
@@ -87,6 +82,7 @@ mod tests {
     use super::*;
     use gotham::test::TestServer;
     use hyper::header::{COOKIE, SET_COOKIE};
+    use hyper::StatusCode;
 
     #[test]
     fn cookie_is_set_and_updates_response() {

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -20,7 +20,7 @@ use gotham::state::{FromState, State};
 ///
 /// Each request made will increment a counter of requests which have been made,
 /// and tell you how many times you've visited the page.
-fn get_handler(mut state: State) -> (State, Response<Body>) {
+fn get_handler(mut state: State) -> (State, String) {
     // Define a narrow scope so that state can be borrowed/moved later in the function.
     let visits = {
         // Borrow a reference to the usize stored for the session (keyed by a cookie) from state.
@@ -29,12 +29,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         *visits
     };
 
-    let res = create_response(
-        &state,
-        StatusCode::OK,
-        mime::TEXT_PLAIN,
-        format!("You have visited this page {} time(s) before\n", visits),
-    );
+    let message = format!("You have visited this page {} time(s) before\n", visits);
 
     {
         // Mutably borrow the usize, so we can increment it.
@@ -42,7 +37,7 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         *visits += 1;
     }
 
-    (state, res)
+    (state, message)
 }
 
 /// Create a `Router`

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -6,9 +6,6 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
@@ -73,6 +70,7 @@ mod tests {
     use cookie::Cookie;
     use gotham::test::TestServer;
     use hyper::header::{COOKIE, SET_COOKIE};
+    use hyper::StatusCode;
 
     #[test]
     fn cookie_is_set_and_counter_increments() {

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -29,21 +29,19 @@ fn get_handler(mut state: State) -> (State, Response<Body>) {
         *visits
     };
 
-    let res = {
-        create_response(
-            &state,
-            StatusCode::OK,
-            (
-                format!("You have visited this page {} time(s) before\n", visits),
-                mime::TEXT_PLAIN,
-            ),
-        )
-    };
+    let res = create_response(
+        &state,
+        StatusCode::OK,
+        mime::TEXT_PLAIN,
+        format!("You have visited this page {} time(s) before\n", visits),
+    );
+
     {
         // Mutably borrow the usize, so we can increment it.
         let visits: &mut usize = SessionData::<usize>::borrow_mut_from(&mut state);
         *visits += 1;
     }
+
     (state, res)
 }
 

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -57,7 +57,7 @@ impl RequestCounter {
 /// The request counter is shared via the state, so we can safely
 /// borrow one from the provided state. As the counter uses locks
 /// internally, we don't have to borrow a mutable reference either!
-fn say_hello(state: State) -> (State, Response<Body>) {
+fn say_hello(state: State) -> (State, String) {
     let message = {
         // borrow a reference of the counter from the state
         let counter = RequestCounter::borrow_from(&state);
@@ -66,11 +66,8 @@ fn say_hello(state: State) -> (State, Response<Body>) {
         format!("Hello from request #{}!\n", counter.incr())
     };
 
-    // create the response
-    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, message);
-
-    // done!
-    (state, res)
+    // return message
+    (state, message)
 }
 
 /// Constructs a simple router on `/` to say hello, along with

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -9,9 +9,6 @@ extern crate gotham_derive;
 extern crate hyper;
 extern crate mime;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::middleware::state::StateMiddleware;
 use gotham::pipeline::single::single_pipeline;
 use gotham::pipeline::single_middleware;
@@ -103,6 +100,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn receive_incrementing_hello_response() {

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -67,8 +67,7 @@ fn say_hello(state: State) -> (State, Response<Body>) {
     };
 
     // create the response
-    let body = (message, mime::TEXT_PLAIN);
-    let res = create_response(&state, StatusCode::OK, body);
+    let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, message);
 
     // done!
     (state, res)

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -8,9 +8,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate tera;
 
-use hyper::{Body, Response, StatusCode};
-
-use gotham::helpers::http::response::create_response;
 use gotham::state::State;
 use tera::{Context, Tera};
 
@@ -44,6 +41,7 @@ pub fn main() {
 mod tests {
     use super::*;
     use gotham::test::TestServer;
+    use hyper::StatusCode;
 
     #[test]
     fn receive_hello_world_response() {

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -29,7 +29,7 @@ pub fn say_hello(state: State) -> (State, Response<Body>) {
     context.insert("user", "Gotham");
     let rendered = TERA.render("example.html.tera", &context).unwrap();
 
-    let res = create_response(&state, StatusCode::OK, (rendered, mime::TEXT_HTML));
+    let res = create_response(&state, StatusCode::OK, mime::TEXT_HTML, rendered);
 
     (state, res)
 }

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -24,14 +24,12 @@ lazy_static! {
 /// Create a `Handler` which calls the Tera static reference, renders
 /// a template with a given Context, and returns the result as a String
 /// to be used as Response Body
-pub fn say_hello(state: State) -> (State, Response<Body>) {
+pub fn say_hello(state: State) -> (State, (mime::Mime, String)) {
     let mut context = Context::new();
     context.insert("user", "Gotham");
     let rendered = TERA.render("example.html.tera", &context).unwrap();
 
-    let res = create_response(&state, StatusCode::OK, mime::TEXT_HTML, rendered);
-
-    (state, res)
+    (state, (mime::TEXT_HTML, rendered))
 }
 
 /// Start a server and call the `Handler` we've defined above for each `Request` we receive.

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -48,7 +48,8 @@ use state::{State, StateData};
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         (body, mime::TEXT_PLAIN),
+///         mime::TEXT_PLAIN,
+///         body,
 ///     );
 ///
 ///     (state, response)

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -56,7 +56,8 @@ use state::{State, StateData};
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         (body, mime::TEXT_PLAIN),
+///         mime::TEXT_PLAIN,
+///         body,
 ///     );
 ///
 ///     (state, response)

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -127,7 +127,7 @@ impl HandlerError {
     }
 }
 
-impl IntoResponse<Body> for HandlerError {
+impl IntoResponse for HandlerError {
     fn into_response(self, state: &State) -> Response<Body> {
         debug!(
             "[{}] HandlerError generating {} {} response: {}",

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -34,7 +34,8 @@ use state::{request_id, FromState, State};
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         (BODY, mime::TEXT_PLAIN),
+///         mime::TEXT_PLAIN,
+///         BODY,
 ///     );
 ///
 ///     (state, response)
@@ -62,14 +63,10 @@ use state::{request_id, FromState, State};
 /// #     );
 /// # }
 /// ```
-pub fn create_response<B: Into<Body>>(
-    state: &State,
-    status: StatusCode,
-    data: (B, Mime),
-) -> Response<Body> {
-    // unwrap the data for the body
-    let (body, mime) = data;
-
+pub fn create_response<B>(state: &State, status: StatusCode, mime: Mime, body: B) -> Response<Body>
+where
+    B: Into<Body>,
+{
     // use the basic empty response as a base
     let mut res = create_empty_response(state, status);
 

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -222,7 +222,8 @@ impl SessionCookieConfig {
 ///
 ///     let response = create_response(&state,
 ///                                    StatusCode::OK,
-///                                    (body, mime::TEXT_PLAIN));
+///                                    mime::TEXT_PLAIN,
+///                                    body);
 ///
 ///     (state, response)
 /// }

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -92,7 +92,8 @@ use state::{request_id, State};
 ///
 ///     let res = create_response(&state,
 ///                               StatusCode::OK,
-///                               (body, mime::TEXT_PLAIN));
+///                               mime::TEXT_PLAIN,
+///                               body);
 ///
 ///     (state, res)
 /// }

--- a/gotham/src/state/client_addr.rs
+++ b/gotham/src/state/client_addr.rs
@@ -35,7 +35,8 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 ///     let response = create_response(
 ///         &state,
 ///         StatusCode::OK,
-///         (body, mime::TEXT_PLAIN),
+///         mime::TEXT_PLAIN,
+///         body,
 ///     );
 ///
 ///     (state, response)

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -338,7 +338,8 @@ trait BodyReader {
 /// #   let body = "This is the body content.".to_string();
 /// #   let response = create_response(&state,
 /// #                                  StatusCode::OK,
-/// #                                  (body, mime::TEXT_PLAIN));
+/// #                                  mime::TEXT_PLAIN,
+/// #                                  body);
 /// #
 /// #   (state, response)
 /// # }
@@ -565,7 +566,7 @@ mod tests {
                     Ok(body) => {
                         let resp_data = body.to_vec();
                         let res =
-                            create_response(&state, StatusCode::OK, (resp_data, mime::TEXT_PLAIN));
+                            create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, resp_data);
                         future::ok((state, res))
                     }
 


### PR DESCRIPTION
This fixes #277, kinda.

This PR will introduce some new constructs for returning responses, namely:

```rust
Into<Body>
(Mime, Into<Body>)
(StatusCode, Mime, Into<Body>)
```

There are a few things to note:

- We can't actually implement for `Into<Body>` due to clashes with `Response<Body>`, so they're manually derived for the meantime (somewhat annoying, but not the end of the world).
- The default mime type is `TEXT_PLAIN`; not sure if it should be something else?
- The default status code is `OK`. 

Each implementation just passes through to the next, and the actual response is built using the `create_response` function in the helper - to keep things consistent. I adjusted the signature there to align with the new types as well. 

The idea is that `create_response` is now only needed when you need to do something to the response itself manually; such as changing headers, and so on. If you only care about status/mime/body, you can just return a Tuple (which should theoretically work for a lot of cases).

In doing all of this, the generic type `B` was removed from `IntoResponse` - which isn't breaking as it was introduced between `0.2.1` and now anyway. I think aligning on `Body` for the response body type makes sense at least for the time being.

Finally I removed `construct_response` in favour of making `create_empty_response` the base response creator. I doubt there's much overhead to doing it this way, and even so it makes the code more readable so likely a non-issue.

A few remaining questions I'd like opinions on:

1. Given that the point of this is to discourage `create_response` directly, should I update all examples to use these new formats?
2. Should `create_response` simply become a function that accepts `State, IntoResponse`? It can then just attach any default headers (etc.) onto the returned response.
3. Is `TEXT_PLAIN` an appropriate default mime type?