### PR TITLE
Fix a broken link in the examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ information on functionality and ordering.
 | [Headers](headers) | Working with HTTP Headers. | 1 |
 | [Handlers](handlers) | Developing application logic that responds to web requests. | 5 |
 | [Middleware](middleware) | Developing custom middleware for your application. | 1 |
-| [Shared State](stared_state) | Sharing state across your application. | 1 |
+| [Shared State](shared_state) | Sharing state across your application. | 1 |
 | [Into Response](into_response) | Implementing the Gotham web framework's `IntoResponse` trait. | 1 |
 | [Templating](templating) | An example using various templating engines. | 1 |
 | [Static Assets](static_assets) | Serving static assets. | 1 |


### PR DESCRIPTION
Link to `shared_state` example was mistyped and was returning 404.