### PR TITLE
Update minimum httpdate version

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -39,7 +39,7 @@ num_cpus = "1.8"
 regex = "1.0"
 cookie = "0.11"
 http = "0.1"
-httpdate = "0.3"
+httpdate = "0.3.2"
 failure = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Versions <0.3.2 contain a typo preventing the correct parsing of dates in the month May.