### PR TITLE
Migrate to Rust 2018 edition

### DIFF
--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -6,7 +6,7 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use hyper::header::{COOKIE, SET_COOKIE};
+use hyper::header::SET_COOKIE;
 use hyper::{Body, Response, StatusCode};
 
 use cookie::{Cookie, CookieJar};

--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -66,7 +66,7 @@ pub fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::*;use hyper::header::COOKIE;
     use cookie::Cookie;
     use gotham::test::TestServer;
 

--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -66,9 +66,10 @@ pub fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;use hyper::header::COOKIE;
+    use super::*;
     use cookie::Cookie;
     use gotham::test::TestServer;
+    use hyper::header::COOKIE;
 
     #[test]
     fn cookie_is_set_and_counter_increments() {

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/gotham-rs/gotham"
 readme = "README.md"
 categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "framework", "blockchain"]
+edition = "2018"
 
 [dependencies]
 log = "0.4"

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -11,6 +11,7 @@ use serde::de::{
     self, Deserialize, DeserializeSeed, Deserializer, EnumAccess, MapAccess, SeqAccess,
     VariantAccess, Visitor,
 };
+use serde::forward_to_deserialize_any;
 
 use crate::helpers::http::request::query_string::QueryStringMapping;
 use crate::router::tree::segment::SegmentMapping;

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -704,6 +704,7 @@ impl<'de> VariantAccess<'de> for UnitVariant {
 mod tests {
     use super::*;
     use crate::helpers::http::{FormUrlDecoded, PercentDecoded};
+    use serde_derive::Deserialize;
     use std;
 
     #[derive(Deserialize)]

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -12,8 +12,8 @@ use serde::de::{
     VariantAccess, Visitor,
 };
 
-use helpers::http::request::query_string::QueryStringMapping;
-use router::tree::segment::SegmentMapping;
+use crate::helpers::http::request::query_string::QueryStringMapping;
+use crate::router::tree::segment::SegmentMapping;
 
 /// Describes the error cases which can result from deserializing a `ExtractorDeserializer` into a
 /// `PathExtractor` provided by the application.
@@ -702,7 +702,7 @@ impl<'de> VariantAccess<'de> for UnitVariant {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use helpers::http::{FormUrlDecoded, PercentDecoded};
+    use crate::helpers::http::{FormUrlDecoded, PercentDecoded};
     use std;
 
     #[derive(Deserialize)]

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -1,8 +1,8 @@
 use hyper::{body::Payload, Body, Response};
 use serde::{Deserialize, Deserializer};
 
-use router::response::extender::StaticResponseExtender;
-use state::{State, StateData};
+use crate::router::response::extender::StaticResponseExtender;
+use crate::state::{State, StateData};
 
 /// Defines a binding for storing the dynamic segments of the `Request` path in `State`. On failure
 /// the `StaticResponseExtender` implementation extends the `Response` to indicate why the

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -1,8 +1,8 @@
 use hyper::{body::Payload, Body, Response};
 use serde::{Deserialize, Deserializer};
 
-use router::response::extender::StaticResponseExtender;
-use state::{State, StateData};
+use crate::router::response::extender::StaticResponseExtender;
+use crate::state::{State, StateData};
 
 /// Defines a binding for storing the query parameters from the `Request` URI in `State`. On
 /// failure the `StaticResponseExtender` implementation extends the `Response` to indicate why the

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -421,13 +421,13 @@ fn get_block_size(metadata: &Metadata) -> usize {
 #[cfg(test)]
 mod tests {
     use super::FileOptions;
+    use crate::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+    use crate::router::Router;
+    use crate::test::TestServer;
     use http::header::HeaderValue;
     use hyper::header::*;
     use hyper::StatusCode;
-    use router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
-    use router::Router;
     use std::{fs, str};
-    use test::TestServer;
 
     #[test]
     fn assets_guesses_content_type() {

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -548,10 +548,7 @@ mod tests {
         let response = test_server
             .client()
             .get("http://localhost/")
-            .with_header(
-                IF_NONE_MATCH,
-                HeaderValue::from_bytes(b"bogus").unwrap(),
-            )
+            .with_header(IF_NONE_MATCH, HeaderValue::from_bytes(b"bogus").unwrap())
             .perform()
             .unwrap();
 

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -8,13 +8,15 @@ mod accepted_encoding;
 
 use crate::error::Result;
 use bytes::{BufMut, BytesMut};
-use futures::{stream, Future, Stream};
+use futures::{stream, try_ready, Future, Stream};
 use http;
 use httpdate::parse_http_date;
 use hyper::header::*;
 use hyper::{Body, Chunk, Response, StatusCode};
+use log::debug;
 use mime::{self, Mime};
 use mime_guess::guess_mime_type_opt;
+use serde_derive::Deserialize;
 use tokio::fs::File;
 use tokio::io::AsyncRead;
 

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -6,8 +6,8 @@
 
 mod accepted_encoding;
 
+use crate::error::Result;
 use bytes::{BufMut, BytesMut};
-use error::Result;
 use futures::{stream, Future, Stream};
 use http;
 use httpdate::parse_http_date;
@@ -19,9 +19,9 @@ use tokio::fs::File;
 use tokio::io::AsyncRead;
 
 use self::accepted_encoding::accepted_encodings;
-use handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
-use router::response::extender::StaticResponseExtender;
-use state::{FromState, State, StateData};
+use crate::handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
+use crate::router::response::extender::StaticResponseExtender;
+use crate::state::{FromState, State, StateData};
 
 use std::cmp;
 use std::convert::From;
@@ -546,7 +546,10 @@ mod tests {
         let response = test_server
             .client()
             .get("http://localhost/")
-            .with_header(IF_NONE_MATCH, HeaderValue::from_bytes(b"bogus").unwrap())
+            .with_header(
+                IF_NONE_MATCH,
+                HeaderValue::from_bytes(b"bogus").unwrap(),
+            )
             .perform()
             .unwrap();
 

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use hyper::{Body, Response, StatusCode};
+use log::{debug, trace};
 
 use crate::handler::IntoResponse;
 use crate::helpers::http::response::create_empty_response;

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -3,9 +3,9 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use hyper::{Body, Response, StatusCode};
 
-use handler::IntoResponse;
-use helpers::http::response::create_empty_response;
-use state::{request_id, State};
+use crate::handler::IntoResponse;
+use crate::helpers::http::response::create_empty_response;
+use crate::state::{request_id, State};
 
 /// Describes an error which occurred during handler execution, and allows the creation of a HTTP
 /// `Response`.
@@ -136,7 +136,7 @@ impl IntoResponse for HandlerError {
             self.status_code
                 .canonical_reason()
                 .unwrap_or("(unregistered)",),
-            self.cause().map(|e| e.description()).unwrap_or("(none)"),
+            self.source().map(|e| e.description()).unwrap_or("(none)"),
         );
 
         create_empty_response(state, self.status_code)

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -11,11 +11,11 @@ use futures::{future, Future};
 use hyper::{Body, Chunk, Response, StatusCode};
 use mime::{self, Mime};
 
-use helpers::http::response;
-use state::State;
+use crate::helpers::http::response;
+use crate::state::State;
 
 mod error;
-use error::*;
+use crate::error::*;
 
 /// Defines handlers for serving static assets.
 pub mod assets;

--- a/gotham/src/helpers/http/mod.rs
+++ b/gotham/src/helpers/http/mod.rs
@@ -4,6 +4,7 @@ pub mod header;
 pub mod request;
 pub mod response;
 
+use log::trace;
 use std;
 use url::percent_encoding::percent_decode;
 

--- a/gotham/src/helpers/http/request/path.rs
+++ b/gotham/src/helpers/http/request/path.rs
@@ -1,6 +1,6 @@
 //! Defines helper functions for processing the request path
 
-use helpers::http::PercentDecoded;
+use crate::helpers::http::PercentDecoded;
 
 const EXCLUDED_SEGMENTS: [&str; 1] = [""];
 

--- a/gotham/src/helpers/http/request/query_string.rs
+++ b/gotham/src/helpers/http/request/query_string.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use helpers::http::{form_url_decode, FormUrlDecoded};
+use crate::helpers::http::{form_url_decode, FormUrlDecoded};
 
 /// Provides a mapping of keys from `Request` query string to their supplied values
 pub(crate) type QueryStringMapping = HashMap<String, Vec<FormUrlDecoded>>;

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -5,8 +5,8 @@ use hyper::{Body, Method, Response, StatusCode};
 use mime::Mime;
 use std::borrow::Cow;
 
-use helpers::http::header::X_REQUEST_ID;
-use state::{request_id, FromState, State};
+use crate::helpers::http::header::X_REQUEST_ID;
+use crate::state::{request_id, FromState, State};
 
 /// Creates a `Response` object and populates it with a set of default headers that help to improve
 /// security and conformance to best practice.

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -14,7 +14,6 @@
         clippy::should_implement_trait,
         clippy::unit_arg,
         clippy::match_wild_err_arm,
-        clippy::new_without_default_derive,
         clippy::new_without_default,
         clippy::wrong_self_convention,
         clippy::mutex_atomic,

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -26,37 +26,6 @@
 // TODO: Remove this when it's a hard error by default (error E0446).
 // See Rust issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 #![deny(private_in_public)]
-
-extern crate base64;
-extern crate bincode;
-extern crate borrow_bag;
-extern crate bytes;
-extern crate chrono;
-extern crate cookie;
-extern crate failure;
-#[macro_use]
-extern crate futures;
-extern crate http;
-extern crate hyper;
-extern crate linked_hash_map;
-#[macro_use]
-extern crate log;
-extern crate mime;
-extern crate mime_guess;
-extern crate mio;
-extern crate num_cpus;
-extern crate rand;
-extern crate rand_chacha;
-extern crate regex;
-#[macro_use]
-extern crate serde;
-extern crate httpdate;
-extern crate tokio;
-extern crate url;
-extern crate uuid;
-#[macro_use]
-extern crate serde_derive;
-
 pub mod error;
 pub mod extractor;
 pub mod handler;
@@ -73,6 +42,7 @@ use std::sync::Arc;
 
 use futures::{Future, Stream};
 use hyper::server::conn::Http;
+use log::{error, info, warn};
 use tokio::executor;
 use tokio::net::TcpListener;
 use tokio::runtime::{self, Runtime, TaskExecutor};

--- a/gotham/src/middleware/chain.rs
+++ b/gotham/src/middleware/chain.rs
@@ -1,5 +1,7 @@
 //! Defines the types for connecting multiple middleware into a "chain" when forming a pipeline.
 
+use log::trace;
+
 use std::io;
 use std::panic::RefUnwindSafe;
 

--- a/gotham/src/middleware/chain.rs
+++ b/gotham/src/middleware/chain.rs
@@ -3,9 +3,9 @@
 use std::io;
 use std::panic::RefUnwindSafe;
 
-use handler::HandlerFuture;
-use middleware::{Middleware, NewMiddleware};
-use state::{request_id, State};
+use crate::handler::HandlerFuture;
+use crate::middleware::{Middleware, NewMiddleware};
+use crate::state::{request_id, State};
 
 /// A recursive type representing a pipeline, which is used to spawn a `MiddlewareChain`.
 ///

--- a/gotham/src/middleware/cookie/mod.rs
+++ b/gotham/src/middleware/cookie/mod.rs
@@ -5,8 +5,8 @@ use cookie::{Cookie, CookieJar};
 use hyper::header::{HeaderMap, COOKIE};
 
 use super::{Middleware, NewMiddleware};
-use handler::HandlerFuture;
-use state::{FromState, State};
+use crate::handler::HandlerFuture;
+use crate::state::{FromState, State};
 
 /// A struct that can act as a cookie parsing middleware for Gotham.
 ///
@@ -51,6 +51,6 @@ impl NewMiddleware for CookieParser {
 
     /// Clones the current middleware to a new instance.
     fn new_middleware(&self) -> io::Result<Self::Instance> {
-        Ok(self.clone())
+        Ok(*self)
     }
 }

--- a/gotham/src/middleware/logger/mod.rs
+++ b/gotham/src/middleware/logger/mod.rs
@@ -8,6 +8,7 @@
 use futures::{future, Future};
 use hyper::{header::CONTENT_LENGTH, Method, Uri, Version};
 use log::Level;
+use log::{log, log_enabled};
 use std::io;
 
 use crate::handler::HandlerFuture;

--- a/gotham/src/middleware/logger/mod.rs
+++ b/gotham/src/middleware/logger/mod.rs
@@ -10,11 +10,11 @@ use hyper::{header::CONTENT_LENGTH, Method, Uri, Version};
 use log::Level;
 use std::io;
 
-use handler::HandlerFuture;
-use helpers::timing::Timer;
-use middleware::{Middleware, NewMiddleware};
-use state::request_id::request_id;
-use state::{client_addr, FromState, State};
+use crate::handler::HandlerFuture;
+use crate::helpers::timing::Timer;
+use crate::middleware::{Middleware, NewMiddleware};
+use crate::state::request_id::request_id;
+use crate::state::{client_addr, FromState, State};
 
 /// A struct that can act as a logging middleware for Gotham.
 ///

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -4,8 +4,8 @@
 use std::io;
 use std::panic::RefUnwindSafe;
 
-use handler::HandlerFuture;
-use state::State;
+use crate::handler::HandlerFuture;
+use crate::state::State;
 
 pub mod chain;
 pub mod cookie;

--- a/gotham/src/middleware/security/mod.rs
+++ b/gotham/src/middleware/security/mod.rs
@@ -13,10 +13,10 @@
 //! More may be added in future, but these headers provide compatibility with
 //! previous versions of Gotham.
 use futures::{future, Future};
-use handler::HandlerFuture;
+use crate::handler::HandlerFuture;
 use hyper::header::{HeaderValue, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
-use middleware::{Middleware, NewMiddleware};
-use state::State;
+use crate::middleware::{Middleware, NewMiddleware};
+use crate::state::State;
 use std::io;
 
 // constant strings to be used as header values

--- a/gotham/src/middleware/security/mod.rs
+++ b/gotham/src/middleware/security/mod.rs
@@ -12,11 +12,11 @@
 //!
 //! More may be added in future, but these headers provide compatibility with
 //! previous versions of Gotham.
-use futures::{future, Future};
 use crate::handler::HandlerFuture;
-use hyper::header::{HeaderValue, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
 use crate::middleware::{Middleware, NewMiddleware};
 use crate::state::State;
+use futures::{future, Future};
+use hyper::header::{HeaderValue, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
 use std::io;
 
 // constant strings to be used as header values

--- a/gotham/src/middleware/session/backend/memory.rs
+++ b/gotham/src/middleware/session/backend/memory.rs
@@ -4,6 +4,7 @@ use std::{io, thread};
 
 use futures::future;
 use linked_hash_map::LinkedHashMap;
+use log::trace;
 
 use crate::middleware::session::backend::{Backend, NewBackend, SessionFuture};
 use crate::middleware::session::{SessionError, SessionIdentifier};

--- a/gotham/src/middleware/session/backend/memory.rs
+++ b/gotham/src/middleware/session/backend/memory.rs
@@ -5,8 +5,8 @@ use std::{io, thread};
 use futures::future;
 use linked_hash_map::LinkedHashMap;
 
-use middleware::session::backend::{Backend, NewBackend, SessionFuture};
-use middleware::session::{SessionError, SessionIdentifier};
+use crate::middleware::session::backend::{Backend, NewBackend, SessionFuture};
+use crate::middleware::session::{SessionError, SessionIdentifier};
 
 /// Type alias for the `MemoryBackend` storage container.
 type MemoryMap = Mutex<LinkedHashMap<String, (Instant, Vec<u8>)>>;

--- a/gotham/src/middleware/session/backend/mod.rs
+++ b/gotham/src/middleware/session/backend/mod.rs
@@ -5,7 +5,7 @@ use std::panic::RefUnwindSafe;
 
 use futures::Future;
 
-use middleware::session::{SessionError, SessionIdentifier};
+use crate::middleware::session::{SessionError, SessionIdentifier};
 
 /// A type which is used to spawn new `Backend` values.
 pub trait NewBackend: Sync + Clone + RefUnwindSafe {

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -15,6 +15,7 @@ use futures::{
 };
 use hyper::header::SET_COOKIE;
 use hyper::{Body, Response, StatusCode};
+use log::{error, trace, warn};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -1044,6 +1044,7 @@ mod tests {
     use hyper::header::{HeaderMap, COOKIE};
     use hyper::{Response, StatusCode};
     use rand;
+    use serde_derive::{Deserialize, Serialize};
     use std::sync::Mutex;
     use std::time::Duration;
 

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -20,9 +20,9 @@ use serde::{Deserialize, Serialize};
 
 use super::cookie::CookieParser;
 use super::{Middleware, NewMiddleware};
-use handler::{HandlerError, HandlerFuture, IntoHandlerError};
-use helpers::http::response::create_empty_response;
-use state::{self, FromState, State, StateData};
+use crate::handler::{HandlerError, HandlerFuture, IntoHandlerError};
+use crate::helpers::http::response::create_empty_response;
+use crate::state::{self, FromState, State, StateData};
 
 mod backend;
 mod rng;

--- a/gotham/src/middleware/session/rng.rs
+++ b/gotham/src/middleware/session/rng.rs
@@ -1,3 +1,5 @@
+use log::error;
+use rand::prng::chacha::ChaChaCore;
 use rand::rngs::adapter::ReseedingRng;
 use rand::rngs::OsRng;
 use rand::FromEntropy;

--- a/gotham/src/middleware/session/rng.rs
+++ b/gotham/src/middleware/session/rng.rs
@@ -1,5 +1,4 @@
 use log::error;
-use rand::prng::chacha::ChaChaCore;
 use rand::rngs::adapter::ReseedingRng;
 use rand::rngs::OsRng;
 use rand::FromEntropy;

--- a/gotham/src/middleware/state/mod.rs
+++ b/gotham/src/middleware/state/mod.rs
@@ -4,9 +4,9 @@
 //! the state of a request, through the use of `Middleware`. Middleware can
 //! be created via `StateMiddleware::with`, with the provided value being the
 //! value to attach to the request state.
-use handler::HandlerFuture;
-use middleware::{Middleware, NewMiddleware};
-use state::{State, StateData};
+use crate::handler::HandlerFuture;
+use crate::middleware::{Middleware, NewMiddleware};
+use crate::state::{State, StateData};
 use std::io;
 use std::panic::RefUnwindSafe;
 

--- a/gotham/src/middleware/timer/mod.rs
+++ b/gotham/src/middleware/timer/mod.rs
@@ -1,10 +1,10 @@
 //! Request timing middleware, used to measure response times of requests.
-use futures::{future, Future};
 use crate::handler::HandlerFuture;
 use crate::helpers::http::header::X_RUNTIME_DURATION;
 use crate::helpers::timing::Timer;
 use crate::middleware::{Middleware, NewMiddleware};
 use crate::state::State;
+use futures::{future, Future};
 use std::io;
 
 /// Middleware binding to attach request execution times inside headers.

--- a/gotham/src/middleware/timer/mod.rs
+++ b/gotham/src/middleware/timer/mod.rs
@@ -1,10 +1,10 @@
 //! Request timing middleware, used to measure response times of requests.
 use futures::{future, Future};
-use handler::HandlerFuture;
-use helpers::http::header::X_RUNTIME_DURATION;
-use helpers::timing::Timer;
-use middleware::{Middleware, NewMiddleware};
-use state::State;
+use crate::handler::HandlerFuture;
+use crate::helpers::http::header::X_RUNTIME_DURATION;
+use crate::helpers::timing::Timer;
+use crate::middleware::{Middleware, NewMiddleware};
+use crate::state::State;
 use std::io;
 
 /// Middleware binding to attach request execution times inside headers.

--- a/gotham/src/pipeline/chain.rs
+++ b/gotham/src/pipeline/chain.rs
@@ -5,11 +5,11 @@ use borrow_bag::{Handle, Lookup};
 use futures::future;
 use std::panic::RefUnwindSafe;
 
-use handler::{HandlerFuture, IntoHandlerError};
-use middleware::chain::NewMiddlewareChain;
-use pipeline::set::PipelineSet;
-use pipeline::Pipeline;
-use state::{request_id, State};
+use crate::handler::{HandlerFuture, IntoHandlerError};
+use crate::middleware::chain::NewMiddlewareChain;
+use crate::pipeline::set::PipelineSet;
+use crate::pipeline::Pipeline;
+use crate::state::{request_id, State};
 
 /// A heterogeneous list of `Handle<P, _>` values, where `P` is a pipeline type. The pipelines are
 /// borrowed and invoked in order to serve a request.

--- a/gotham/src/pipeline/chain.rs
+++ b/gotham/src/pipeline/chain.rs
@@ -3,6 +3,7 @@
 
 use borrow_bag::{Handle, Lookup};
 use futures::future;
+use log::trace;
 use std::panic::RefUnwindSafe;
 
 use crate::handler::{HandlerFuture, IntoHandlerError};

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -4,6 +4,7 @@ pub mod chain;
 pub mod set;
 pub mod single;
 
+use log::trace;
 use std::io;
 
 use crate::handler::HandlerFuture;

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -6,10 +6,10 @@ pub mod single;
 
 use std::io;
 
-use handler::HandlerFuture;
-use middleware::chain::{MiddlewareChain, NewMiddlewareChain};
-use middleware::NewMiddleware;
-use state::{request_id, State};
+use crate::handler::HandlerFuture;
+use crate::middleware::chain::{MiddlewareChain, NewMiddlewareChain};
+use crate::middleware::NewMiddleware;
+use crate::state::{request_id, State};
 
 /// When using middleware, one or more `Middleware` are combined to form a `Pipeline`.
 /// `Middleware` are invoked strictly in the order they're added to the `Pipeline`.
@@ -289,10 +289,10 @@ mod tests {
     use futures::future;
     use hyper::{Body, Response, StatusCode};
 
-    use handler::{Handler, IntoHandlerError};
-    use middleware::Middleware;
-    use state::StateData;
-    use test::TestServer;
+    use crate::handler::{Handler, IntoHandlerError};
+    use crate::middleware::Middleware;
+    use crate::state::StateData;
+    use crate::test::TestServer;
 
     fn handler(state: State) -> (State, Response<Body>) {
         let number = state.borrow::<Number>().value;

--- a/gotham/src/pipeline/single.rs
+++ b/gotham/src/pipeline/single.rs
@@ -3,8 +3,8 @@
 
 use borrow_bag::{Append, Handle};
 
-use pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
-use pipeline::{NewMiddlewareChain, Pipeline};
+use crate::pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
+use crate::pipeline::{NewMiddlewareChain, Pipeline};
 
 /// A `PipelineSet` which contains only a single pipeline.
 pub type SinglePipelineSet<C> = PipelineSet<<() as Append<Pipeline<C>>>::Output>;
@@ -65,8 +65,8 @@ where
 mod tests {
     use super::*;
 
-    use pipeline::new_pipeline;
-    use router::builder::*;
+    use crate::pipeline::new_pipeline;
+    use crate::router::builder::*;
 
     #[test]
     fn test_pipeline_construction() {

--- a/gotham/src/router/builder/associated.rs
+++ b/gotham/src/router/builder/associated.rs
@@ -3,14 +3,14 @@ use std::panic::RefUnwindSafe;
 
 use hyper::{Body, Method};
 
-use extractor::{PathExtractor, QueryStringExtractor};
-use pipeline::chain::PipelineHandleChain;
-use pipeline::set::PipelineSet;
-use router::builder::SingleRouteBuilder;
-use router::route::matcher::{
+use crate::extractor::{PathExtractor, QueryStringExtractor};
+use crate::pipeline::chain::PipelineHandleChain;
+use crate::pipeline::set::PipelineSet;
+use crate::router::builder::SingleRouteBuilder;
+use crate::router::route::matcher::{
     AndRouteMatcher, AnyRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher,
 };
-use router::tree::node::Node;
+use crate::router::tree::node::Node;
 
 pub type AssociatedRouteBuilderMatcher<M, NM> = AndRouteMatcher<M, NM>;
 pub type AssociatedRouteMatcher<M> = AndRouteMatcher<MethodOnlyRouteMatcher, M>;

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -953,14 +953,14 @@ mod tests {
     use futures::future;
     use hyper::{Body, Response, StatusCode};
 
-    use handler::HandlerFuture;
-    use helpers::http::response::create_empty_response;
-    use middleware::{Middleware, NewMiddleware};
-    use pipeline::single::*;
-    use pipeline::*;
-    use router::builder::*;
-    use state::State;
-    use test::TestServer;
+    use crate::handler::HandlerFuture;
+    use crate::helpers::http::response::create_empty_response;
+    use crate::middleware::{Middleware, NewMiddleware};
+    use crate::pipeline::single::*;
+    use crate::pipeline::*;
+    use crate::router::builder::*;
+    use crate::state::State;
+    use crate::test::TestServer;
 
     #[derive(Clone, Copy)]
     struct QuickExitMiddleware;

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
 use hyper::Method;
+use log::trace;
 
 use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
 use crate::pipeline::chain::PipelineHandleChain;

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -3,18 +3,18 @@ use std::panic::RefUnwindSafe;
 
 use hyper::Method;
 
-use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-use pipeline::chain::PipelineHandleChain;
-use pipeline::set::PipelineSet;
-use router::builder::{
+use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+use crate::pipeline::chain::PipelineHandleChain;
+use crate::pipeline::set::PipelineSet;
+use crate::router::builder::{
     AssociatedRouteBuilder, DelegateRouteBuilder, RouterBuilder, ScopeBuilder, SingleRouteBuilder,
 };
-use router::route::matcher::{
+use crate::router::route::matcher::{
     AnyRouteMatcher, IntoRouteMatcher, MethodOnlyRouteMatcher, RouteMatcher,
 };
-use router::tree::node::Node;
-use router::tree::regex::ConstrainedSegmentRegex;
-use router::tree::segment::SegmentType;
+use crate::router::tree::node::Node;
+use crate::router::tree::regex::ConstrainedSegmentRegex;
+use crate::router::tree::segment::SegmentType;
 
 /// The type returned when building a route that only considers path and http verb(s) when
 /// determining if it matches a request.

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -313,13 +313,14 @@ mod tests {
     use futures::{Future, Stream};
     use hyper::service::Service;
     use hyper::{Body, Request, Response, StatusCode};
+    use serde_derive::Deserialize;
 
-    use middleware::cookie::CookieParser;
-    use middleware::session::NewSessionMiddleware;
-    use pipeline::new_pipeline;
-    use router::response::extender::StaticResponseExtender;
-    use service::GothamService;
-    use state::{State, StateData};
+    use crate::middleware::cookie::CookieParser;
+    use crate::middleware::session::NewSessionMiddleware;
+    use crate::pipeline::new_pipeline;
+    use crate::router::response::extender::StaticResponseExtender;
+    use crate::service::GothamService;
+    use crate::state::{State, StateData};
 
     #[derive(Deserialize)]
     struct SalutationParams {

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -10,17 +10,19 @@ use std::panic::RefUnwindSafe;
 
 use hyper::{Body, StatusCode};
 
-use extractor::{NoopPathExtractor, NoopQueryStringExtractor, PathExtractor, QueryStringExtractor};
-use pipeline::chain::PipelineHandleChain;
-use pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
-use router::response::extender::ResponseExtender;
-use router::response::finalizer::ResponseFinalizerBuilder;
-use router::route::dispatch::DispatcherImpl;
-use router::route::matcher::{AnyRouteMatcher, RouteMatcher};
-use router::route::{Delegation, Extractors, RouteImpl};
-use router::tree::node::Node;
-use router::tree::Tree;
-use router::Router;
+use crate::extractor::{
+    NoopPathExtractor, NoopQueryStringExtractor, PathExtractor, QueryStringExtractor,
+};
+use crate::pipeline::chain::PipelineHandleChain;
+use crate::pipeline::set::{finalize_pipeline_set, new_pipeline_set, PipelineSet};
+use crate::router::response::extender::ResponseExtender;
+use crate::router::response::finalizer::ResponseFinalizerBuilder;
+use crate::router::route::dispatch::DispatcherImpl;
+use crate::router::route::matcher::{AnyRouteMatcher, RouteMatcher};
+use crate::router::route::{Delegation, Extractors, RouteImpl};
+use crate::router::tree::node::Node;
+use crate::router::tree::Tree;
+use crate::router::Router;
 
 pub use self::associated::{AssociatedRouteBuilder, AssociatedSingleRouteBuilder};
 pub use self::draw::DrawRoutes;

--- a/gotham/src/router/builder/modify.rs
+++ b/gotham/src/router/builder/modify.rs
@@ -1,3 +1,5 @@
+use hyper::Body;
+
 use std::panic::RefUnwindSafe;
 
 use crate::extractor::{PathExtractor, QueryStringExtractor};
@@ -5,7 +7,6 @@ use crate::pipeline::chain::PipelineHandleChain;
 use crate::router::builder::single::DefineSingleRoute;
 use crate::router::builder::SingleRouteBuilder;
 use crate::router::route::matcher::{AndRouteMatcher, RouteMatcher};
-use hyper::Body;
 
 /// Describes the operation of replacing a `PathExtractor` on a route. This trait exists to remove
 /// type clutter from the documentation of `SingleRouteBuilder::with_path_extractor`.

--- a/gotham/src/router/builder/modify.rs
+++ b/gotham/src/router/builder/modify.rs
@@ -1,11 +1,11 @@
 use std::panic::RefUnwindSafe;
 
-use extractor::{PathExtractor, QueryStringExtractor};
+use crate::extractor::{PathExtractor, QueryStringExtractor};
+use crate::pipeline::chain::PipelineHandleChain;
+use crate::router::builder::single::DefineSingleRoute;
+use crate::router::builder::SingleRouteBuilder;
+use crate::router::route::matcher::{AndRouteMatcher, RouteMatcher};
 use hyper::Body;
-use pipeline::chain::PipelineHandleChain;
-use router::builder::single::DefineSingleRoute;
-use router::builder::SingleRouteBuilder;
-use router::route::matcher::{AndRouteMatcher, RouteMatcher};
 
 /// Describes the operation of replacing a `PathExtractor` on a route. This trait exists to remove
 /// type clutter from the documentation of `SingleRouteBuilder::with_path_extractor`.

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -1,16 +1,16 @@
 use std::panic::RefUnwindSafe;
 
-use extractor::{PathExtractor, QueryStringExtractor};
-use handler::assets::{DirHandler, FileHandler, FileOptions, FilePathExtractor};
-use handler::{Handler, NewHandler};
-use hyper::Body;
-use pipeline::chain::PipelineHandleChain;
-use router::builder::{
+use crate::extractor::{PathExtractor, QueryStringExtractor};
+use crate::handler::assets::{DirHandler, FileHandler, FileOptions, FilePathExtractor};
+use crate::handler::{Handler, NewHandler};
+use crate::pipeline::chain::PipelineHandleChain;
+use crate::router::builder::{
     ExtendRouteMatcher, ReplacePathExtractor, ReplaceQueryStringExtractor, SingleRouteBuilder,
 };
-use router::route::dispatch::DispatcherImpl;
-use router::route::matcher::RouteMatcher;
-use router::route::{Delegation, Extractors, RouteImpl};
+use crate::router::route::dispatch::DispatcherImpl;
+use crate::router::route::matcher::RouteMatcher;
+use crate::router::route::{Delegation, Extractors, RouteImpl};
+use hyper::Body;
 
 /// Describes the API for defining a single route, after determining which request paths will be
 /// dispatched here. The API here uses chained function calls to build and add the route into the

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -1,3 +1,5 @@
+use hyper::Body;
+
 use std::panic::RefUnwindSafe;
 
 use crate::extractor::{PathExtractor, QueryStringExtractor};
@@ -10,7 +12,6 @@ use crate::router::builder::{
 use crate::router::route::dispatch::DispatcherImpl;
 use crate::router::route::matcher::RouteMatcher;
 use crate::router::route::{Delegation, Extractors, RouteImpl};
-use hyper::Body;
 
 /// Describes the API for defining a single route, after determining which request paths will be
 /// dispatched here. The API here uses chained function calls to build and add the route into the

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use futures::{future, Future};
 use hyper::header::ALLOW;
 use hyper::{Body, Response, StatusCode};
+use log::{error, trace};
 
 use crate::error::*;
 use crate::handler::{Handler, HandlerFuture, IntoResponse, NewHandler};

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -203,17 +203,17 @@ mod tests {
     use hyper::{Body, Method, Uri};
     use std::str::FromStr;
 
-    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-    use handler::HandlerError;
-    use pipeline::set::*;
-    use router::response::finalizer::ResponseFinalizerBuilder;
-    use router::route::dispatch::DispatcherImpl;
-    use router::route::matcher::MethodOnlyRouteMatcher;
-    use router::route::{Extractors, RouteImpl};
-    use router::tree::node::Node;
-    use router::tree::segment::SegmentType;
-    use router::tree::Tree;
-    use state::set_request_id;
+    use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use crate::handler::HandlerError;
+    use crate::pipeline::set::*;
+    use crate::router::response::finalizer::ResponseFinalizerBuilder;
+    use crate::router::route::dispatch::DispatcherImpl;
+    use crate::router::route::matcher::MethodOnlyRouteMatcher;
+    use crate::router::route::{Extractors, RouteImpl};
+    use crate::router::tree::node::Node;
+    use crate::router::tree::segment::SegmentType;
+    use crate::router::tree::Tree;
+    use crate::state::set_request_id;
 
     fn handler(state: State) -> (State, Response<Body>) {
         (state, Response::new(Body::empty()))

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -12,15 +12,15 @@ use futures::{future, Future};
 use hyper::header::ALLOW;
 use hyper::{Body, Response, StatusCode};
 
-use error::*;
-use handler::{Handler, HandlerFuture, IntoResponse, NewHandler};
-use helpers::http::request::path::RequestPathSegments;
-use helpers::http::response::create_empty_response;
-use router::response::finalizer::ResponseFinalizer;
-use router::route::{Delegation, Route};
-use router::tree::segment::SegmentMapping;
-use router::tree::Tree;
-use state::{request_id, State};
+use crate::error::*;
+use crate::handler::{Handler, HandlerFuture, IntoResponse, NewHandler};
+use crate::helpers::http::request::path::RequestPathSegments;
+use crate::helpers::http::response::create_empty_response;
+use crate::router::response::finalizer::ResponseFinalizer;
+use crate::router::route::{Delegation, Route};
+use crate::router::tree::segment::SegmentMapping;
+use crate::router::tree::Tree;
+use crate::state::{request_id, State};
 
 struct RouterData {
     tree: Tree,

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -1,7 +1,7 @@
 //! Defines functionality for extending a Response.
 
 use hyper::{body::Payload, Body, Response};
-use state::{request_id, State};
+use crate::state::{request_id, State};
 use std::panic::RefUnwindSafe;
 
 /// Extend the `Response` based on current `State` and `Response` data.
@@ -10,13 +10,13 @@ pub trait StaticResponseExtender: RefUnwindSafe {
     type ResBody: Payload;
 
     /// Extend the response.
-    fn extend(&mut State, &mut Response<Self::ResBody>);
+    fn extend(state: &mut State, response: &mut Response<Self::ResBody>);
 }
 
 /// Allow complex types to extend the `Response` based on current `State` and `Response` data.
 pub trait ResponseExtender<B>: RefUnwindSafe {
     /// Extend the Response
-    fn extend(&self, &mut State, &mut Response<B>);
+    fn extend(&self, state: &mut State, response: &mut Response<B>);
 }
 
 impl<F, B> ResponseExtender<B> for F

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -1,7 +1,8 @@
 //! Defines functionality for extending a Response.
 
-use hyper::{body::Payload, Body, Response};
 use crate::state::{request_id, State};
+use hyper::{body::Payload, Body, Response};
+use log::trace;
 use std::panic::RefUnwindSafe;
 
 /// Extend the `Response` based on current `State` and `Response` data.

--- a/gotham/src/router/response/finalizer.rs
+++ b/gotham/src/router/response/finalizer.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 use futures::future;
 use hyper::{Body, Response, StatusCode};
 
-use handler::HandlerFuture;
-use state::{request_id, State};
+use crate::handler::HandlerFuture;
+use crate::state::{request_id, State};
 
-use router::response::extender::ResponseExtender;
+use crate::router::response::extender::ResponseExtender;
 
 /// Holds an immutable collection of `ResponseExtender` values, as configured using
 /// `ResponseFinalizerBuilder::add`. This type is constructed automatically when using the
@@ -36,7 +36,7 @@ impl ResponseFinalizerBuilder {
         ResponseFinalizerBuilder::internal_new()
     }
 
-    pub(in router) fn internal_new() -> Self {
+    pub(in crate::router) fn internal_new() -> Self {
         let handlers = HashMap::new();
         ResponseFinalizerBuilder { data: handlers }
     }

--- a/gotham/src/router/response/finalizer.rs
+++ b/gotham/src/router/response/finalizer.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use futures::future;
 use hyper::{Body, Response, StatusCode};
+use log::trace;
 
 use crate::handler::HandlerFuture;
 use crate::state::{request_id, State};

--- a/gotham/src/router/route/dispatch.rs
+++ b/gotham/src/router/route/dispatch.rs
@@ -80,11 +80,11 @@ mod tests {
 
     use hyper::{Body, Response, StatusCode};
 
-    use middleware::{Middleware, NewMiddleware};
-    use pipeline::new_pipeline;
-    use pipeline::set::*;
-    use state::StateData;
-    use test::TestServer;
+    use crate::middleware::{Middleware, NewMiddleware};
+    use crate::pipeline::new_pipeline;
+    use crate::pipeline::set::*;
+    use crate::state::StateData;
+    use crate::test::TestServer;
 
     fn handler(state: State) -> (State, Response<Body>) {
         let number = state.borrow::<Number>().value;

--- a/gotham/src/router/route/dispatch.rs
+++ b/gotham/src/router/route/dispatch.rs
@@ -1,6 +1,7 @@
 //! Defines the route `Dispatcher` and supporting types.
 
 use futures::future;
+use log::trace;
 use std::panic::RefUnwindSafe;
 
 use crate::handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};

--- a/gotham/src/router/route/dispatch.rs
+++ b/gotham/src/router/route/dispatch.rs
@@ -3,10 +3,10 @@
 use futures::future;
 use std::panic::RefUnwindSafe;
 
-use handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
-use pipeline::chain::PipelineHandleChain;
-use pipeline::set::PipelineSet;
-use state::{request_id, State};
+use crate::handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
+use crate::pipeline::chain::PipelineHandleChain;
+use crate::pipeline::set::PipelineSet;
+use crate::state::{request_id, State};
 
 /// Used by `Router` to dispatch requests via pipelines and finally into the configured `Handler`.
 pub trait Dispatcher: RefUnwindSafe {

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -2,6 +2,7 @@
 
 use hyper::header::{HeaderMap, HeaderValue, ACCEPT};
 use hyper::StatusCode;
+use log::trace;
 use mime;
 
 use crate::error;

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -4,10 +4,10 @@ use hyper::header::{HeaderMap, HeaderValue, ACCEPT};
 use hyper::StatusCode;
 use mime;
 
-use error;
-use router::non_match::RouteNonMatch;
-use router::route::RouteMatcher;
-use state::{request_id, FromState, State};
+use crate::error;
+use crate::router::non_match::RouteNonMatch;
+use crate::router::route::RouteMatcher;
+use crate::state::{request_id, FromState, State};
 
 /// A `RouteMatcher` that succeeds when the `Request` has been made with an `Accept` header that
 /// includes one or more supported media types. A missing `Accept` header, or the value of `*/*`

--- a/gotham/src/router/route/matcher/and.rs
+++ b/gotham/src/router/route/matcher/and.rs
@@ -1,8 +1,8 @@
 //! Defines the type `AndRouteMatcher`
 
-use router::non_match::RouteNonMatch;
-use router::route::RouteMatcher;
-use state::State;
+use crate::router::non_match::RouteNonMatch;
+use crate::router::route::RouteMatcher;
+use crate::state::State;
 
 /// Allows multiple `RouteMatcher` values to be combined when accessing a request.
 ///

--- a/gotham/src/router/route/matcher/any.rs
+++ b/gotham/src/router/route/matcher/any.rs
@@ -1,8 +1,8 @@
 //! Defines the type `AnyRouteMatcher`
 
-use router::non_match::RouteNonMatch;
-use router::route::RouteMatcher;
-use state::State;
+use crate::router::non_match::RouteNonMatch;
+use crate::router::route::RouteMatcher;
+use crate::state::State;
 
 /// Matches any request without restriction (i.e. will accept any request which has already matched
 /// the path to the current route). For example, this matcher is used when delegating a path prefix

--- a/gotham/src/router/route/matcher/content_type.rs
+++ b/gotham/src/router/route/matcher/content_type.rs
@@ -4,9 +4,9 @@ use hyper::header::{HeaderMap, CONTENT_TYPE};
 use hyper::StatusCode;
 use mime;
 
-use router::non_match::RouteNonMatch;
-use router::route::RouteMatcher;
-use state::{request_id, FromState, State};
+use crate::router::non_match::RouteNonMatch;
+use crate::router::route::RouteMatcher;
+use crate::state::{request_id, FromState, State};
 
 /// A `RouteMatcher` that succeeds when the `Request` has been made with a `Content-Type` header
 /// that includes a supported media type. The matcher will fail if the Content-Type

--- a/gotham/src/router/route/matcher/content_type.rs
+++ b/gotham/src/router/route/matcher/content_type.rs
@@ -2,6 +2,7 @@
 
 use hyper::header::{HeaderMap, CONTENT_TYPE};
 use hyper::StatusCode;
+use log::trace;
 use mime;
 
 use crate::router::non_match::RouteNonMatch;

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -12,6 +12,7 @@ pub use self::any::AnyRouteMatcher;
 use std::panic::RefUnwindSafe;
 
 use hyper::{Method, StatusCode};
+use log::trace;
 
 use crate::router::non_match::RouteNonMatch;
 use crate::state::{request_id, FromState, State};

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -13,8 +13,8 @@ use std::panic::RefUnwindSafe;
 
 use hyper::{Method, StatusCode};
 
-use router::non_match::RouteNonMatch;
-use state::{request_id, FromState, State};
+use crate::router::non_match::RouteNonMatch;
+use crate::state::{request_id, FromState, State};
 
 /// Determines if conditions required for the associated `Route` to be invoked by the `Router` have
 /// been met.

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -11,6 +11,7 @@ use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
 
 use hyper::{Body, Response, Uri};
+use log::debug;
 
 use crate::extractor::{self, PathExtractor, QueryStringExtractor};
 use crate::handler::HandlerFuture;

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -12,14 +12,14 @@ use std::panic::RefUnwindSafe;
 
 use hyper::{Body, Response, Uri};
 
-use extractor::{self, PathExtractor, QueryStringExtractor};
-use handler::HandlerFuture;
-use helpers::http::request::query_string;
-use router::non_match::RouteNonMatch;
-use router::route::dispatch::Dispatcher;
-use router::route::matcher::RouteMatcher;
-use router::tree::segment::SegmentMapping;
-use state::{request_id, State};
+use crate::extractor::{self, PathExtractor, QueryStringExtractor};
+use crate::handler::HandlerFuture;
+use crate::helpers::http::request::query_string;
+use crate::router::non_match::RouteNonMatch;
+use crate::router::route::dispatch::Dispatcher;
+use crate::router::route::matcher::RouteMatcher;
+use crate::router::tree::segment::SegmentMapping;
+use crate::state::{request_id, State};
 
 #[derive(Clone, Copy, PartialEq)]
 /// Indicates whether this `Route` will dispatch the request to an inner `Router` instance. To

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -224,14 +224,14 @@ mod tests {
     use hyper::{HeaderMap, Method, StatusCode, Uri};
     use std::str::FromStr;
 
-    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-    use helpers::http::request::path::RequestPathSegments;
-    use helpers::http::response::create_empty_response;
-    use pipeline::set::*;
-    use router::builder::*;
-    use router::route::dispatch::DispatcherImpl;
-    use router::route::matcher::MethodOnlyRouteMatcher;
-    use state::set_request_id;
+    use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use crate::helpers::http::request::path::RequestPathSegments;
+    use crate::helpers::http::response::create_empty_response;
+    use crate::pipeline::set::*;
+    use crate::router::builder::*;
+    use crate::router::route::dispatch::DispatcherImpl;
+    use crate::router::route::matcher::MethodOnlyRouteMatcher;
+    use crate::state::set_request_id;
 
     #[test]
     fn internal_route_tests() {

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -1,10 +1,10 @@
 //! Defines a hierarchial `Tree` with subtrees of `Node`.
 
-use helpers::http::PercentDecoded;
+use crate::helpers::http::PercentDecoded;
+use crate::router::route::Route;
+use crate::router::tree::node::Node;
+use crate::router::tree::segment::{SegmentMapping, SegmentType};
 use hyper::Body;
-use router::route::Route;
-use router::tree::node::Node;
-use router::tree::segment::{SegmentMapping, SegmentType};
 
 pub mod node;
 pub mod regex;

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -5,6 +5,7 @@ use crate::router::route::Route;
 use crate::router::tree::node::Node;
 use crate::router::tree::segment::{SegmentMapping, SegmentType};
 use hyper::Body;
+use log::trace;
 
 pub mod node;
 pub mod regex;

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -66,14 +66,14 @@ impl Tree {
 mod tests {
     use hyper::{Method, Response, StatusCode};
 
-    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-    use helpers::http::request::path::RequestPathSegments;
-    use helpers::http::response::create_empty_response;
-    use pipeline::set::*;
-    use router::route::dispatch::DispatcherImpl;
-    use router::route::matcher::MethodOnlyRouteMatcher;
-    use router::route::{Delegation, Extractors, RouteImpl};
-    use state::State;
+    use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use crate::helpers::http::request::path::RequestPathSegments;
+    use crate::helpers::http::response::create_empty_response;
+    use crate::pipeline::set::*;
+    use crate::router::route::dispatch::DispatcherImpl;
+    use crate::router::route::matcher::MethodOnlyRouteMatcher;
+    use crate::router::route::{Delegation, Extractors, RouteImpl};
+    use crate::state::State;
 
     use super::*;
 

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -1,6 +1,7 @@
 //! Defines `Node` for `Tree`.
 
 use hyper::{Body, StatusCode};
+use log::trace;
 
 use crate::helpers::http::PercentDecoded;
 use crate::router::non_match::RouteNonMatch;

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -292,15 +292,15 @@ mod tests {
 
     use hyper::{HeaderMap, Method, Response};
 
-    use extractor::{NoopPathExtractor, NoopQueryStringExtractor};
-    use helpers::http::request::path::RequestPathSegments;
-    use helpers::http::PercentDecoded;
-    use pipeline::set::*;
-    use router::route::dispatch::DispatcherImpl;
-    use router::route::matcher::MethodOnlyRouteMatcher;
-    use router::route::{Delegation, Extractors, Route, RouteImpl};
-    use router::tree::regex::ConstrainedSegmentRegex;
-    use state::{set_request_id, State};
+    use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+    use crate::helpers::http::request::path::RequestPathSegments;
+    use crate::helpers::http::PercentDecoded;
+    use crate::pipeline::set::*;
+    use crate::router::route::dispatch::DispatcherImpl;
+    use crate::router::route::matcher::MethodOnlyRouteMatcher;
+    use crate::router::route::{Delegation, Extractors, Route, RouteImpl};
+    use crate::router::tree::regex::ConstrainedSegmentRegex;
+    use crate::state::{set_request_id, State};
 
     fn handler(state: State) -> (State, Response<Body>) {
         (state, Response::new(Body::empty()))

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -2,11 +2,11 @@
 
 use hyper::{Body, StatusCode};
 
-use helpers::http::PercentDecoded;
-use router::non_match::RouteNonMatch;
-use router::route::{Delegation, Route};
-use router::tree::segment::{SegmentMapping, SegmentType};
-use state::{request_id, State};
+use crate::helpers::http::PercentDecoded;
+use crate::router::non_match::RouteNonMatch;
+use crate::router::route::{Delegation, Route};
+use crate::router::tree::segment::{SegmentMapping, SegmentType};
+use crate::state::{request_id, State};
 
 use std::cmp::Ordering;
 use std::collections::HashMap;

--- a/gotham/src/router/tree/segment.rs
+++ b/gotham/src/router/tree/segment.rs
@@ -1,8 +1,8 @@
 //! Defines `SegmentType` for `Tree`.
 use std::collections::HashMap;
 
-use helpers::http::PercentDecoded;
-use router::tree::regex::ConstrainedSegmentRegex;
+use crate::helpers::http::PercentDecoded;
+use crate::router::tree::regex::ConstrainedSegmentRegex;
 
 /// Mapping of segment names into the collection of values for that segment.
 pub type SegmentMapping<'r> = HashMap<&'r str, Vec<&'r PercentDecoded>>;

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -12,6 +12,7 @@ use futures::Future;
 use http::request;
 use hyper::service::Service;
 use hyper::{Body, Request, Response};
+use log::debug;
 
 use crate::handler::NewHandler;
 use crate::helpers::http::request::path::RequestPathSegments;

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -13,10 +13,10 @@ use http::request;
 use hyper::service::Service;
 use hyper::{Body, Request, Response};
 
-use handler::NewHandler;
-use helpers::http::request::path::RequestPathSegments;
-use state::client_addr::put_client_addr;
-use state::{set_request_id, State};
+use crate::handler::NewHandler;
+use crate::helpers::http::request::path::RequestPathSegments;
+use crate::state::client_addr::put_client_addr;
+use crate::state::{set_request_id, State};
 
 mod trap;
 
@@ -109,9 +109,9 @@ mod tests {
 
     use hyper::{Body, StatusCode};
 
-    use helpers::http::response::create_empty_response;
-    use router::builder::*;
-    use state::State;
+    use crate::helpers::http::response::create_empty_response;
+    use crate::router::builder::*;
+    use crate::state::State;
 
     fn handler(state: State) -> (State, Response<Body>) {
         let res = create_empty_response(&state, StatusCode::ACCEPTED);

--- a/gotham/src/service/trap.rs
+++ b/gotham/src/service/trap.rs
@@ -10,6 +10,7 @@ use failure;
 use futures::future::{self, Future, FutureResult, IntoFuture};
 use futures::Async;
 use hyper::{Body, Response, StatusCode};
+use log::error;
 
 use crate::handler::{Handler, HandlerError, IntoResponse, NewHandler};
 use crate::state::{request_id, State};

--- a/gotham/src/service/trap.rs
+++ b/gotham/src/service/trap.rs
@@ -11,8 +11,8 @@ use futures::future::{self, Future, FutureResult, IntoFuture};
 use futures::Async;
 use hyper::{Body, Response, StatusCode};
 
-use handler::{Handler, HandlerError, IntoResponse, NewHandler};
-use state::{request_id, State};
+use crate::handler::{Handler, HandlerError, IntoResponse, NewHandler};
+use crate::state::{request_id, State};
 
 type CompatError = failure::Compat<failure::Error>;
 
@@ -62,10 +62,10 @@ fn finalize_error_response(
     err: HandlerError,
 ) -> FutureResult<Response<Body>, CompatError> {
     {
-        // HandlerError::cause() is far more interesting for logging, but the
+        // HandlerError::source() is far more interesting for logging, but the
         // API doesn't guarantee its presence (even though it always is).
         let err_description = err
-            .cause()
+            .source()
             .map(Error::description)
             .unwrap_or_else(|| err.description());
 
@@ -170,9 +170,9 @@ mod tests {
 
     use hyper::{HeaderMap, Method, StatusCode};
 
-    use handler::{HandlerFuture, IntoHandlerError};
-    use helpers::http::response::create_empty_response;
-    use state::set_request_id;
+    use crate::handler::{HandlerFuture, IntoHandlerError};
+    use crate::helpers::http::response::create_empty_response;
+    use crate::state::set_request_id;
 
     #[test]
     fn success() {

--- a/gotham/src/state/client_addr.rs
+++ b/gotham/src/state/client_addr.rs
@@ -1,6 +1,6 @@
 //! Defines storage for the remote address of the client
 
-use state::{FromState, State, StateData};
+use crate::state::{FromState, State, StateData};
 use std::net::SocketAddr;
 
 struct ClientAddr {

--- a/gotham/src/state/data.rs
+++ b/gotham/src/state/data.rs
@@ -3,8 +3,8 @@ use std::any::Any;
 use cookie::CookieJar;
 use hyper::{Body, HeaderMap, Method, Uri, Version};
 
-use helpers::http::request::path::RequestPathSegments;
-use state::request_id::RequestId;
+use crate::helpers::http::request::path::RequestPathSegments;
+use crate::state::request_id::RequestId;
 
 /// A marker trait for types that can be stored in `State`.
 ///

--- a/gotham/src/state/from_state.rs
+++ b/gotham/src/state/from_state.rs
@@ -1,4 +1,4 @@
-use state::{State, StateData};
+use crate::state::{State, StateData};
 
 /// A trait for accessing data that is stored in `State`.
 ///
@@ -32,7 +32,7 @@ pub trait FromState: StateData + Sized {
     /// # });
     /// # }
     /// ```
-    fn try_borrow_from(&State) -> Option<&Self>;
+    fn try_borrow_from(state: &State) -> Option<&Self>;
 
     /// Borrows a value from the `State` storage.
     ///
@@ -63,7 +63,7 @@ pub trait FromState: StateData + Sized {
     /// # });
     /// # }
     /// ```
-    fn borrow_from(&State) -> &Self;
+    fn borrow_from(state: &State) -> &Self;
 
     /// Tries to mutably borrow a value from the `State` storage.
     ///
@@ -94,7 +94,7 @@ pub trait FromState: StateData + Sized {
     /// # });
     /// # }
     /// ```
-    fn try_borrow_mut_from(&mut State) -> Option<&mut Self>;
+    fn try_borrow_mut_from(state: &mut State) -> Option<&mut Self>;
 
     /// Mutably borrows a value from the `State` storage.
     ///
@@ -128,7 +128,7 @@ pub trait FromState: StateData + Sized {
     /// # });
     /// # }
     /// ```
-    fn borrow_mut_from(&mut State) -> &mut Self;
+    fn borrow_mut_from(state: &mut State) -> &mut Self;
 
     /// Tries to move a value out of the `State` storage and return ownership.
     ///
@@ -157,7 +157,7 @@ pub trait FromState: StateData + Sized {
     /// # });
     /// # }
     /// ```
-    fn try_take_from(&mut State) -> Option<Self>;
+    fn try_take_from(state: &mut State) -> Option<Self>;
 
     /// Moves a value out of the `State` storage and returns ownership.
     ///
@@ -188,7 +188,7 @@ pub trait FromState: StateData + Sized {
     /// # });
     /// # }
     /// ```
-    fn take_from(&mut State) -> Self;
+    fn take_from(state: &mut State) -> Self;
 }
 
 impl<T> FromState for T

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -8,12 +8,12 @@ pub mod request_id;
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
-pub use state::client_addr::client_addr;
-pub use state::data::StateData;
-pub use state::from_state::FromState;
-pub use state::request_id::request_id;
+pub use crate::state::client_addr::client_addr;
+pub use crate::state::data::StateData;
+pub use crate::state::from_state::FromState;
+pub use crate::state::request_id::request_id;
 
-pub(crate) use state::request_id::set_request_id;
+pub(crate) use crate::state::request_id::set_request_id;
 
 /// Provides storage for request state, and stores one item of each type. The types used for
 /// storage must implement the `gotham::state::StateData` trait to allow its storage. The

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -5,6 +5,8 @@ mod data;
 mod from_state;
 pub mod request_id;
 
+use log::trace;
+
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 

--- a/gotham/src/state/request_id.rs
+++ b/gotham/src/state/request_id.rs
@@ -1,6 +1,7 @@
 //! Defines a unique id per `Request` that should be output with all logging.
 
 use hyper::header::HeaderMap;
+use log::trace;
 use uuid::Uuid;
 
 use crate::state::{FromState, State};

--- a/gotham/src/state/request_id.rs
+++ b/gotham/src/state/request_id.rs
@@ -3,7 +3,7 @@
 use hyper::header::HeaderMap;
 use uuid::Uuid;
 
-use state::{FromState, State};
+use crate::state::{FromState, State};
 
 /// A container type for the value returned by `request_id`.
 pub(super) struct RequestId {

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -23,9 +23,9 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::timer::Delay;
 
-use handler::NewHandler;
+use crate::handler::NewHandler;
 
-use error::*;
+use crate::error::*;
 
 mod request;
 
@@ -438,9 +438,9 @@ mod tests {
     use hyper::{Body, Response, StatusCode, Uri};
     use mime;
 
-    use handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
-    use helpers::http::response::create_response;
-    use state::{client_addr, FromState, State};
+    use crate::handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
+    use crate::helpers::http::response::create_response;
+    use crate::state::{client_addr, FromState, State};
 
     #[derive(Clone)]
     struct TestHandler {

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -17,7 +17,7 @@ use hyper::client::{
     Client,
 };
 use hyper::header::CONTENT_TYPE;
-use hyper::{Body, Method, Request, Response, Uri};
+use hyper::{Body, Method, Response, Uri};
 use log::{info, warn};
 use mime;
 use tokio::net::{TcpListener, TcpStream};

--- a/gotham/src/test/mod.rs
+++ b/gotham/src/test/mod.rs
@@ -17,7 +17,8 @@ use hyper::client::{
     Client,
 };
 use hyper::header::CONTENT_TYPE;
-use hyper::{Body, Method, Response, Uri};
+use hyper::{Body, Method, Request, Response, Uri};
+use log::{info, warn};
 use mime;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Runtime;

--- a/gotham/src/test/request.rs
+++ b/gotham/src/test/request.rs
@@ -5,9 +5,9 @@ use http::HttpTryFrom;
 use hyper::header::{HeaderValue, IntoHeaderName};
 use hyper::{Body, Method, Request, Uri};
 
-use test::{TestClient, TestResponse};
+use super::{TestClient, TestResponse};
 
-use error::*;
+use crate::error::*;
 
 /// Builder API for constructing `TestServer` requests. When the request is built,
 /// `RequestBuilder::perform` will issue the request and provide access to the response.

--- a/gotham_derive/Cargo.toml
+++ b/gotham_derive/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/gotham-rs/gotham"
 categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "framework", "gotham"]
+edition = "2018"
 
 [dependencies]
 syn = "0.15"

--- a/gotham_derive/src/extenders.rs
+++ b/gotham_derive/src/extenders.rs
@@ -1,4 +1,5 @@
 use proc_macro;
+use quote::quote;
 use syn;
 
 pub(crate) fn bad_request_static_response_extender(

--- a/gotham_derive/src/extractors.rs
+++ b/gotham_derive/src/extractors.rs
@@ -1,4 +1,5 @@
 use proc_macro;
+use quote::quote;
 use syn;
 
 pub(crate) fn base_path(_ast: &syn::DeriveInput) -> proc_macro::TokenStream {

--- a/gotham_derive/src/lib.rs
+++ b/gotham_derive/src/lib.rs
@@ -1,9 +1,5 @@
 #![recursion_limit = "256"]
-
 extern crate proc_macro;
-#[macro_use]
-extern crate quote;
-extern crate syn;
 
 mod extenders;
 mod extractors;

--- a/gotham_derive/src/new_middleware.rs
+++ b/gotham_derive/src/new_middleware.rs
@@ -1,4 +1,5 @@
 use proc_macro;
+use quote::quote;
 use syn;
 
 pub(crate) fn new_middleware(ast: &syn::DeriveInput) -> proc_macro::TokenStream {

--- a/gotham_derive/src/state.rs
+++ b/gotham_derive/src/state.rs
@@ -1,4 +1,5 @@
 use proc_macro;
+use quote::quote;
 use syn;
 
 pub(crate) fn state_data(ast: &syn::DeriveInput) -> proc_macro::TokenStream {


### PR DESCRIPTION
This PR updates gotham/gotham_derive to Rust 2018. I didn't update the examples (yet), because I'm not sure if that might be "too soon" for general audiences.