### PR TITLE
Add askama templating example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ members = [
     # Tera template
     "examples/templating/tera",
 
+    # Askama template
+    "examples/templating/askama",
+
     # routing
     "examples/routing/introduction",
     "examples/routing/http_verbs",

--- a/examples/templating/README.md
+++ b/examples/templating/README.md
@@ -8,6 +8,7 @@ templating engines from with Gotham.
 As the engines are external, there's no real order to check these examples out;
 feel free to view examples as they're needed.
 
+- [Askama](askama) - Render templates using `askama`
 - [Tera](tera) - Demonstrates the `Tera` templating engine with Gotham.
 
 ## Help

--- a/examples/templating/askama/Cargo.toml
+++ b/examples/templating/askama/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "gotham_examples_templating_askama"
+version = "0.0.0"
+build = "build.rs"
+publish = false
+
+[dependencies]
+gotham = { path = "../../../gotham" }
+
+askama = "0.7.2"
+hyper = "0.12.17"
+mime = "0.3.12"
+
+[build-dependencies]
+askama = "0.7.2"

--- a/examples/templating/askama/README.md
+++ b/examples/templating/askama/README.md
@@ -1,0 +1,58 @@
+# Templating using Askama
+
+An example usage of the Askama template engine working with Gotham.
+
+## Running
+
+From the `examples/templating/askama` directory:
+
+```
+Terminal 1:
+$ cargo run
+   Compiling gotham_examples_templating_askama (file:///.../examples/templating/tera)
+    Finished dev [unoptimized + debuginfo] target(s) in 13.18s
+     Running `../gotham_examples_templating_askama`
+  Listening at 127.0.0.1:7878
+
+Terminal 2:
+$ curl -v http://127.0.0.1:7878/
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to 127.0.0.1 (127.0.0.1) port 7878 (#0)
+> GET / HTTP/1.1
+> Host: 127.0.0.1:7878
+> User-Agent: curl/7.54.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< x-request-id: fc67c641-e586-4f79-a972-6171efde6782
+< content-type: text/html; charset=utf-8
+< content-length: 165
+< date: Sat, 08 Dec 2018 21:04:32 GMT
+< 
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello, Gotham!</title>
+</head>
+<body>
+    Askama says: "Hello, Gotham!"
+</body>
+* Connection #0 to host 127.0.0.1 left intact
+</html>
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/templating/askama/build.rs
+++ b/examples/templating/askama/build.rs
@@ -1,0 +1,7 @@
+extern crate askama;
+
+fn main() {
+    // Instruct askama to rebuild the templates if they've changed.
+    // This can be removed if the templates are not expected to change; remember to rebuild the crate if they do, however.
+    askama::rerun_if_templates_changed();
+}

--- a/examples/templating/askama/src/main.rs
+++ b/examples/templating/askama/src/main.rs
@@ -1,0 +1,72 @@
+extern crate askama;
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+
+use askama::Template;
+use gotham::helpers::http::response::{create_empty_response, create_response};
+use gotham::state::State;
+use hyper::{Body, Response, StatusCode};
+
+pub const MESSAGE: &str = "Hello, Gotham!";
+
+/// The index displays a message to the browser.
+/// The default template directory is `$CRATE_ROOT/templates`,which is what we are using in this example
+#[derive(Debug, Template)]
+#[template(path = "index.html")]
+pub struct Index {
+    pub message: String,
+}
+
+/// Renders the `index.html` template with the `MESSAGE` constant as the message
+pub fn index(state: State) -> (State, Response<Body>) {
+    let tpl = Index {
+        message: MESSAGE.to_string(),
+    };
+
+    // The response is either the rendered template, or a server error if something really goes wrong
+    let res = match tpl.render() {
+        Ok(content) => create_response(
+            &state,
+            StatusCode::OK,
+            mime::TEXT_HTML_UTF_8,
+            content.into_bytes(),
+        ),
+        Err(_) => create_empty_response(&state, StatusCode::INTERNAL_SERVER_ERROR),
+    };
+
+    (state, res)
+}
+
+/// Run on the normal port for Gotham examples, passing the handler as the only function for the gotham web server.
+pub fn main() {
+    let addr = "127.0.0.1:7878";
+    println!("Listening at {}", addr);
+    gotham::start(addr, || Ok(index));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn askama_template_variable_included_in_response() {
+        let test_server =
+            TestServer::new(|| Ok(index)).expect("Failed to launch test server with index handler");
+
+        let response = test_server
+            .client()
+            .get("http://localhost")
+            .perform()
+            .expect("Failed to send request to test server");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response
+            .read_utf8_body()
+            .expect("Failed to read utf-8 from response body");
+
+        assert!(&body.contains(MESSAGE));
+    }
+}

--- a/examples/templating/askama/templates/index.html
+++ b/examples/templating/askama/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello, Gotham!</title>
+</head>
+<body>
+    Askama says: "{{ message }}"
+</body>
+</html>


### PR DESCRIPTION
I've added an example of using the `askama` templating engine. This example borrows heavily from the `tera` templating example, but also uses some common patterns specific to `askama`, such as a build file to recompile templates when they change and template variables.