### PR TITLE
Add ability to spawn futures ontop of the TestServer

### DIFF
--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -115,6 +115,20 @@ impl TestServer {
         self.client_with_address(SocketAddr::new(IpAddr::from([127, 0, 0, 1]), 10000))
     }
 
+    /// Spawns the given future on the `TestServer`'s internal runtime.
+    /// This allows you to spawn more futures ontop of the `TestServer` in your
+    /// tests.
+    pub fn spawn<F>(&self, fut: F)
+    where
+        F: Future<Item = (), Error = ()> + Send + 'static,
+    {
+        self.data
+            .runtime
+            .write()
+            .expect("unable to acquire read lock")
+            .spawn(fut);
+    }
+
     /// Returns a client connected to the `TestServer`. The transport is handled internally, and
     /// the server will see `client_addr` as the source address for the connection. The
     /// `client_addr` can be any valid `SocketAddr`, and need not be contactable.


### PR DESCRIPTION
For https://github.com/toshi-search/Toshi we need to spawn some additional futures along side the test server to be able to properly test some features. This change exposes the spawn method from the internal test server runtime.