### PR TITLE
Add static assets example to readme.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -42,6 +42,7 @@ information on functionality and ordering.
 | [Shared State](stared_state) | Sharing state across your application. | 1 |
 | [Into Response](into_response) | Implementing the Gotham web framework's `IntoResponse` trait. | 1 |
 | [Templating](templating) | An example using various templating engines. | 1 |
+| [Static Assets](static_assets) | Serving static assets. | 1 |
 
 ^ Gotham web framework examples are under active development.
 


### PR DESCRIPTION
I noticed the static assets example missed being added to the examples readme.