### PR TITLE
Re-exporting all of plain

### DIFF
--- a/examples/hello_world_until/src/main.rs
+++ b/examples/hello_world_until/src/main.rs
@@ -30,7 +30,7 @@ pub fn say_hello(state: State) -> (State, Response<Body>) {
 pub fn main() {
     let addr = "127.0.0.1:7878";
 
-    let server = gotham::plain::init_server(addr, || Ok(say_hello));
+    let server = gotham::init_server(addr, || Ok(say_hello));
     // Future to wait for Ctrl+C.
     let signal = tokio_signal::ctrl_c()
         .flatten_stream()

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -50,7 +50,7 @@ use std::net::ToSocketAddrs;
 use tokio::net::TcpListener;
 use tokio::runtime::{self, Runtime};
 
-pub use plain::start;
+pub use plain::*;
 
 fn new_runtime(threads: usize) -> Runtime {
     runtime::Builder::new()


### PR DESCRIPTION
Secure interfaces remain available behind `gotham::tls`