### PR TITLE
Add POST handler (application/x-www-form-urlencoded) example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "examples/handlers/stateful",
     "examples/handlers/simple_async_handlers",
     "examples/handlers/async_handlers",
+    "examples/handlers/form_urlencoded",
 
     # static_assets
     "examples/static_assets",

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ information on functionality and ordering.
 | [Cookies](cookies) | Working with Cookies. | 1 |
 | [Sessions](sessions) | Working with Sessions. | 2 |
 | [Headers](headers) | Working with HTTP Headers. | 1 |
-| [Handlers](handlers) | Developing application logic that responds to web requests. | 4 |
+| [Handlers](handlers) | Developing application logic that responds to web requests. | 5 |
 | [Middleware](middleware) | Developing custom middleware for your application. | 1 |
 | [Shared State](stared_state) | Sharing state across your application. | 1 |
 | [Into Response](into_response) | Implementing the Gotham web framework's `IntoResponse` trait. | 1 |

--- a/examples/handlers/form_urlencoded/Cargo.toml
+++ b/examples/handlers/form_urlencoded/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gotham_examples_handlers_form_urlencoded"
+description = "An example of decoding requests from an HTML form element"
+version = "0.0.0"
+authors = ["Jacob Budin <self@jacobbudin.com>"]
+publish = false
+
+[dependencies]
+gotham = { path = "../../../gotham" }
+
+hyper = "0.12"
+mime = "0.3"
+futures = "0.1"
+url = "1.6"

--- a/examples/handlers/form_urlencoded/README.md
+++ b/examples/handlers/form_urlencoded/README.md
@@ -1,0 +1,36 @@
+# HTML Form Parsing
+
+An example showing how to decode requests from an HTML form element with `Content-Type: application/x-www-form-urlencoded` data.
+
+## Running
+
+From the `examples/handlers/form_urlencoded` directory:
+
+```
+Terminal 1:
+  $ cargo run
+     Compiling handlers/form_urlencoded (file:///.../examples/handlers/form_urlencoded)
+      Finished dev [unoptimized + debuginfo] target(s) in 4.26 secs
+       Running `../handlers/form_urlencoded`
+  Listening for requests at http://127.0.0.1:7878
+
+Terminal 2:
+  $ curl -d name=Bob -d address="123 Jersey Ave." -d message="Hello world!" http://127.0.0.1:7878/
+  name: Bob
+  address: 123 Jersey Ave.
+  message: Hello world!
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/handlers/form_urlencoded/src/main.rs
+++ b/examples/handlers/form_urlencoded/src/main.rs
@@ -1,0 +1,81 @@
+//! An example of decoding requests from an HTML form element
+
+extern crate futures;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate url;
+
+use futures::{future, Future, Stream};
+use hyper::{Body, StatusCode};
+use url::form_urlencoded;
+
+use gotham::handler::{HandlerFuture, IntoHandlerError};
+use gotham::helpers::http::response::create_response;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::router::Router;
+use gotham::state::{FromState, State};
+
+/// Extracts the elements of the POST request and responds with the form keys and values
+fn form_handler(mut state: State) -> Box<HandlerFuture> {
+    let f = Body::take_from(&mut state)
+        .concat2()
+        .then(|full_body| match full_body {
+            Ok(valid_body) => {
+                let body_content = valid_body.into_bytes();
+                // Perform decoding on request body
+                let form_data = form_urlencoded::parse(&body_content).into_owned();
+                // Add form keys and values to response body
+                let mut res_body = String::new();
+                for (key, value) in form_data {
+                    let res_body_line = format!("{}: {}\n", key, value);
+                    res_body.push_str(&res_body_line);
+                }
+                let res = create_response(&state, StatusCode::OK, (res_body, mime::TEXT_PLAIN));
+                future::ok((state, res))
+            }
+            Err(e) => return future::err((state, e.into_handler_error())),
+        });
+
+    Box::new(f)
+}
+
+/// Create a `Router`
+fn router() -> Router {
+    build_simple_router(|route| {
+        route.post("/").to(form_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn form_request() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .post(
+                "http://localhost",
+                "name=Bob&address=123+Jersey Ave.&message=Hello world%21",
+                mime::APPLICATION_WWW_FORM_URLENCODED,
+            ).perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.read_body().unwrap();
+        assert_eq!(
+            body,
+            "name: Bob\naddress: 123 Jersey Ave.\nmessage: Hello world!\n".as_bytes()
+        );
+    }
+}


### PR DESCRIPTION
This fixes #113.

This PR adds a POST handler example for `Content-Type: application/x-www-form-urlencoded` requests.