### PR TITLE
Surface the source() fn in HandlerError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: rust
 sudo: required
 dist: trusty
+addons:
+  apt:
+    packages:
+      - libssl-dev
 env:
   - PATH=$HOME/.cargo/bin:$PATH
 script:
@@ -14,9 +18,7 @@ matrix:
     # Run rustfmt in its own shard.
     - rust: stable
       env:
-        # Give a useful display name in the job list.
         - SHARD=rustfmt
-        - PATH=$HOME/.cargo/bin/:$PATH
       before_script:
         - rustup component add --toolchain stable rustfmt-preview
       script:
@@ -26,21 +28,21 @@ matrix:
     - rust: stable
       env:
         - SHARD=clippy
-        - PATH=$HOME/.cargo/bin/:$PATH
       before_script:
         - rustup component add --toolchain stable clippy
       script:
         - echo "Checking Gotham codebase with Clippy release `cargo clippy --version`."
         - cargo clippy --all --profile test
+    # Run coverage in its own shard.
+    - rust: stable
+      env:
+        - SHARD=coverage
+      before_script:
+        - cargo install -f cargo-tarpaulin
+      script:
+        - cargo tarpaulin --all --forward --out Xml
+        - bash <(curl -s https://codecov.io/bash)
   allow_failures:
     - rust: nightly
-addons:
-  apt:
-    packages:
-        - libssl-dev
-after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == stable && "$SHARD" != rustfmt ]]; then
-    cargo install cargo-tarpaulin
-    cargo tarpaulin --all --forward --out Xml
-    bash <(curl -s https://codecov.io/bash)
-  fi
+    - env:
+        - SHARD=coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons:
         - libssl-dev
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable && "$SHARD" != rustfmt ]]; then
-    bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+    cargo install cargo-tarpaulin
     cargo tarpaulin --all --forward --out Xml
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/examples/diesel/src/main.rs
+++ b/examples/diesel/src/main.rs
@@ -29,7 +29,7 @@ use schema::products;
 // For this example, we'll use a static database URL,
 // although one might commonly pass this in via
 // environment variables instead.
-static DATABASE_URL: &'static str = "products.db";
+static DATABASE_URL: &str = "products.db";
 
 // We'll use a file based Sqlite database to keep things simple.
 // Don't forget to run the step in the README to create the database
@@ -142,7 +142,7 @@ mod tests {
     use std::str;
     use tokio::runtime;
 
-    static DATABASE_URL: &'static str = ":memory:";
+    static DATABASE_URL: &str = ":memory:";
 
     // For this example, we run migrations automatically in each test.
     // You could also choose to do this separately using something like

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -240,17 +240,14 @@ fn router() -> Router {
             .get("/series")
             .with_query_string_extractor::<QueryStringExtractor>()
             .to(series_handler);
-        ;
         route
             .get("/loop")
             .with_query_string_extractor::<QueryStringExtractor>()
             .to(loop_handler);
-        ;
         route
             .get("/parallel")
             .with_query_string_extractor::<QueryStringExtractor>()
             .to(parallel_handler);
-        ;
     })
 }
 

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -134,12 +134,10 @@ fn router() -> Router {
             .get("/sleep")
             .with_query_string_extractor::<QueryStringExtractor>()
             .to(sleep_handler);
-        ;
         route
             .get("/loop")
             .with_query_string_extractor::<QueryStringExtractor>()
             .to(loop_handler);
-        ;
     })
 }
 

--- a/examples/hello_world_until/src/main.rs
+++ b/examples/hello_world_until/src/main.rs
@@ -105,7 +105,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn signal_self() {
-        let thread_handle = thread::spawn(|| main());
+        let thread_handle = thread::spawn(main);
 
         // Wait until server will be able to answer.
         let mut max_retries = 25;

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -11,8 +11,8 @@ extern crate tera;
 use gotham::state::State;
 use tera::{Context, Tera};
 
-/// Assuming the Rust file is at the same level as the templates folder
-/// we can get a Tera instance that way:
+// Assuming the Rust file is at the same level as the templates folder
+// we can get a Tera instance that way:
 lazy_static! {
     pub static ref TERA: Tera =
         compile_templates!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/**/*"));

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -24,7 +24,7 @@ bincode = "1.0"
 mime = "0.3"
 # Using alpha version of mime_guess until mime crate stabilizes (releases 1.0).
 # see https://github.com/hyperium/mime/issues/52
-mime_guess = "2.0.0-alpha.6"
+mime_guess = "2.0.1"
 futures = "0.1"
 tokio = "0.1"
 bytes = "0.4"

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -84,6 +84,10 @@ impl Error for HandlerError {
     fn cause(&self) -> Option<&dyn Error> {
         Some(&*self.cause)
     }
+
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.cause.source()
+    }
 }
 
 impl HandlerError {

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -197,6 +197,7 @@ impl SessionCookieConfig {
 /// # extern crate bincode;
 /// # extern crate mime;
 /// #
+/// # use std::sync::Arc;
 /// # use std::time::Duration;
 /// # use futures::future;
 /// # use gotham::handler::HandlerFuture;
@@ -241,9 +242,12 @@ impl SessionCookieConfig {
 /// #   backend.persist_session(identifier.clone(), &bytes[..]).unwrap();
 /// #
 /// #   let nm = NewSessionMiddleware::new(backend).with_session_type::<MySessionType>();
+/// #   let nm = Arc::new(nm);
 /// #
 /// #   let new_handler = move || {
-/// #       let handler = |state| {
+/// #       let nm = nm.clone();
+/// #
+/// #       let handler = move |state| {
 /// #           let m = nm.new_middleware().unwrap();
 /// #           let chain = |state| Box::new(future::ok(my_handler(state))) as Box<HandlerFuture>;
 /// #

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -210,8 +210,7 @@ pub trait DefineSingleRoute {
     /// ```
     fn to_dir<P>(self, options: P)
     where
-        Self: Sized,
-        Self: ReplacePathExtractor<FilePathExtractor>,
+        Self: ReplacePathExtractor<FilePathExtractor> + Sized,
         Self::Output: DefineSingleRoute,
         FileOptions: From<P>,
     {


### PR DESCRIPTION
This might fix #359.

Basically we just surface the `source()` function from the `Error` trait correctly, by delegating to the internal error.