### PR TITLE
Introduce a middleware to parse HTTP cookies

### DIFF
--- a/gotham/src/middleware/cookie/mod.rs
+++ b/gotham/src/middleware/cookie/mod.rs
@@ -1,0 +1,56 @@
+//! Defines a cookie parsing middleware to be attach cookies on requests.
+use std::io;
+
+use cookie::{Cookie, CookieJar};
+use hyper::header::{HeaderMap, COOKIE};
+
+use super::{Middleware, NewMiddleware};
+use handler::HandlerFuture;
+use state::{FromState, State};
+
+/// A struct that can act as a cookie parsing middleware for Gotham.
+///
+/// We implement `NewMiddleware` here for Gotham to allow us to work with the request
+/// lifecycle correctly. This trait requires `Clone`, so that is also included. Cookies
+/// become availabe on the request state as the `CookieJar` type.
+#[derive(Copy, Clone)]
+pub struct CookieParser;
+
+/// Public API for external re-use.
+impl CookieParser {
+    /// Parses a `CookieJar` from a `State`.
+    pub fn from_state(state: &State) -> CookieJar {
+        HeaderMap::borrow_from(&state)
+            .get_all(COOKIE)
+            .iter()
+            .flat_map(|cv| cv.to_str())
+            .flat_map(|cs| Cookie::parse(cs.to_owned()))
+            .fold(CookieJar::new(), |mut jar, cookie| {
+                jar.add_original(cookie);
+                jar
+            })
+    }
+}
+
+/// `Middleware` trait implementation.
+impl Middleware for CookieParser {
+    /// Attaches a set of parsed cookies to the request state.
+    fn call<Chain>(self, mut state: State, chain: Chain) -> Box<HandlerFuture>
+    where
+        Chain: FnOnce(State) -> Box<HandlerFuture>,
+    {
+        let cookies = { CookieParser::from_state(&state) };
+        state.put(cookies);
+        chain(state)
+    }
+}
+
+/// `NewMiddleware` trait implementation.
+impl NewMiddleware for CookieParser {
+    type Instance = Self;
+
+    /// Clones the current middleware to a new instance.
+    fn new_middleware(&self) -> io::Result<Self::Instance> {
+        Ok(self.clone())
+    }
+}

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -8,6 +8,7 @@ use handler::HandlerFuture;
 use state::State;
 
 pub mod chain;
+pub mod cookie;
 pub mod logger;
 pub mod security;
 pub mod session;

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -312,6 +312,7 @@ mod tests {
     use hyper::service::Service;
     use hyper::{Body, Request, Response, StatusCode};
 
+    use middleware::cookie::CookieParser;
     use middleware::session::NewSessionMiddleware;
     use pipeline::new_pipeline;
     use router::response::extender::StaticResponseExtender;
@@ -460,8 +461,12 @@ mod tests {
     #[test]
     fn build_router_test() {
         let pipelines = new_pipeline_set();
-        let (pipelines, default) =
-            pipelines.add(new_pipeline().add(NewSessionMiddleware::default()).build());
+        let (pipelines, default) = pipelines.add(
+            new_pipeline()
+                .add(CookieParser)
+                .add(NewSessionMiddleware::default())
+                .build(),
+        );
 
         let pipelines = finalize_pipeline_set(pipelines);
 

--- a/gotham/src/state/data.rs
+++ b/gotham/src/state/data.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 
+use cookie::CookieJar;
 use hyper::{Body, HeaderMap, Method, Uri, Version};
 
 use helpers::http::request::path::RequestPathSegments;
@@ -35,6 +36,7 @@ impl StateData for Method {}
 impl StateData for Uri {}
 impl StateData for Version {}
 impl StateData for HeaderMap {}
+impl StateData for CookieJar {}
 
 impl StateData for RequestPathSegments {}
 impl StateData for RequestId {}


### PR DESCRIPTION
This PR introduces a new `CookieParser`, which can act as a middleware to store `CookieJar` structs on the `State`. This avoids the user having to manually parse out their cookies (potentially in multiple places). The `CookieParser` can also be used manually to parse cookies anyway, if the user desires.

This PR also re-works the `SessionMiddleware` to make use of the same parser. If cookies have already been parsed, then it just uses those anyway. This feels a little gross (particularly the `to_owned()` call), but the only alternative I could think of was requiring the that user include the `CookieParser` before the `SessionMiddleware`. 