### PR TITLE
Fix #348: Support trailing slashes when building a route

### DIFF
--- a/gotham/src/helpers/http/request/path.rs
+++ b/gotham/src/helpers/http/request/path.rs
@@ -12,6 +12,10 @@ pub struct RequestPathSegments {
     segments: Vec<PercentDecoded>,
 }
 
+pub(crate) fn split_path_segments<'a>(path: &'a str) -> impl Iterator<Item = &'a str> {
+    path.split('/').filter(|s| !EXCLUDED_SEGMENTS.contains(s))
+}
+
 impl RequestPathSegments {
     /// Creates a new RequestPathSegments instance by splitting a `Request` URI path.
     ///
@@ -23,9 +27,7 @@ impl RequestPathSegments {
     /// ["/", "some", "path", "to", "my", "handler"]
     /// ```
     pub(crate) fn new(path: &str) -> Self {
-        let segments = path
-            .split('/')
-            .filter(|s| !EXCLUDED_SEGMENTS.contains(s))
+        let segments = split_path_segments(path)
             .filter_map(PercentDecoded::new)
             .collect();
 

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -5,6 +5,7 @@ use hyper::Method;
 use log::trace;
 
 use crate::extractor::{NoopPathExtractor, NoopQueryStringExtractor};
+use crate::helpers::http::request::path::split_path_segments;
 use crate::pipeline::chain::PipelineHandleChain;
 use crate::pipeline::set::PipelineSet;
 use crate::router::builder::{
@@ -875,7 +876,7 @@ fn descend<'n>(node_builder: &'n mut Node, path: &str) -> &'n mut Node {
     if path.is_empty() {
         node_builder
     } else {
-        build_subtree(node_builder, path.split('/'))
+        build_subtree(node_builder, split_path_segments(path))
     }
 }
 


### PR DESCRIPTION
Uniformizes the parsing of path segments between `RouterBuilder` and
`RequestPathSegments`.

This fixes #348 