### PR TITLE
Fix master: Update urlencoded example for new create_response signature.

### DIFF
--- a/examples/handlers/form_urlencoded/src/main.rs
+++ b/examples/handlers/form_urlencoded/src/main.rs
@@ -31,7 +31,7 @@ fn form_handler(mut state: State) -> Box<HandlerFuture> {
                     let res_body_line = format!("{}: {}\n", key, value);
                     res_body.push_str(&res_body_line);
                 }
-                let res = create_response(&state, StatusCode::OK, (res_body, mime::TEXT_PLAIN));
+                let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, res_body);
                 future::ok((state, res))
             }
             Err(e) => return future::err((state, e.into_handler_error())),


### PR DESCRIPTION
So merging https://github.com/gotham-rs/gotham/pull/280 broke master.
This seems like a fail in the CI / Travis setup, given the build had passed on the branch.
I'm not sure if much can be done about it to prevent this scenario in the future though.

