### PR TITLE
diesel middleware features: r2d2 instead of extras

### DIFF
--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["http", "async", "web", "gotham", "diesel"]
 futures = "0.1"
 gotham = "0.5.0-dev"
 gotham_derive = "0.5.0-dev"
-diesel = { version = "1.3", features = ["extras"] }
+diesel = { version = "1.3", features = ["r2d2"] }
 r2d2 = "0.8"
 tokio-threadpool = "0.1"
 log = "0.4"


### PR DESCRIPTION
There is no need to require features that aren't used by the middleware.