### PR TITLE
Repairs for beta and nightly compilers

### DIFF
--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -24,7 +24,7 @@ use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-type ResponseContentFuture = Box<Future<Item = Vec<u8>, Error = hyper::Error> + Send>;
+type ResponseContentFuture = Box<dyn Future<Item = Vec<u8>, Error = hyper::Error> + Send>;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -25,7 +25,7 @@ use gotham::state::{FromState, State};
 
 use tokio::timer::Delay;
 
-type SleepFuture = Box<Future<Item = Vec<u8>, Error = HandlerError> + Send>;
+type SleepFuture = Box<dyn Future<Item = Vec<u8>, Error = HandlerError> + Send>;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -12,7 +12,7 @@ use crate::state::{request_id, State};
 /// `Response`.
 pub struct HandlerError {
     status_code: StatusCode,
-    cause: Box<Error + Send>,
+    cause: Box<dyn Error + Send>,
 }
 
 /// Allows conversion into a HandlerError from an implementing type.
@@ -81,7 +81,7 @@ impl Error for HandlerError {
         "handler failed to process request"
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         Some(&*self.cause)
     }
 }

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -27,7 +27,7 @@ pub use self::error::{HandlerError, IntoHandlerError};
 /// When the `Future` resolves to an error, the `(State, HandlerError)` value is used to generate
 /// an appropriate HTTP error response.
 pub type HandlerFuture =
-    Future<Item = (State, Response<Body>), Error = (State, HandlerError)> + Send;
+    dyn Future<Item = (State, Response<Body>), Error = (State, HandlerError)> + Send;
 
 /// A `Handler` is an asynchronous function, taking a `State` value which represents the request
 /// and related runtime state, and returns a future which resolves to a response.

--- a/gotham/src/middleware/session/backend/mod.rs
+++ b/gotham/src/middleware/session/backend/mod.rs
@@ -17,7 +17,7 @@ pub trait NewBackend: Sync + Clone + RefUnwindSafe {
 }
 
 /// Type alias for the trait objects returned by `Backend`.
-pub type SessionFuture = Future<Item = Option<Vec<u8>>, Error = SessionError> + Send;
+pub type SessionFuture = dyn Future<Item = Option<Vec<u8>>, Error = SessionError> + Send;
 
 /// A `Backend` receives session data and stores it, and recalls the session data subsequently.
 ///

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -273,7 +273,7 @@ where
     cookie_state: SessionCookieState,
     state: SessionDataState,
     identifier: SessionIdentifier,
-    backend: Box<Backend + Send>,
+    backend: Box<dyn Backend + Send>,
     cookie_config: Arc<SessionCookieConfig>,
 }
 
@@ -463,7 +463,7 @@ where
     new_backend: B,
     identifier_rng: Arc<Mutex<rng::SessionIdentifierRng>>,
     cookie_config: Arc<SessionCookieConfig>,
-    phantom: PhantomData<SessionTypePhantom<T>>,
+    phantom: PhantomData<dyn SessionTypePhantom<T>>,
 }
 
 /// The per-request value which provides session storage for other middleware and handlers.

--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -180,7 +180,7 @@ impl Connect for TestConnect {
     type Transport = TcpStream;
     type Error = CompatError;
     type Future =
-        Box<Future<Item = (Self::Transport, Connected), Error = Self::Error> + Send + Sync>;
+        Box<dyn Future<Item = (Self::Transport, Connected), Error = Self::Error> + Send + Sync>;
 
     fn connect(&self, _dst: Destination) -> Self::Future {
         Box::new(

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -141,7 +141,7 @@ impl Router {
         &self,
         mut state: State,
         params: SegmentMapping<'a>,
-        route: &Box<Route<ResBody = Body> + Send + Sync>,
+        route: &Box<dyn Route<ResBody = Body> + Send + Sync>,
     ) -> Box<HandlerFuture> {
         match route.extract_request_path(&mut state, params) {
             Ok(()) => {

--- a/gotham/src/router/response/finalizer.rs
+++ b/gotham/src/router/response/finalizer.rs
@@ -19,12 +19,12 @@ use crate::router::response::extender::ResponseExtender;
 /// configuring `ResponseExtender` values for each `StatusCode`.
 #[derive(Clone)]
 pub struct ResponseFinalizer {
-    data: Arc<HashMap<StatusCode, Box<ResponseExtender<Body> + Send + Sync>>>,
+    data: Arc<HashMap<StatusCode, Box<dyn ResponseExtender<Body> + Send + Sync>>>,
 }
 
 /// Builds an immutable `ResponseFinalizer`.
 pub struct ResponseFinalizerBuilder {
-    data: HashMap<StatusCode, Box<ResponseExtender<Body> + Send + Sync>>,
+    data: HashMap<StatusCode, Box<dyn ResponseExtender<Body> + Send + Sync>>,
 }
 
 impl ResponseFinalizerBuilder {
@@ -46,7 +46,7 @@ impl ResponseFinalizerBuilder {
     pub fn add(
         &mut self,
         status_code: StatusCode,
-        extender: Box<ResponseExtender<Body> + Send + Sync>,
+        extender: Box<dyn ResponseExtender<Body> + Send + Sync>,
     ) {
         trace!(" adding response extender for {}", status_code);
         self.data.insert(status_code, extender);

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -97,7 +97,7 @@ where
     QSE: QueryStringExtractor<Body>,
 {
     matcher: RM,
-    dispatcher: Box<Dispatcher + Send + Sync>,
+    dispatcher: Box<dyn Dispatcher + Send + Sync>,
     _extractors: Extractors<PE, QSE>,
     delegation: Delegation,
 }
@@ -122,7 +122,7 @@ where
     /// Creates a new `RouteImpl` from the provided components.
     pub fn new(
         matcher: RM,
-        dispatcher: Box<Dispatcher + Send + Sync>,
+        dispatcher: Box<dyn Dispatcher + Send + Sync>,
         _extractors: Extractors<PE, QSE>,
         delegation: Delegation,
     ) -> Self {

--- a/gotham/src/router/tree/mod.rs
+++ b/gotham/src/router/tree/mod.rs
@@ -35,7 +35,7 @@ impl Tree {
     }
 
     /// Adds a `Route` be evaluated by the `Router` when the root of the `Tree` is requested.
-    pub fn add_route(&mut self, route: Box<Route<ResBody = Body> + Send + Sync>) {
+    pub fn add_route(&mut self, route: Box<dyn Route<ResBody = Body> + Send + Sync>) {
         self.root.add_route(route);
     }
 

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 pub struct Node {
     segment: String,
     segment_type: SegmentType,
-    routes: Vec<Box<Route<ResBody = Body> + Send + Sync>>,
+    routes: Vec<Box<dyn Route<ResBody = Body> + Send + Sync>>,
     children: Vec<Node>,
 }
 
@@ -43,7 +43,7 @@ impl Node {
     }
 
     /// Adds a `Route` to this `Node`, to be potentially evaluated by the `Router`.
-    pub fn add_route(&mut self, route: Box<Route<ResBody = Body> + Send + Sync>) -> &mut Self {
+    pub fn add_route(&mut self, route: Box<dyn Route<ResBody = Body> + Send + Sync>) -> &mut Self {
         self.routes.push(route);
         self
     }
@@ -127,7 +127,7 @@ impl Node {
     pub fn select_route(
         &self,
         state: &State,
-    ) -> Result<&Box<Route<ResBody = Body> + Send + Sync>, RouteNonMatch> {
+    ) -> Result<&Box<dyn Route<ResBody = Body> + Send + Sync>, RouteNonMatch> {
         let mut err = Ok(());
 
         // check for matching routes
@@ -306,7 +306,7 @@ mod tests {
         (state, Response::new(Body::empty()))
     }
 
-    fn get_route<P>(pipeline_set: PipelineSet<P>) -> Box<Route<ResBody = Body> + Send + Sync>
+    fn get_route<P>(pipeline_set: PipelineSet<P>) -> Box<dyn Route<ResBody = Body> + Send + Sync>
     where
         P: Send + Sync + RefUnwindSafe + 'static,
     {

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -65,7 +65,7 @@ where
     type ReqBody = Body; // required by hyper::server::conn::Http::serve_connection()
     type ResBody = Body; // has to impl Payload...
     type Error = failure::Compat<failure::Error>; // :Into<Box<StdError + Send + Sync>>
-    type Future = Box<Future<Item = Response<Self::ResBody>, Error = Self::Error> + Send>;
+    type Future = Box<dyn Future<Item = Response<Self::ResBody>, Error = Self::Error> + Send>;
 
     fn call(&mut self, req: Request<Self::ReqBody>) -> Self::Future {
         let mut state = State::new();

--- a/gotham/src/service/trap.rs
+++ b/gotham/src/service/trap.rs
@@ -26,7 +26,7 @@ type CompatError = failure::Compat<failure::Error>;
 pub(super) fn call_handler<'a, T>(
     t: &T,
     state: AssertUnwindSafe<State>,
-) -> Box<Future<Item = Response<Body>, Error = CompatError> + Send + 'a>
+) -> Box<dyn Future<Item = Response<Body>, Error = CompatError> + Send + 'a>
 where
     T: NewHandler + 'a,
 {
@@ -91,7 +91,7 @@ fn finalize_panic_response() -> FutureResult<Response<Body>, CompatError> {
 }
 
 fn finalize_catch_unwind_response(
-    result: Result<Result<Response<Body>, CompatError>, Box<Any + Send>>,
+    result: Result<Result<Response<Body>, CompatError>, Box<dyn Any + Send>>,
 ) -> FutureResult<Response<Body>, CompatError> {
     let response = result
         .unwrap_or_else(|_| {

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -45,7 +45,7 @@ pub(crate) use crate::state::request_id::set_request_id;
 /// # }
 /// ```
 pub struct State {
-    data: HashMap<TypeId, Box<Any + Send>>,
+    data: HashMap<TypeId, Box<dyn Any + Send>>,
 }
 
 impl State {

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -232,7 +232,7 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
 ///
 pub struct TestResponse {
     response: Response<Body>,
-    reader: Box<BodyReader>,
+    reader: Box<dyn BodyReader>,
 }
 
 impl Deref for TestResponse {

--- a/gotham/src/tls/test.rs
+++ b/gotham/src/tls/test.rs
@@ -203,7 +203,7 @@ impl Connect for TestConnect {
     type Transport = TlsStream<TcpStream, ClientSession>;
     type Error = CompatError;
     type Future =
-        Box<Future<Item = (Self::Transport, Connected), Error = Self::Error> + Send + Sync>;
+        Box<dyn Future<Item = (Self::Transport, Connected), Error = Self::Error> + Send + Sync>;
 
     fn connect(&self, dst: Destination) -> Self::Future {
         let tls = TlsConnector::from(self.config.clone());

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -69,7 +69,7 @@ use std::{io, marker::PhantomData, panic::RefUnwindSafe};
 ///     let pipelines = new_pipeline_set();
 ///     let (pipelines, defaults) = pipelines.add(
 ///         new_pipeline()
-///             .add(JWTMiddleware::<Claims>::new("secret".as_ref()))
+///             .add(JWTMiddleware::<Claims>::new("secret"))
 ///             .build(),
 ///     );
 ///     let default_chain = (defaults, ());


### PR DESCRIPTION
This PR resolves tests from CI that were broken by #324. It also updates the code base to latest Rust coding standards, like using [`dyn` for trait objects](https://doc.rust-lang.org/stable/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html).