### PR TITLE
router.to_async(), simple async/.await examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "examples/handlers/request_data",
     "examples/handlers/stateful",
     "examples/handlers/simple_async_handlers",
+    "examples/handlers/simple_async_handlers_await",
     "examples/handlers/async_handlers",
     "examples/handlers/form_urlencoded",
     "examples/handlers/multipart",

--- a/examples/handlers/README.md
+++ b/examples/handlers/README.md
@@ -18,6 +18,7 @@ We recommend reviewing our handler examples in the order shown below:
 1. [Request Data](request_data) - Accessing common request information
 1. [Stateful Handlers](stateful) - Keeping state in a handler
 1. [Simple Async Handlers](simple_async_handlers) - Async Request Handlers 101
+1. [Simple Async Handlers (.await version)](simple_async_handlers_await) - Request Handlers that use async/.await
 1. [Async Handlers](async_handlers) - More complicated async request handlers
 
 ## Help

--- a/examples/handlers/simple_async_handlers/README.md
+++ b/examples/handlers/simple_async_handlers/README.md
@@ -24,6 +24,9 @@ find yourself doing lots of CPU/memory intensive operations on the web server,
 then futures are probably not going to help your performance, and you might be
 better off spawning a new thread per request.
 
+If you came here looking for an example that uses async/.await, please read
+[Async Request Handlers (.await version)](../simple_async_handlers).
+
 ## Running
 
 From the `examples/handlers/async_handlers` directory:

--- a/examples/handlers/simple_async_handlers/README.md
+++ b/examples/handlers/simple_async_handlers/README.md
@@ -25,7 +25,7 @@ then futures are probably not going to help your performance, and you might be
 better off spawning a new thread per request.
 
 If you came here looking for an example that uses async/.await, please read
-[Async Request Handlers (.await version)](../simple_async_handlers).
+[Async Request Handlers (.await version)](../simple_async_handlers_await).
 
 ## Running
 

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-mime = "0.3.16"
+mime = "0.3"
 futures = "0.3.1"
-serde = "1.0.104"
-serde_derive = "1.0.104"
+serde = "1.0"
+serde_derive = "1.0"
 tokio = "0.2.9"

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gotham_examples_handlers_simple_async_handlers"
+description = "An example that does asynchronous work before responding"
+version = "0.0.0"
+authors = ["David Laban <alsuren@gmail.com>"]
+publish = false
+
+[dependencies]
+gotham = { path = "../../../gotham" }
+gotham_derive = { path = "../../../gotham_derive" }
+
+hyper = "0.12"
+mime = "0.3"
+futures = "0.1"
+serde = "1.0"
+serde_derive = "1.0"
+tokio = "0.1"

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "gotham_examples_handlers_simple_async_handlers"
+name = "gotham_examples_handlers_simple_async_handlers_await"
 description = "An example that does asynchronous work before responding"
 version = "0.0.0"
 authors = ["David Laban <alsuren@gmail.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
@@ -11,7 +12,12 @@ gotham_derive = { path = "../../../gotham_derive" }
 
 hyper = "0.12"
 mime = "0.3"
-futures = "0.1"
+# We need two versions of the futures library. One that matches what Gotham
+# understands, and one that matches what .await understands. Stolen from:
+# https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html
+# (although they call the old version futures01 and we call it legacy_futures)
+legacy_futures = {package = "futures", version = "0.1"}
+futures = {package = "futures", version = "0.3.1", features = ["compat"]}
 serde = "1.0"
 serde_derive = "1.0"
 tokio = "0.1"

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -10,14 +10,8 @@ edition = "2018"
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.13.1"
 mime = "0.3.16"
-# We need two versions of the futures library. One that matches what Gotham
-# understands, and one that matches what .await understands. Stolen from:
-# https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html
-# (although they call the old version futures01 and we call it legacy_futures)
-legacy_futures = {package = "futures", version = "0.1"}
-futures = { package = "futures", version = "0.3.1", features = ["compat"] }
+futures = "0.3.1"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 tokio = "0.2.9"

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
-mime = "0.3"
+hyper = "0.13.1"
+mime = "0.3.16"
 # We need two versions of the futures library. One that matches what Gotham
 # understands, and one that matches what .await understands. Stolen from:
 # https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html
 # (although they call the old version futures01 and we call it legacy_futures)
 legacy_futures = {package = "futures", version = "0.1"}
-futures = {package = "futures", version = "0.3.1", features = ["compat"]}
-serde = "1.0"
-serde_derive = "1.0"
-tokio = "0.1"
+futures = { package = "futures", version = "0.3.1", features = ["compat"] }
+serde = "1.0.104"
+serde_derive = "1.0.104"
+tokio = "0.2.9"

--- a/examples/handlers/simple_async_handlers_await/README.md
+++ b/examples/handlers/simple_async_handlers_await/README.md
@@ -1,0 +1,65 @@
+# Async Request Handlers
+
+The idea of async handlers has already been introduced by the post_handler example in
+[Request Data](../request_data), which waits for the POST body asyncronously, and resolves
+the response future once it has processed the body.
+
+This example contains a pair of endpoints that sleep for a number of seconds,
+in different ways. Note that we never call `std::thread::sleep` in this example,
+so none of our request handlers block the thread from handling other requests
+in parallel. Instead, in each case, we return a future, which will resolve when
+the requested time has elapsed, and cause Gotham to respond to the http request.
+
+The approach of using futures to track the status of long-running operations
+is significantly lower overhead than that of spawning a new thread per request.
+In our case, the long-running operations are sleeps, but in
+[Async Handlers](../async_handlers), the long-running operations are http
+requests.
+
+You will often find that most of the time that a web server spends dealing
+with a web request, it is waiting on another service (e.g. a database, or an
+external api). If you can track these operations using futures, you should end
+up with a very lightweight and performant web server. On the other hand, if you
+find yourself doing lots of CPU/memory intensive operations on the web server,
+then futures are probably not going to help your performance, and you might be
+better off spawning a new thread per request.
+
+## Running
+
+From the `examples/handlers/async_handlers` directory:
+
+```
+Terminal 1:
+   Compiling gotham_examples_handlers_simple_async_handlers v0.0.0 (file:///.../gotham/examples/handlers/simple_async_handlers)
+    Finished dev [unoptimized + debuginfo] target(s) in 8.19 secs
+     Running `.../gotham/target/debug/gotham_examples_handlers_simple_async_handlers`
+Listening for requests at http://127.0.0.1:7878
+sleep for 5 seconds once: starting
+sleep for 5 seconds once: finished
+sleep for one second 5 times: starting
+sleep for one second 5 times: finished
+
+Terminal 2:
+$ curl 'http://127.0.0.1:7878/sleep?seconds=5'
+slept for 5 seconds
+$ curl 'http://127.0.0.1:7878/loop?seconds=5'
+slept for 1 seconds
+slept for 1 seconds
+slept for 1 seconds
+slept for 1 seconds
+slept for 1 seconds
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/handlers/simple_async_handlers_await/README.md
+++ b/examples/handlers/simple_async_handlers_await/README.md
@@ -1,28 +1,15 @@
-# Async Request Handlers
+# Async Request Handlers (.await version)
 
 The idea of async handlers has already been introduced by the post_handler example in
 [Request Data](../request_data), which waits for the POST body asyncronously, and resolves
-the response future once it has processed the body.
+the response future once it has processed the body. The combinator-based version
+of this example can be found at [Async Request Handlers](../simple_async_handlers).
 
-This example contains a pair of endpoints that sleep for a number of seconds,
-in different ways. Note that we never call `std::thread::sleep` in this example,
-so none of our request handlers block the thread from handling other requests
-in parallel. Instead, in each case, we return a future, which will resolve when
-the requested time has elapsed, and cause Gotham to respond to the http request.
-
-The approach of using futures to track the status of long-running operations
-is significantly lower overhead than that of spawning a new thread per request.
-In our case, the long-running operations are sleeps, but in
-[Async Handlers](../async_handlers), the long-running operations are http
-requests.
-
-You will often find that most of the time that a web server spends dealing
-with a web request, it is waiting on another service (e.g. a database, or an
-external api). If you can track these operations using futures, you should end
-up with a very lightweight and performant web server. On the other hand, if you
-find yourself doing lots of CPU/memory intensive operations on the web server,
-then futures are probably not going to help your performance, and you might be
-better off spawning a new thread per request.
+This example has exactly the same behavior and API as the combinator-based version,
+and it can be used as a reference when converting your code to use async/await.
+It also leaves the versions of gotham, tokio and hyper the same, and uses the
+compatibility helpers from the `futures` crate to convert things at the
+interface boundaries.
 
 ## Running
 

--- a/examples/handlers/simple_async_handlers_await/README.md
+++ b/examples/handlers/simple_async_handlers_await/README.md
@@ -7,9 +7,6 @@ of this example can be found at [Async Request Handlers](../simple_async_handler
 
 This example has exactly the same behavior and API as the combinator-based version,
 and it can be used as a reference when converting your code to use async/await.
-It also leaves the versions of gotham, tokio and hyper the same, and uses the
-compatibility helpers from the `futures` crate to convert things at the
-interface boundaries.
 
 ## Running
 

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -60,11 +60,12 @@ fn get_duration(seconds: u64) -> Duration {
 /// real world problems.
 ///
 /// This function returns a LegacyFuture (a Future from the 0.1.x branch of
-/// the `futures` crate rather than a std::future::Future that we can .await).
+/// the `futures` crate, rather than a std::future::Future that we can .await).
 /// This is partly to keep it the same as the simple_async_handlers example,
 /// and partly to show you how to use the .compat() combinators (because you
-/// will probably be using them a lot while the ecosystem stabilises). For a
-/// better explanation of .compat(), please read this blog post:
+/// will probably be using them a lot while the ecosystem stabilises).
+/// 
+/// For a better explanation of .compat(), please read this blog post:
 /// https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html
 fn sleep(seconds: u64) -> SleepFuture {
     let when = Instant::now() + get_duration(seconds);

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -1,0 +1,180 @@
+//! A basic example showing the request components
+
+extern crate futures;
+extern crate gotham;
+#[macro_use]
+extern crate gotham_derive;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate tokio;
+
+use futures::{stream, Future, Stream};
+use std::time::{Duration, Instant};
+
+use hyper::StatusCode;
+
+use gotham::handler::{HandlerError, HandlerFuture, IntoHandlerError};
+use gotham::helpers::http::response::create_response;
+use gotham::router::builder::DefineSingleRoute;
+use gotham::router::builder::{build_simple_router, DrawRoutes};
+use gotham::router::Router;
+use gotham::state::{FromState, State};
+
+use tokio::timer::Delay;
+
+type SleepFuture = Box<dyn Future<Item = Vec<u8>, Error = HandlerError> + Send>;
+
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct QueryStringExtractor {
+    seconds: u64,
+}
+
+/// Sneaky hack to make tests take less time. Nothing to see here ;-).
+#[cfg(not(test))]
+fn get_duration(seconds: u64) -> Duration {
+    Duration::from_secs(seconds)
+}
+#[cfg(test)]
+fn get_duration(seconds: u64) -> Duration {
+    Duration::from_millis(seconds)
+}
+/// All this function does is return a future that resolves after a number of
+/// seconds, with a Vec<u8> that tells you how long it slept for.
+///
+/// Note that it does not block the thread from handling other requests, because
+/// it returns a `Future`, which will be managed by the tokio reactor, and
+/// called back once the timeout has expired.
+///
+/// Vec<u8> is chosen because it is one of the things that you need to resolve
+/// a HandlerFuture and respond to a request.
+///
+/// Most things that you call to access remote services (e.g databases and
+/// web apis) can be coerced into returning futures that yield useful data,
+/// so the patterns that you learn in this example should be applicable to
+/// real world problems.
+fn sleep(seconds: u64) -> SleepFuture {
+    let when = Instant::now() + get_duration(seconds);
+    let delay = Delay::new(when)
+        .map_err(|e| panic!("timer failed; err={:?}", e))
+        .and_then(move |_| {
+            Ok(format!("slept for {} seconds\n", seconds)
+                .as_bytes()
+                .to_vec())
+        });
+
+    Box::new(delay)
+}
+
+/// This handler sleeps for the requested number of seconds, using the `sleep()`
+/// helper method, above.
+fn sleep_handler(mut state: State) -> Box<HandlerFuture> {
+    let seconds = QueryStringExtractor::take_from(&mut state).seconds;
+    println!("sleep for {} seconds once: starting", seconds);
+
+    // Here, we call our helper function that returns a future.
+    let sleep_future = sleep(seconds);
+
+    // Here, we convert the future from `sleep()` into the form that Gotham expects.
+    // We have to use .then() rather than .and_then() because we need to coerce both
+    // the success and error cases into the right shape.
+    // `state` is moved in, so that we can return it, and we convert any errors
+    // that we have into the form that Hyper expects, using the helper from
+    // IntoHandlerError.
+    Box::new(sleep_future.then(move |result| match result {
+        Ok(data) => {
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
+            println!("sleep for {} seconds once: finished", seconds);
+            Ok((state, res))
+        }
+        Err(err) => Err((state, err.into_handler_error())),
+    }))
+}
+
+/// This example uses a `future::Stream` to implement a `for` loop. It calls sleep(1)
+/// as many times as needed to make the requested duration.
+///
+/// https://github.com/alexcrichton/futures-await has a more readable syntax for
+/// async for loops, if you are using nightly Rust.
+fn loop_handler(mut state: State) -> Box<HandlerFuture> {
+    let seconds = QueryStringExtractor::take_from(&mut state).seconds;
+    println!("sleep for one second {} times: starting", seconds);
+
+    // Here, we create a stream of Ok(_) that's as long as we need, and use fold
+    // to loop over it asyncronously, accumulating the return values from sleep().
+    let sleep_future: SleepFuture = Box::new(stream::iter_ok(0..seconds).fold(
+        Vec::new(),
+        move |mut accumulator, _| {
+            // Do the sleep(), and append the result to the accumulator so that it can
+            // be returned.
+            sleep(1).and_then(move |body| {
+                accumulator.extend(body);
+                Ok(accumulator)
+            })
+        },
+    ));
+
+    // This bit is the same as the bit in the first example.
+    Box::new(sleep_future.then(move |result| match result {
+        Ok(data) => {
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
+            println!("sleep for one second {} times: finished", seconds);
+            Ok((state, res))
+        }
+        Err(err) => Err((state, err.into_handler_error())),
+    }))
+}
+
+/// Create a `Router`.
+fn router() -> Router {
+    build_simple_router(|route| {
+        route
+            .get("/sleep")
+            .with_query_string_extractor::<QueryStringExtractor>()
+            .to(sleep_handler);
+        route
+            .get("/loop")
+            .with_query_string_extractor::<QueryStringExtractor>()
+            .to(loop_handler);
+    })
+}
+
+/// Start a server and use a `Router` to dispatch requests.
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening for requests at http://{}", addr);
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use gotham::test::TestServer;
+
+    use super::*;
+
+    fn assert_returns_ok(url_str: &str, expected_response: &str) {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server.client().get(url_str).perform().unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            &String::from_utf8(response.read_body().unwrap()).unwrap(),
+            expected_response
+        );
+    }
+
+    #[test]
+    fn sleep_says_how_long_it_slept_for() {
+        assert_returns_ok("http://localhost/sleep?seconds=2", "slept for 2 seconds\n");
+    }
+
+    #[test]
+    fn loop_breaks_the_time_into_one_second_sleeps() {
+        assert_returns_ok(
+            "http://localhost/loop?seconds=2",
+            "slept for 1 seconds\nslept for 1 seconds\n",
+        );
+    }
+}

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -4,7 +4,7 @@ use futures::prelude::*;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
-use hyper::{Body, StatusCode};
+use gotham::hyper::{Body, StatusCode};
 
 use gotham::handler::HandlerResult;
 use gotham::helpers::http::response::create_response;

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -1,16 +1,5 @@
 //! A basic example showing the request components
 
-extern crate futures;
-extern crate gotham;
-#[macro_use]
-extern crate gotham_derive;
-extern crate hyper;
-extern crate mime;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate tokio;
-
 use futures::prelude::*;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
@@ -23,6 +12,8 @@ use gotham::router::builder::DefineSingleRoute;
 use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+use gotham_derive::{StateData, StaticResponseExtender};
+use serde_derive::Deserialize;
 
 use tokio::time::delay_until;
 

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -64,7 +64,7 @@ fn get_duration(seconds: u64) -> Duration {
 /// This is partly to keep it the same as the simple_async_handlers example,
 /// and partly to show you how to use the .compat() combinators (because you
 /// will probably be using them a lot while the ecosystem stabilises).
-/// 
+///
 /// For a better explanation of .compat(), please read this blog post:
 /// https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html
 fn sleep(seconds: u64) -> SleepFuture {

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -23,12 +23,14 @@ pub mod assets;
 
 pub use self::error::{HandlerError, IntoHandlerError};
 
+/// A type alias for the results returned by async fns that can be passed to to_async.
+pub type HandlerResult = std::result::Result<(State, Response<Body>), (State, HandlerError)>;
+
 /// A type alias for the trait objects returned by `HandlerService`.
 ///
 /// When the `Future` resolves to an error, the `(State, HandlerError)` value is used to generate
 /// an appropriate HTTP error response.
-pub type HandlerFuture =
-    dyn Future<Output = std::result::Result<(State, Response<Body>), (State, HandlerError)>> + Send;
+pub type HandlerFuture = dyn Future<Output = HandlerResult> + Send;
 
 /// A `Handler` is an asynchronous function, taking a `State` value which represents the request
 /// and related runtime state, and returns a future which resolves to a response.

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -4,7 +4,7 @@ use std::panic::RefUnwindSafe;
 
 use crate::extractor::{PathExtractor, QueryStringExtractor};
 use crate::handler::assets::{DirHandler, FileHandler, FileOptions, FilePathExtractor};
-use crate::handler::{Handler, HandlerError, NewHandler};
+use crate::handler::{Handler, HandlerResult, NewHandler};
 use crate::pipeline::chain::PipelineHandleChain;
 use crate::router::builder::{
     ExtendRouteMatcher, ReplacePathExtractor, ReplaceQueryStringExtractor, SingleRouteBuilder,
@@ -15,7 +15,6 @@ use crate::router::route::{Delegation, Extractors, RouteImpl};
 use crate::state::State;
 use core::future::Future;
 use futures::FutureExt;
-use hyper::Response;
 
 /// Describes the API for defining a single route, after determining which request paths will be
 /// dispatched here. The API here uses chained function calls to build and add the route into the
@@ -111,14 +110,53 @@ pub trait DefineSingleRoute {
         H: Handler + RefUnwindSafe + Copy + Send + Sync + 'static;
 
     /// Similar to `to`, but accepts an `async fn`
-    fn to_async<F, Fut>(self, handler: F)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # extern crate gotham;
+    /// # extern crate hyper;
+    /// #
+    /// # use hyper::{Body, Response, StatusCode};
+    /// # use gotham::handler::HandlerResult;
+    /// # use gotham::state::State;
+    /// # use gotham::router::Router;
+    /// # use gotham::router::builder::*;
+    /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::single::*;
+    /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use gotham::test::TestServer;
+    /// #
+    /// async fn my_handler(state: State) -> HandlerResult {
+    ///     // Handler implementation elided.
+    /// #   Ok((state, Response::builder().status(StatusCode::ACCEPTED).body(Body::empty()).unwrap()))
+    /// }
+    /// #
+    /// # fn router() -> Router {
+    /// #   let (chain, pipelines) = single_pipeline(
+    /// #       new_pipeline().add(NewSessionMiddleware::default()).build()
+    /// #   );
+    ///
+    /// build_router(chain, pipelines, |route| {
+    ///     route.get("/request/path").to_async(my_handler);
+    /// })
+    /// #
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   let test_server = TestServer::new(router()).unwrap();
+    /// #   let response = test_server.client()
+    /// #       .get("https://example.com/request/path")
+    /// #       .perform()
+    /// #       .unwrap();
+    /// #   assert_eq!(response.status(), StatusCode::ACCEPTED);
+    /// # }
+    /// ```
+    fn to_async<H, Fut>(self, handler: H)
     where
         Self: Sized,
-        F: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
-        Fut: Future<Output = std::result::Result<(State, Response<Body>), (State, HandlerError)>>
-            + Send
-            + 'static,
-        Self: Sized,
+        H: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
+        Fut: Future<Output = HandlerResult> + Send + 'static,
     {
         self.to_new_handler(move || Ok(move |s: State| handler(s).boxed()))
     }

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -156,10 +156,7 @@ pub trait DefineSingleRoute {
     where
         Self: Sized,
         H: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
-        Fut: Future<Output = HandlerResult> + Send + 'static,
-    {
-        self.to_new_handler(move || Ok(move |s: State| handler(s).boxed()))
-    }
+        Fut: Future<Output = HandlerResult> + Send + 'static;
     /// Directs the route to the given `NewHandler`. This gives more control over how `Handler`
     /// values are constructed.
     ///
@@ -523,6 +520,15 @@ where
         H: Handler + RefUnwindSafe + Copy + Send + Sync + 'static,
     {
         self.to_new_handler(move || Ok(handler))
+    }
+
+    fn to_async<H, Fut>(self, handler: H)
+    where
+        Self: Sized,
+        H: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
+        Fut: Future<Output = HandlerResult> + Send + 'static,
+    {
+        self.to_new_handler(move || Ok(move |s: State| handler(s).boxed()))
     }
 
     fn to_new_handler<NH>(self, new_handler: NH)


### PR DESCRIPTION
In a previous iteration of this PR, I noticed in another project that I was wanting to use try!() a lot, now that my code looked like sync code, so I made a `handler_try!()` macro. In this version of the PR, I just use nested async blocks. Both are a bit ugly. I'm not sure which is better.

~It would be really nice if we could have an impl of Handler for async functions (it would let me collapse my `fn _() {Box::new(async {}.boxed(...).compat())}` boilerplate into `async fn _() {...}`). Not the end of the world though.~ This pr now includes a .to_async() method on router.

The examples are a bit contrived, because they don't call anything that can fail, so the lack of a working `?` operator isn't brought to the surface. It's probably worth porting at least `examples/handlers/form_urlencoded` before we cut a release, and decide whether there is a way to pass `State` around that is compatible with `?` (I probably won't have time for this until Febuary). This may cause us to change the signature of `.to_async()`.