### PR TITLE
Fix an issue with missing cookie values

### DIFF
--- a/gotham/src/middleware/cookie/mod.rs
+++ b/gotham/src/middleware/cookie/mod.rs
@@ -24,6 +24,7 @@ impl CookieParser {
             .get_all(COOKIE)
             .iter()
             .flat_map(HeaderValue::to_str)
+            .flat_map(|cs| cs.split("; "))
             .flat_map(|cs| Cookie::parse(cs.to_owned()))
             .fold(CookieJar::new(), |mut jar, cookie| {
                 jar.add_original(cookie);


### PR DESCRIPTION
This fixes #330.

There's a dumb bug where it's only parsing the first cookie per header; this ensures that it parses all cookies. Very simple change, slightly annoying it got through the first time :p 