### PR TITLE
WIP Websocket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,9 @@ members = [
     "examples/diesel",
 
     # example_contribution_template
-    "examples/example_contribution_template/name"
+    "examples/example_contribution_template/name",
+
+    "examples/websocket",
 ]
 
 [patch.crates-io]

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "websocket"
+version = "0.1.0"
+authors = ["Vickenty Fesunov <kent@setattr.net>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+gotham = { path = "../../gotham" }
+hyper = "0.12"
+futures = "0.1"
+tokio-tungstenite = "0.9"
+pretty_env_logger = "0.3"
+sha1 = "*"
+base64 = "*"

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -1,0 +1,29 @@
+# Websocket
+
+Shows how to use Gotham with Tungstenite
+
+## Running
+
+From the `examples/websocket` directory:
+
+```
+Terminal 1:
+  $ cargo run
+    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
+     Running `.../gotham/target/debug/websocket`
+Listening on http://127.0.0.1:7878/
+```
+
+## License
+
+Licensed under your option of:
+
+* [MIT License](../../LICENSE-MIT)
+* [Apache License, Version 2.0](../../LICENSE-APACHE)
+
+## Community
+
+The following policies guide participation in our project and our community:
+
+* [Code of conduct](../../CODE_OF_CONDUCT.md)
+* [Contributing](../../CONTRIBUTING.md)

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -1,0 +1,95 @@
+use futures::{Future, Sink, Stream};
+use gotham::state::{request_id, FromState, State};
+use hyper::{Body, HeaderMap, Response, StatusCode};
+
+mod ws;
+
+fn main() {
+    pretty_env_logger::init();
+
+    let addr = "127.0.0.1:7878";
+    println!("Listening on http://{}/", addr);
+
+    gotham::start(addr, || Ok(handler));
+}
+
+fn handler(mut state: State) -> (State, Response<Body>) {
+    let body = Body::take_from(&mut state);
+    let headers = HeaderMap::take_from(&mut state);
+
+    if ws::requested(&headers) {
+        let (response, ws) = match ws::accept(&headers, body) {
+            Ok(res) => res,
+            Err(_) => return bad_request(state),
+        };
+
+        let req_id = request_id(&state).to_owned();
+        let ws = ws
+            .map_err(|err| eprintln!("websocket init error: {}", err))
+            .and_then(move |ws| connected(req_id, ws));
+
+        hyper::rt::spawn(ws);
+
+        (state, response)
+    } else {
+        (state, Response::new(Body::from(INDEX_HTML)))
+    }
+}
+
+fn connected<S>(req_id: String, stream: S) -> impl Future<Item = (), Error = ()>
+where
+    S: Stream<Item = ws::Message, Error = ws::Error>
+        + Sink<SinkItem = ws::Message, SinkError = ws::Error>,
+{
+    let (sink, stream) = stream.split();
+
+    println!("Client {} connected", req_id);
+
+    sink.send_all(stream.map({
+        let req_id = req_id.clone();
+        move |msg| {
+            println!("{}: {:?}", req_id, msg);
+            msg
+        }
+    }))
+    .map_err(|err| println!("Websocket error: {}", err))
+    .map(move |_| println!("Client {} disconnected", req_id))
+}
+
+fn bad_request(state: State) -> (State, Response<Body>) {
+    let response = Response::builder()
+        .status(StatusCode::BAD_REQUEST)
+        .body(Body::empty())
+        .unwrap();
+    (state, response)
+}
+
+const INDEX_HTML: &str = r#"
+<!DOCTYPE html>
+<body>
+<h1>Websocket Echo Server</h1>
+<form id="ws" onsubmit="return send(this.message);">
+    <input name="message">
+    <input type="submit" value="Send">    
+</form>
+<script>
+    var sock = new WebSocket("ws://" + window.location.host);
+    sock.onopen = recv.bind(window, "Connected");
+    sock.onclose = recv.bind(window, "Disconnected");
+    sock.onmessage = function(msg) { recv(msg.data) };
+    sock.onerror = function(err) { recv("Error: " + e); };
+
+    function recv(msg) {
+        var e = document.createElement("PRE");
+        e.innerText = msg;
+        document.body.appendChild(e);
+    }
+
+    function send(msg) {
+        sock.send(msg.value);
+        msg.value = "";
+        return false;
+    }
+</script>
+</body>
+"#;

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -1,0 +1,60 @@
+use base64;
+use futures::Future;
+use hyper::header::{HeaderValue, CONNECTION, UPGRADE};
+use hyper::{upgrade::Upgraded, Body, HeaderMap, Response, StatusCode};
+use sha1::Sha1;
+use tokio_tungstenite::{tungstenite, WebSocketStream};
+
+pub use tungstenite::protocol::{Message, Role};
+pub use tungstenite::Error;
+
+const PROTO_WEBSOCKET: &str = "websocket";
+const SEC_WEBSOCKET_KEY: &str = "Sec-WebSocket-Key";
+const SEC_WEBSOCKET_ACCEPT: &str = "Sec-WebSocket-Accept";
+
+/// Check if a WebSocket upgrade was requested.
+pub fn requested(headers: &HeaderMap) -> bool {
+    headers.get(UPGRADE) == Some(&HeaderValue::from_static(PROTO_WEBSOCKET))
+}
+
+/// Accept a WebSocket upgrade request.
+///
+/// Returns HTTP response, and a future that eventually resolves
+/// into websocket object.
+pub fn accept(
+    headers: &HeaderMap,
+    body: Body,
+) -> Result<
+    (
+        Response<Body>,
+        impl Future<Item = WebSocketStream<Upgraded>, Error = hyper::Error>,
+    ),
+    (),
+> {
+    let res = response(headers)?;
+    let ws = body
+        .on_upgrade()
+        .map(|upgraded| WebSocketStream::from_raw_socket(upgraded, Role::Server, None));
+
+    Ok((res, ws))
+}
+
+fn response(headers: &HeaderMap) -> Result<Response<Body>, ()> {
+    let key = headers.get(SEC_WEBSOCKET_KEY).ok_or(())?;
+
+    Ok(Response::builder()
+        .header(UPGRADE, PROTO_WEBSOCKET)
+        .header(CONNECTION, "upgrade")
+        .header(SEC_WEBSOCKET_ACCEPT, accept_key(key.as_bytes()))
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .body(Body::empty())
+        .unwrap())
+}
+
+fn accept_key(key: &[u8]) -> String {
+    const WS_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    let mut sha1 = Sha1::default();
+    sha1.update(key);
+    sha1.update(WS_GUID);
+    base64::encode(&sha1.digest().bytes())
+}

--- a/gotham/src/plain.rs
+++ b/gotham/src/plain.rs
@@ -78,7 +78,10 @@ where
         .for_each(move |socket| {
             let addr = socket.peer_addr().unwrap();
             let service = gotham_service.connect(addr);
-            let handler = protocol.serve_connection(socket, service).then(|_| Ok(()));
+            let handler = protocol
+                .serve_connection(socket, service)
+                .with_upgrades()
+                .then(|_| Ok(()));
 
             executor::spawn(handler);
 

--- a/gotham/src/tls.rs
+++ b/gotham/src/tls.rs
@@ -103,6 +103,7 @@ where
                 .and_then(move |socket| {
                     accepted_protocol
                         .serve_connection(socket, service)
+                        .with_upgrades()
                         .map_err(|e| panic!("http error = {:?}", e))
                 });
 


### PR DESCRIPTION
This adds minimal support for websockets to gotham.

More precisely, it enables protocol upgrades on hyper requests, which is sufficient to handle websocket requests from the user code, without adding anything else to gotham.

While this make it possible to handle websockets (or other protocol upgrades), it doesn't make it ergonomic. Websocket implementations that I tried to use (rust-websocket and tungstenite) do not seem to provide a way to integrate their handshake implementations with Hyper (even when websockets uses hyper internally).

In the example I ended up implementing the handshake part myself, handing the upgraded connection to tungstenite to take care of the actual protocol. It works, but it is hardly an example to follow.

So I would like to use this PR to share my findings, and collect feedback about which direction to take this. Hopefully both rust-websocket and tungstenite can be improved to play along with hyper.