### PR TITLE
Migrate Gotham to std Futures to support Async/Await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,15 @@ members = [
 
     ## Middleware
     "middleware/template",
-    "middleware/diesel",
-    "middleware/jwt",
+    # TODO: Re-enable middleware when their dependencies are updated
+    # "middleware/diesel",
+    # "middleware/jwt",
 
     ## Examples (these crates are not published)
     "examples/hello_world",
     "examples/hello_world_tls",
-    "examples/hello_world_until",
+    # TODO: Re-enable when the tokio-signal dependency is updated
+    # "examples/hello_world_until",
     "examples/shared_state",
 
     # Tera template
@@ -65,15 +67,18 @@ members = [
     "examples/static_assets",
 
     # diesel
-    "examples/diesel",
+    # TODO: Re-enable when the middleware is updated
+    # "examples/diesel",
 
     # openssl
-    "examples/openssl",
+    # TODO: Re-enable when this example is updated
+    # "examples/openssl",
 
     # example_contribution_template
     "examples/example_contribution_template/name",
 
-    "examples/websocket",
+    # TODO: Re-enable when tokio-tungstenite is updated
+    # "examples/websocket",
 ]
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ members = [
     ## Examples (these crates are not published)
     "examples/hello_world",
     "examples/hello_world_tls",
-    # TODO: Re-enable when the tokio-signal dependency is updated
-    # "examples/hello_world_until",
+    "examples/hello_world_until",
     "examples/shared_state",
 
     # Tera template

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ members = [
 
     ## Middleware
     "middleware/template",
+    "middleware/diesel",
     # TODO: Re-enable middleware when their dependencies are updated
-    # "middleware/diesel",
     # "middleware/jwt",
 
     ## Examples (these crates are not published)
@@ -66,8 +66,7 @@ members = [
     "examples/static_assets",
 
     # diesel
-    # TODO: Re-enable when the middleware is updated
-    # "examples/diesel",
+    "examples/diesel",
 
     # openssl
     # TODO: Re-enable when this example is updated

--- a/examples/cookies/introduction/Cargo.toml
+++ b/examples/cookies/introduction/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 cookie = "0.12"

--- a/examples/cookies/introduction/Cargo.toml
+++ b/examples/cookies/introduction/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 cookie = "0.12"

--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 gotham = { path = "../../gotham/"}
 gotham_derive = { path = "../../gotham_derive/" }
 gotham_middleware_diesel = { path = "../../middleware/diesel"}
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
-futures-preview = "0.3.0-alpha.19"
+hyper = "0.13.1"
+futures = "0.3.1"
 mime = "0.3"
 log = "0.4"
 diesel = { version = "1.4", features = ["sqlite", "extras"] }
@@ -25,4 +25,4 @@ serde_derive = "1.0"
 
 [dev-dependencies]
 diesel_migrations = "1.4.0"
-tokio = "=0.2.0-alpha.6"
+tokio = { version = "0.2.6", features = ["full"] }

--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 gotham = { path = "../../gotham/"}
 gotham_derive = { path = "../../gotham_derive/" }
 gotham_middleware_diesel = { path = "../../middleware/diesel"}
-hyper = "0.12"
-futures = "0.1"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures-preview = "0.3.0-alpha.19"
 mime = "0.3"
 log = "0.4"
 diesel = { version = "1.4", features = ["sqlite", "extras"] }
@@ -25,4 +25,4 @@ serde_derive = "1.0"
 
 [dev-dependencies]
 diesel_migrations = "1.4.0"
-tokio = "0.1"
+tokio = "=0.2.0-alpha.6"

--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -12,6 +12,7 @@ gotham = { path = "../../gotham/"}
 gotham_derive = { path = "../../gotham_derive/" }
 gotham_middleware_diesel = { path = "../../middleware/diesel"}
 hyper = "0.13.1"
+failure = "0.1"
 futures = "0.3.1"
 mime = "0.3"
 log = "0.4"

--- a/examples/diesel/src/main.rs
+++ b/examples/diesel/src/main.rs
@@ -16,8 +16,9 @@ use gotham::pipeline::{new_pipeline, single::single_pipeline};
 use gotham::router::{builder::*, Router};
 use gotham::state::{FromState, State};
 use gotham_middleware_diesel::DieselMiddleware;
-use hyper::{Body, StatusCode};
+use hyper::{body, Body, StatusCode};
 use serde_derive::Serialize;
+use std::pin::Pin;
 use std::str::from_utf8;
 
 mod models;
@@ -45,43 +46,48 @@ struct RowsUpdated {
 
 fn create_product_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let repo = Repo::borrow_from(&state).clone();
-    extract_json::<NewProduct>(&mut state)
-        .and_then(move |product| {
-            repo.run(move |conn| {
-                // Insert the `NewProduct` in the DB
+    async move {
+        let product = match extract_json::<NewProduct>(&mut state).await {
+            Ok(product) => product,
+            Err(e) => return Err((state, e)),
+        };
+
+        let rows = match repo
+            .run(move |conn| {
                 diesel::insert_into(products::table)
                     .values(&product)
                     .execute(&conn)
             })
-            .map_err(|e| e.into_handler_error())
-        })
-        .then(|result| match result {
-            Ok(rows) => {
-                let body = serde_json::to_string(&RowsUpdated { rows })
-                    .expect("Failed to serialise to json");
-                let res =
-                    create_response(&state, StatusCode::CREATED, mime::APPLICATION_JSON, body);
-                future::ok((state, res))
-            }
-            Err(e) => future::err((state, e)),
-        })
-        .boxed()
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => return Err((state, e.into_handler_error())),
+        };
+
+        let body =
+            serde_json::to_string(&RowsUpdated { rows }).expect("Failed to serialise to json");
+        let res = create_response(&state, StatusCode::CREATED, mime::APPLICATION_JSON, body);
+        Ok((state, res))
+    }
+    .boxed()
 }
 
 fn get_products_handler(state: State) -> Pin<Box<HandlerFuture>> {
     use crate::schema::products::dsl::*;
 
     let repo = Repo::borrow_from(&state).clone();
-    repo.run(move |conn| products.load::<Product>(&conn))
-        .then(|result| match result {
+    async move {
+        let result = repo.run(move |conn| products.load::<Product>(&conn)).await;
+        match result {
             Ok(users) => {
                 let body = serde_json::to_string(&users).expect("Failed to serialize users.");
                 let res = create_response(&state, StatusCode::OK, mime::APPLICATION_JSON, body);
-                future::ok((state, res))
+                Ok((state, res))
             }
-            Err(e) => future::err((state, e.into_handler_error())),
-        })
-        .boxed()
+            Err(e) => Err((state, e.into_handler_error())),
+        }
+    }
+    .boxed()
 }
 
 fn router(repo: Repo) -> Router {
@@ -103,19 +109,17 @@ where
     e.into_handler_error().with_status(StatusCode::BAD_REQUEST)
 }
 
-fn extract_json<T>(state: &mut State) -> impl Future<Output = Result<T, HandlerError>>
+async fn extract_json<T>(state: &mut State) -> Result<T, HandlerError>
 where
     T: serde::de::DeserializeOwned,
 {
-    Body::take_from(state)
-        .concat2()
+    let body = body::to_bytes(Body::take_from(state))
         .map_err(bad_request)
-        .and_then(|body| {
-            let b = body.to_vec();
-            from_utf8(&b)
-                .map_err(bad_request)
-                .and_then(|s| serde_json::from_str::<T>(s).map_err(bad_request))
-        })
+        .await?;
+    let b = body.to_vec();
+    from_utf8(&b)
+        .map_err(bad_request)
+        .and_then(|s| serde_json::from_str::<T>(s).map_err(bad_request))
 }
 
 /// Start a server and use a `Router` to dispatch requests
@@ -135,11 +139,11 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use failure::Fail;
     use gotham::test::TestServer;
     use gotham_middleware_diesel::Repo;
     use hyper::StatusCode;
     use std::str;
-    use tokio::runtime;
 
     static DATABASE_URL: &str = ":memory:";
 
@@ -152,7 +156,9 @@ mod tests {
     #[test]
     fn get_empty_products() {
         let repo = Repo::with_test_transactions(DATABASE_URL);
-        runtime::run(repo.run(|conn| embedded_migrations::run(&conn).map_err(|_| ())));
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let _ = runtime
+            .block_on(repo.run(|conn| embedded_migrations::run(&conn).map_err(|e| e.compat())));
         let test_server = TestServer::new(router(repo)).unwrap();
         let response = test_server
             .client()
@@ -171,7 +177,9 @@ mod tests {
     #[test]
     fn create_and_retrieve_product() {
         let repo = Repo::with_test_transactions(DATABASE_URL);
-        runtime::run(repo.run(|conn| embedded_migrations::run(&conn).map_err(|_| ())));
+        let mut runtime = tokio::runtime::Runtime::new().unwrap();
+        let _ = runtime
+            .block_on(repo.run(|conn| embedded_migrations::run(&conn).map_err(|e| e.compat())));
         let test_server = TestServer::new(router(repo)).unwrap();
 
         //  First we'll insert something into the DB with a post

--- a/examples/diesel/src/main.rs
+++ b/examples/diesel/src/main.rs
@@ -52,14 +52,15 @@ fn create_product_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
             Err(e) => return Err((state, e)),
         };
 
-        let rows = match repo
+        let query_result = repo
             .run(move |conn| {
                 diesel::insert_into(products::table)
                     .values(&product)
                     .execute(&conn)
             })
-            .await
-        {
+            .await;
+
+        let rows = match query_result {
             Ok(rows) => rows,
             Err(e) => return Err((state, e.into_handler_error())),
         };

--- a/examples/example_contribution_template/name/Cargo.toml
+++ b/examples/example_contribution_template/name/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 
 # Add other dependencies if necessary

--- a/examples/example_contribution_template/name/Cargo.toml
+++ b/examples/example_contribution_template/name/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 
 # Add other dependencies if necessary

--- a/examples/handlers/async_handlers/Cargo.toml
+++ b/examples/handlers/async_handlers/Cargo.toml
@@ -9,9 +9,8 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 serde = "1"
 serde_derive = "1"
-tokio-core = "0.1"

--- a/examples/handlers/async_handlers/Cargo.toml
+++ b/examples/handlers/async_handlers/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 serde = "1"
 serde_derive = "1"

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -9,9 +9,9 @@ extern crate mime;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate tokio_core;
 
-use futures::{future, stream, Future, Stream};
+use futures::prelude::*;
+use std::pin::Pin;
 
 use hyper::StatusCode;
 #[cfg(not(test))]
@@ -24,7 +24,7 @@ use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-type ResponseContentFuture = Box<dyn Future<Item = Vec<u8>, Error = hyper::Error> + Send>;
+type ResponseContentFuture = Pin<Box<dyn Future<Output = Result<Vec<u8>, hyper::Error>> + Send>>;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {
@@ -42,11 +42,11 @@ fn http_get(url_str: &str) -> ResponseContentFuture {
     let f = client.get(url).and_then(|response| {
         response
             .into_body()
-            .concat2()
-            .and_then(|full_body| Ok(full_body.to_vec()))
+            .try_concat()
+            .and_then(|full_body| future::ok(full_body.to_vec()))
     });
 
-    Box::new(f)
+    f.boxed()
 }
 
 /// The other advantage of using a helper function is that you can easily patch it out for testing.
@@ -58,7 +58,7 @@ fn http_get(url_str: &str) -> ResponseContentFuture {
 fn http_get(_url_str: &str) -> ResponseContentFuture {
     // We make the test version return something different from what a real view would, to make
     // it easier to spot in the tests.
-    Box::new(future::ok(b"y".to_vec()))
+    future::ok(b"y".to_vec()).boxed()
 }
 
 /// Now we come to the business end of the example.
@@ -73,7 +73,7 @@ fn http_get(_url_str: &str) -> ResponseContentFuture {
 /// to the next, our code drifts to the right. If you are using nightly, you can avoid this by
 /// using something like:
 /// https://github.com/alexcrichton/futures-await
-fn series_handler(mut state: State) -> Box<HandlerFuture> {
+fn series_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let length = QueryStringExtractor::take_from(&mut state).length;
     println!("series length: {} starting", length);
 
@@ -81,9 +81,9 @@ fn series_handler(mut state: State) -> Box<HandlerFuture> {
     // Note that we pick a signature for our future that makes lives easier for our business logic,
     // and then convert it into a `Box<HandlerFuture>` in the end.
     let data_future: ResponseContentFuture = if length == 0 {
-        Box::new(future::ok(Vec::new()))
+        future::ok(Vec::new()).boxed()
     } else if length == 1 {
-        Box::new(future::ok(b"z".to_vec()))
+        future::ok(b"z".to_vec()).boxed()
     } else {
         // These are the two URLs we're going to request. We're just splitting the length into
         // two roughly equal parts and calling ourselves. In a real application, these might
@@ -100,23 +100,25 @@ fn series_handler(mut state: State) -> Box<HandlerFuture> {
         let f = http_get(&url_a).and_then(move |mut body_a| {
             http_get(&url_b).and_then(move |body_b| {
                 body_a.extend(body_b);
-                Ok(body_a)
+                future::ok(body_a)
             })
         });
 
-        Box::new(f)
+        f.boxed()
     };
 
     // Here, we convert the future from our handler into the form that Gotham expects.
     // All we do is move `state` in, to return it, and convert any errors that we have.
-    Box::new(data_future.then(move |result| match result {
-        Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
-            println!("series length: {} finished", length);
-            Ok((state, res))
-        }
-        Err(err) => Err((state, err.into_handler_error())),
-    }))
+    data_future
+        .then(move |result| match result {
+            Ok(data) => {
+                let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
+                println!("series length: {} finished", length);
+                future::ok((state, res))
+            }
+            Err(err) => future::err((state, err.into_handler_error())),
+        })
+        .boxed()
 }
 
 /// This example uses a `future::Stream` to implement a `for` loop. This example only has two urls
@@ -127,15 +129,15 @@ fn series_handler(mut state: State) -> Box<HandlerFuture> {
 ///
 /// https://github.com/alexcrichton/futures-await has a more readable syntax for this as
 /// well, if you are using nightly Rust.
-fn loop_handler(mut state: State) -> Box<HandlerFuture> {
+fn loop_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let length = QueryStringExtractor::take_from(&mut state).length;
     println!("loop length: {} starting", length);
 
     // The structure is the same as `series_handler`, above.
     let data_future: ResponseContentFuture = if length == 0 {
-        Box::new(future::ok(Vec::new()))
+        future::ok(Vec::new()).boxed()
     } else if length == 1 {
-        Box::new(future::ok(b"z".to_vec()))
+        future::ok(b"z".to_vec()).boxed()
     } else {
         let url_a = format!("http://127.0.0.1:7878/loop?length={}", length / 2);
         let url_b = format!(
@@ -146,27 +148,31 @@ fn loop_handler(mut state: State) -> Box<HandlerFuture> {
         // Here, we create a stream that contains our two URLs, and call fold to loop over all URLs
         // and get the urls, concatenating the results into the accumulator (which starts off as the
         // empty `Vec`).
-        let f =
-            stream::iter_ok(vec![url_a, url_b]).fold(Vec::new(), move |mut accumulator, url| {
+        let f = futures::stream::iter(vec![url_a, url_b]).map(Ok).try_fold(
+            Vec::new(),
+            move |mut accumulator, url| {
                 // Do the http_get(), and append the result to the accumulator so that it can
                 // be returned.
                 http_get(&url).and_then(move |body| {
                     accumulator.extend(body);
-                    Ok(accumulator)
+                    future::ok(accumulator)
                 })
-            });
+            },
+        );
 
-        Box::new(f)
+        f.boxed()
     };
 
-    Box::new(data_future.then(move |result| match result {
-        Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
-            println!("loop length: {} finished", length);
-            Ok((state, res))
-        }
-        Err(err) => Err((state, err.into_handler_error())),
-    }))
+    data_future
+        .then(move |result| match result {
+            Ok(data) => {
+                let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
+                println!("loop length: {} finished", length);
+                future::ok((state, res))
+            }
+            Err(err) => future::err((state, err.into_handler_error())),
+        })
+        .boxed()
 }
 
 /// This example does the same thing as `series_handler`, but doesn't wait for the first request
@@ -196,15 +202,15 @@ fn loop_handler(mut state: State) -> Box<HandlerFuture> {
 /// In summary:
 ///     Don't do this at home kids. It is only included as a cautionary tale.
 ///
-fn parallel_handler(mut state: State) -> Box<HandlerFuture> {
+fn parallel_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let length = QueryStringExtractor::take_from(&mut state).length;
     println!("parallel length: {} starting", length);
 
     // The structure is the same as in `series_handler`, above.
     let data_future: ResponseContentFuture = if length == 0 {
-        Box::new(future::ok(Vec::new()))
+        future::ok(Vec::new()).boxed()
     } else if length == 1 {
-        Box::new(future::ok(b"z".to_vec()))
+        future::ok(b"z".to_vec()).boxed()
     } else {
         let url_a = format!("http://127.0.0.1:7878/parallel?length={}", length / 2);
         let url_b = format!(
@@ -217,20 +223,24 @@ fn parallel_handler(mut state: State) -> Box<HandlerFuture> {
         let f1 = http_get(&url_a);
         let f2 = http_get(&url_b);
 
-        Box::new(f1.join(f2).and_then(|(mut body_a, body_b)| {
-            body_a.extend(body_b);
-            Ok(body_a)
-        }))
+        future::try_join(f1, f2)
+            .and_then(|(mut body_a, body_b)| {
+                body_a.extend(body_b);
+                future::ok(body_a)
+            })
+            .boxed()
     };
 
-    Box::new(data_future.then(move |result| match result {
-        Ok(data) => {
-            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
-            println!("parallel length: {} finished", length);
-            Ok((state, res))
-        }
-        Err(err) => Err((state, err.into_handler_error())),
-    }))
+    data_future
+        .then(move |result| match result {
+            Ok(data) => {
+                let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
+                println!("parallel length: {} finished", length);
+                future::ok((state, res))
+            }
+            Err(err) => future::err((state, err.into_handler_error())),
+        })
+        .boxed()
 }
 
 /// Create a `Router`.

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -1,5 +1,4 @@
 //! A basic example showing the request components
-
 extern crate futures;
 extern crate gotham;
 #[macro_use]
@@ -15,7 +14,7 @@ use std::pin::Pin;
 
 use hyper::StatusCode;
 #[cfg(not(test))]
-use hyper::{Client, Uri};
+use hyper::{body, Client, Uri};
 
 use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::helpers::http::response::create_response;
@@ -40,10 +39,7 @@ fn http_get(url_str: &str) -> ResponseContentFuture {
     let client = Client::new();
     let url: Uri = url_str.parse().unwrap();
     let f = client.get(url).and_then(|response| {
-        response
-            .into_body()
-            .try_concat()
-            .and_then(|full_body| future::ok(full_body.to_vec()))
+        body::to_bytes(response.into_body()).and_then(|full_body| future::ok(full_body.to_vec()))
     });
 
     f.boxed()

--- a/examples/handlers/form_urlencoded/Cargo.toml
+++ b/examples/handlers/form_urlencoded/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 url = "2.1"

--- a/examples/handlers/form_urlencoded/Cargo.toml
+++ b/examples/handlers/form_urlencoded/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 url = "2.1"

--- a/examples/handlers/form_urlencoded/src/main.rs
+++ b/examples/handlers/form_urlencoded/src/main.rs
@@ -7,7 +7,7 @@ extern crate mime;
 extern crate url;
 
 use futures::prelude::*;
-use hyper::{Body, StatusCode};
+use hyper::{body, Body, StatusCode};
 use std::pin::Pin;
 use url::form_urlencoded;
 
@@ -19,24 +19,21 @@ use gotham::state::{FromState, State};
 
 /// Extracts the elements of the POST request and responds with the form keys and values
 fn form_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
-    let f = Body::take_from(&mut state)
-        .try_concat()
-        .then(|full_body| match full_body {
-            Ok(valid_body) => {
-                let body_content = valid_body.into_bytes();
-                // Perform decoding on request body
-                let form_data = form_urlencoded::parse(&body_content).into_owned();
-                // Add form keys and values to response body
-                let mut res_body = String::new();
-                for (key, value) in form_data {
-                    let res_body_line = format!("{}: {}\n", key, value);
-                    res_body.push_str(&res_body_line);
-                }
-                let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, res_body);
-                future::ok((state, res))
+    let f = body::to_bytes(Body::take_from(&mut state)).then(|full_body| match full_body {
+        Ok(body_content) => {
+            // Perform decoding on request body
+            let form_data = form_urlencoded::parse(&body_content).into_owned();
+            // Add form keys and values to response body
+            let mut res_body = String::new();
+            for (key, value) in form_data {
+                let res_body_line = format!("{}: {}\n", key, value);
+                res_body.push_str(&res_body_line);
             }
-            Err(e) => future::err((state, e.into_handler_error())),
-        });
+            let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, res_body);
+            future::ok((state, res))
+        }
+        Err(e) => future::err((state, e.into_handler_error())),
+    });
 
     f.boxed()
 }

--- a/examples/handlers/multipart/Cargo.toml
+++ b/examples/handlers/multipart/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 multipart = { version = "0.16", default-features = false, features = ["server"] }

--- a/examples/handlers/multipart/Cargo.toml
+++ b/examples/handlers/multipart/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 multipart = { version = "0.16", default-features = false, features = ["server"] }

--- a/examples/handlers/multipart/src/main.rs
+++ b/examples/handlers/multipart/src/main.rs
@@ -1,5 +1,4 @@
 //! An example of decoding multipart form requests
-
 extern crate futures;
 extern crate gotham;
 extern crate hyper;
@@ -13,7 +12,7 @@ use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 use hyper::header::CONTENT_TYPE;
-use hyper::{Body, HeaderMap, StatusCode};
+use hyper::{body, Body, HeaderMap, StatusCode};
 use multipart::server::Multipart;
 use std::io::Cursor;
 use std::io::Read;
@@ -32,8 +31,7 @@ fn form_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
         })
         .unwrap();
 
-    Body::take_from(&mut state)
-        .try_concat()
+    body::to_bytes(Body::take_from(&mut state))
         .then(|full_body| match full_body {
             Ok(valid_body) => {
                 let mut m = Multipart::with_body(Cursor::new(valid_body), boundary);

--- a/examples/handlers/request_data/Cargo.toml
+++ b/examples/handlers/request_data/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"

--- a/examples/handlers/request_data/Cargo.toml
+++ b/examples/handlers/request_data/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"

--- a/examples/handlers/request_data/src/main.rs
+++ b/examples/handlers/request_data/src/main.rs
@@ -6,7 +6,7 @@ extern crate hyper;
 extern crate mime;
 
 use futures::prelude::*;
-use hyper::{Body, HeaderMap, Method, Response, StatusCode, Uri, Version};
+use hyper::{body, Body, HeaderMap, Method, Response, StatusCode, Uri, Version};
 use std::pin::Pin;
 
 use gotham::handler::{HandlerFuture, IntoHandlerError};
@@ -30,17 +30,15 @@ fn print_request_elements(state: &State) {
 /// Extracts the elements of the POST request and prints them
 fn post_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     print_request_elements(&state);
-    let f = Body::take_from(&mut state)
-        .try_concat()
-        .then(|full_body| match full_body {
-            Ok(valid_body) => {
-                let body_content = String::from_utf8(valid_body.to_vec()).unwrap();
-                println!("Body: {}", body_content);
-                let res = create_empty_response(&state, StatusCode::OK);
-                future::ok((state, res))
-            }
-            Err(e) => future::err((state, e.into_handler_error())),
-        });
+    let f = body::to_bytes(Body::take_from(&mut state)).then(|full_body| match full_body {
+        Ok(valid_body) => {
+            let body_content = String::from_utf8(valid_body.to_vec()).unwrap();
+            println!("Body: {}", body_content);
+            let res = create_empty_response(&state, StatusCode::OK);
+            future::ok((state, res))
+        }
+        Err(e) => future::err((state, e.into_handler_error())),
+    });
 
     f.boxed()
 }

--- a/examples/handlers/simple_async_handlers/Cargo.toml
+++ b/examples/handlers/simple_async_handlers/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 serde = "1.0"
 serde_derive = "1.0"
-tokio = "=0.2.0-alpha.6"
+tokio = { version = "0.2.6", features = ["full"] }

--- a/examples/handlers/simple_async_handlers/Cargo.toml
+++ b/examples/handlers/simple_async_handlers/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 serde = "1.0"
 serde_derive = "1.0"
-tokio = "0.1"
+tokio = "=0.2.0-alpha.6"

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -24,7 +24,7 @@ use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-use tokio::timer::delay;
+use tokio::time::delay_until;
 
 type SleepFuture = Pin<Box<dyn Future<Output = Vec<u8>> + Send>>;
 
@@ -58,7 +58,7 @@ fn get_duration(seconds: u64) -> Duration {
 /// real world problems.
 fn sleep(seconds: u64) -> SleepFuture {
     let when = Instant::now() + get_duration(seconds);
-    let delay = delay(when).map(move |_| {
+    let delay = delay_until(when.into()).map(move |_| {
         format!("slept for {} seconds\n", seconds)
             .as_bytes()
             .to_vec()

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -11,21 +11,22 @@ extern crate serde;
 extern crate serde_derive;
 extern crate tokio;
 
-use futures::{stream, Future, Stream};
+use futures::prelude::*;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use hyper::StatusCode;
 
-use gotham::handler::{HandlerError, HandlerFuture, IntoHandlerError};
+use gotham::handler::HandlerFuture;
 use gotham::helpers::http::response::create_response;
 use gotham::router::builder::DefineSingleRoute;
 use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-use tokio::timer::Delay;
+use tokio::timer::delay;
 
-type SleepFuture = Box<dyn Future<Item = Vec<u8>, Error = HandlerError> + Send>;
+type SleepFuture = Pin<Box<dyn Future<Output = Vec<u8>> + Send>>;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {
@@ -57,20 +58,18 @@ fn get_duration(seconds: u64) -> Duration {
 /// real world problems.
 fn sleep(seconds: u64) -> SleepFuture {
     let when = Instant::now() + get_duration(seconds);
-    let delay = Delay::new(when)
-        .map_err(|e| panic!("timer failed; err={:?}", e))
-        .and_then(move |_| {
-            Ok(format!("slept for {} seconds\n", seconds)
-                .as_bytes()
-                .to_vec())
-        });
+    let delay = delay(when).map(move |_| {
+        format!("slept for {} seconds\n", seconds)
+            .as_bytes()
+            .to_vec()
+    });
 
-    Box::new(delay)
+    delay.boxed()
 }
 
 /// This handler sleeps for the requested number of seconds, using the `sleep()`
 /// helper method, above.
-fn sleep_handler(mut state: State) -> Box<HandlerFuture> {
+fn sleep_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let seconds = QueryStringExtractor::take_from(&mut state).seconds;
     println!("sleep for {} seconds once: starting", seconds);
 
@@ -83,14 +82,13 @@ fn sleep_handler(mut state: State) -> Box<HandlerFuture> {
     // `state` is moved in, so that we can return it, and we convert any errors
     // that we have into the form that Hyper expects, using the helper from
     // IntoHandlerError.
-    Box::new(sleep_future.then(move |result| match result {
-        Ok(data) => {
+    sleep_future
+        .map(move |data| {
             let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("sleep for {} seconds once: finished", seconds);
             Ok((state, res))
-        }
-        Err(err) => Err((state, err.into_handler_error())),
-    }))
+        })
+        .boxed()
 }
 
 /// This example uses a `future::Stream` to implement a `for` loop. It calls sleep(1)
@@ -98,33 +96,31 @@ fn sleep_handler(mut state: State) -> Box<HandlerFuture> {
 ///
 /// https://github.com/alexcrichton/futures-await has a more readable syntax for
 /// async for loops, if you are using nightly Rust.
-fn loop_handler(mut state: State) -> Box<HandlerFuture> {
+fn loop_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let seconds = QueryStringExtractor::take_from(&mut state).seconds;
     println!("sleep for one second {} times: starting", seconds);
 
     // Here, we create a stream of Ok(_) that's as long as we need, and use fold
     // to loop over it asyncronously, accumulating the return values from sleep().
-    let sleep_future: SleepFuture = Box::new(stream::iter_ok(0..seconds).fold(
-        Vec::new(),
-        move |mut accumulator, _| {
+    let sleep_future: SleepFuture = futures::stream::iter(0..seconds)
+        .fold(Vec::new(), move |mut accumulator, _| {
             // Do the sleep(), and append the result to the accumulator so that it can
             // be returned.
-            sleep(1).and_then(move |body| {
+            sleep(1).map(move |body| {
                 accumulator.extend(body);
-                Ok(accumulator)
+                accumulator
             })
-        },
-    ));
+        })
+        .boxed();
 
     // This bit is the same as the bit in the first example.
-    Box::new(sleep_future.then(move |result| match result {
-        Ok(data) => {
+    sleep_future
+        .map(move |data| {
             let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
             println!("sleep for one second {} times: finished", seconds);
             Ok((state, res))
-        }
-        Err(err) => Err((state, err.into_handler_error())),
-    }))
+        })
+        .boxed()
 }
 
 /// Create a `Router`.

--- a/examples/handlers/stateful/Cargo.toml
+++ b/examples/handlers/stateful/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-futures-preview = "0.3.0-alpha.19"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures = "0.3.1"
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/handlers/stateful/Cargo.toml
+++ b/examples/handlers/stateful/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-futures = "0.1"
-hyper = "0.12"
+futures-preview = "0.3.0-alpha.19"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/handlers/stateful/src/main.rs
+++ b/examples/handlers/stateful/src/main.rs
@@ -6,7 +6,8 @@ extern crate gotham;
 extern crate hyper;
 extern crate mime;
 
-use futures::future;
+use futures::prelude::*;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -38,7 +39,7 @@ impl CountingHandler {
 }
 
 impl Handler for CountingHandler {
-    fn handle(self, state: State) -> Box<HandlerFuture> {
+    fn handle(self, state: State) -> Pin<Box<HandlerFuture>> {
         let uptime = SystemTime::now().duration_since(self.started_at).unwrap();
 
         // Create a short scope so that self.visits will only be locked for long enough to
@@ -57,7 +58,7 @@ impl Handler for CountingHandler {
 
         let response = response_text.into_response(&state);
 
-        Box::new(future::ok((state, response)))
+        future::ok((state, response)).boxed()
     }
 }
 

--- a/examples/headers/setting/Cargo.toml
+++ b/examples/headers/setting/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/headers/setting/Cargo.toml
+++ b/examples/headers/setting/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 gotham = { path = "../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 gotham = { path = "../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/hello_world_tls/Cargo.toml
+++ b/examples/hello_world_tls/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 futures-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "futures-rustls" }

--- a/examples/hello_world_tls/Cargo.toml
+++ b/examples/hello_world_tls/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-tokio-rustls = "0.9"
+futures-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "futures-rustls" }

--- a/examples/hello_world_tls/src/main.rs
+++ b/examples/hello_world_tls/src/main.rs
@@ -1,16 +1,16 @@
 //! A Hello World example application for working with Gotham.
 
+extern crate futures_rustls;
 extern crate gotham;
 extern crate hyper;
 extern crate mime;
-extern crate tokio_rustls;
 
-use std::io::BufReader;
-use tokio_rustls::rustls::{
+use futures_rustls::rustls::{
     self,
     internal::pemfile::{certs, pkcs8_private_keys},
     NoClientAuth,
 };
+use std::io::BufReader;
 
 use gotham::state::State;
 

--- a/examples/hello_world_until/Cargo.toml
+++ b/examples/hello_world_until/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 [dependencies]
 gotham = { path = "../../gotham" }
 
-futures-preview = "0.3.0-alpha.19"
-tokio = "=0.2.0-alpha.6"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures = "0.3.1"
+tokio = { version = "0.2.6", features = ["full"] }
+hyper = "0.13.1"
 mime = "0.3"
 tokio-signal = "0.2"
 

--- a/examples/hello_world_until/Cargo.toml
+++ b/examples/hello_world_until/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 [dependencies]
 gotham = { path = "../../gotham" }
 
-futures = "0.1"
-tokio = "0.1"
-hyper = "0.12"
+futures-preview = "0.3.0-alpha.19"
+tokio = "=0.2.0-alpha.6"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 tokio-signal = "0.2"
 

--- a/examples/hello_world_until/Cargo.toml
+++ b/examples/hello_world_until/Cargo.toml
@@ -12,7 +12,6 @@ futures = "0.3.1"
 tokio = { version = "0.2.6", features = ["full"] }
 hyper = "0.13.1"
 mime = "0.3"
-tokio-signal = "0.2"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = "0.15"

--- a/examples/hello_world_until/src/main.rs
+++ b/examples/hello_world_until/src/main.rs
@@ -4,7 +4,7 @@
 #[cfg(all(test, unix))]
 extern crate nix;
 
-use futures::{Future, Stream};
+use futures::prelude::*;
 use hyper::{Body, Response, StatusCode};
 
 use gotham::helpers::http::response::create_response;

--- a/examples/hello_world_until/src/main.rs
+++ b/examples/hello_world_until/src/main.rs
@@ -5,10 +5,10 @@
 extern crate nix;
 
 use futures::prelude::*;
-use hyper::{Body, Response, StatusCode};
-
 use gotham::helpers::http::response::create_response;
 use gotham::state::State;
+use hyper::{Body, Response, StatusCode};
+use tokio::signal;
 
 /// Create a `Handler` which is invoked when responding to a `Request`.
 ///
@@ -27,27 +27,19 @@ pub fn say_hello(state: State) -> (State, Response<Body>) {
 }
 
 /// Start a server and call the `Handler` we've defined above for each `Request` we receive.
-pub fn main() {
+#[tokio::main]
+pub async fn main() {
     let addr = "127.0.0.1:7878";
 
     let server = gotham::init_server(addr, || Ok(say_hello));
     // Future to wait for Ctrl+C.
-    let signal = tokio_signal::ctrl_c()
-        .flatten_stream()
-        .map_err(|error| panic!("Error listening for signal: {}", error))
-        .take(1)
-        .for_each(|()| {
-            println!("Ctrl+C pressed");
-            Ok(())
-        });
+    let signal = async {
+        signal::ctrl_c().map_err(|_| ()).await?;
+        println!("Ctrl+C pressed");
+        Ok::<(), ()>(())
+    };
 
-    let serve_until = signal
-        .select(server)
-        .map(|(res, _)| res)
-        .map_err(|(error, _)| error);
-
-    tokio::run(serve_until);
-
+    future::select(server.boxed(), signal.boxed()).await;
     println!("Shutting down gracefully");
 }
 

--- a/examples/into_response/introduction/Cargo.toml
+++ b/examples/into_response/introduction/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/into_response/introduction/Cargo.toml
+++ b/examples/into_response/introduction/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/middleware/introduction/Cargo.toml
+++ b/examples/middleware/introduction/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
-futures-preview = "0.3.0-alpha.19"
+hyper = "0.13.1"
+futures = "0.3.1"
 mime = "0.3"

--- a/examples/middleware/introduction/Cargo.toml
+++ b/examples/middleware/introduction/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
-futures = "0.1"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures-preview = "0.3.0-alpha.19"
 mime = "0.3"

--- a/examples/middleware/introduction/src/main.rs
+++ b/examples/middleware/introduction/src/main.rs
@@ -7,7 +7,9 @@ extern crate gotham_derive;
 extern crate hyper;
 extern crate mime;
 
-use futures::{future, Future};
+use futures::prelude::*;
+use std::pin::Pin;
+
 use gotham::handler::HandlerFuture;
 use gotham::helpers::http::response::create_empty_response;
 use gotham::middleware::Middleware;
@@ -49,9 +51,9 @@ pub struct ExampleMiddleware;
 /// ^Later examples will show how Middlewares in a pipeline can work with each other in a similar
 /// manner.
 impl Middleware for ExampleMiddleware {
-    fn call<Chain>(self, mut state: State, chain: Chain) -> Box<HandlerFuture>
+    fn call<Chain>(self, mut state: State, chain: Chain) -> Pin<Box<HandlerFuture>>
     where
-        Chain: FnOnce(State) -> Box<HandlerFuture>,
+        Chain: FnOnce(State) -> Pin<Box<HandlerFuture>>,
     {
         let user_agent = match HeaderMap::borrow_from(&state).get(USER_AGENT) {
             Some(ua) => ua.to_str().unwrap().to_string(),
@@ -97,7 +99,7 @@ impl Middleware for ExampleMiddleware {
             future::ok((state, response))
         });
 
-        Box::new(f)
+        f.boxed()
     }
 }
 

--- a/examples/middleware/multiple_pipelines/Cargo.toml
+++ b/examples/middleware/multiple_pipelines/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
-futures-preview = "0.3.0-alpha.19"
+hyper = "0.13.1"
+futures = "0.3.1"
 mime = "0.3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/examples/middleware/multiple_pipelines/Cargo.toml
+++ b/examples/middleware/multiple_pipelines/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
-futures = "0.1"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures-preview = "0.3.0-alpha.19"
 mime = "0.3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/examples/openssl/Cargo.toml
+++ b/examples/openssl/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 [dependencies]
 gotham = { path = "../../gotham", default-features = false }
 
-futures-preview = "0.3.0-alpha.19"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures = "0.3.1"
+hyper = "0.13.1"
 mime = "0.3"
 tokio-openssl = "=0.4.0-alpha.6"
 openssl = "0.10"
-tokio = "=0.2.0-alpha.6"
+tokio = { version = "0.2.6", features = ["full"] }
 failure = "0.1"

--- a/examples/openssl/Cargo.toml
+++ b/examples/openssl/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 [dependencies]
 gotham = { path = "../../gotham", default-features = false }
 
-futures = "0.1"
-hyper = "0.12"
+futures-preview = "0.3.0-alpha.19"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
-tokio-openssl = "0.3"
+tokio-openssl = "=0.4.0-alpha.6"
 openssl = "0.10"
-tokio = "0.1"
+tokio = "=0.2.0-alpha.6"
 failure = "0.1"

--- a/examples/openssl/src/main.rs
+++ b/examples/openssl/src/main.rs
@@ -41,19 +41,14 @@ pub fn main() -> Result<(), Error> {
 
     let listener = TcpListener::bind(&addr)?;
 
+    let mut runtime = Runtime::new()?;
+
     let server = bind_server(
         listener,
         || Ok(say_hello),
         // NOTE: We're ignoring handshake errors here. You can modify to e.g. report them.
-        move |socket| {
-            acceptor
-                .accept_async(socket)
-                .map_err(|_| ())
-                .map_ok(|socket| futures_tokio_compat::Compat::new(socket))
-        },
+        move |socket| acceptor.accept_async(socket).map_err(|_| ()),
     );
-
-    let mut runtime = Runtime::new()?;
 
     runtime
         .block_on(server)

--- a/examples/openssl/src/main.rs
+++ b/examples/openssl/src/main.rs
@@ -41,8 +41,6 @@ pub fn main() -> Result<(), Error> {
 
     let listener = TcpListener::bind(&addr)?;
 
-    let mut runtime = Runtime::new()?;
-
     let server = bind_server(
         listener,
         || Ok(say_hello),
@@ -50,6 +48,7 @@ pub fn main() -> Result<(), Error> {
         move |socket| acceptor.accept_async(socket).map_err(|_| ()),
     );
 
+    let mut runtime = Runtime::new()?;
     runtime
         .block_on(server)
         .map_err(|()| err_msg("Server failed"))

--- a/examples/path/globs/Cargo.toml
+++ b/examples/path/globs/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/path/globs/Cargo.toml
+++ b/examples/path/globs/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/path/introduction/Cargo.toml
+++ b/examples/path/introduction/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/path/introduction/Cargo.toml
+++ b/examples/path/introduction/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/path/regex/Cargo.toml
+++ b/examples/path/regex/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/path/regex/Cargo.toml
+++ b/examples/path/regex/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/query_string/introduction/Cargo.toml
+++ b/examples/query_string/introduction/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/query_string/introduction/Cargo.toml
+++ b/examples/query_string/introduction/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/routing/associations/Cargo.toml
+++ b/examples/routing/associations/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/routing/associations/Cargo.toml
+++ b/examples/routing/associations/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/routing/http_verbs/Cargo.toml
+++ b/examples/routing/http_verbs/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/routing/http_verbs/Cargo.toml
+++ b/examples/routing/http_verbs/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/routing/introduction/Cargo.toml
+++ b/examples/routing/introduction/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/routing/introduction/Cargo.toml
+++ b/examples/routing/introduction/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/routing/scopes/Cargo.toml
+++ b/examples/routing/scopes/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/routing/scopes/Cargo.toml
+++ b/examples/routing/scopes/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/sessions/custom_data_type/Cargo.toml
+++ b/examples/sessions/custom_data_type/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/sessions/custom_data_type/Cargo.toml
+++ b/examples/sessions/custom_data_type/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 serde = "1"
 serde_derive = "1"

--- a/examples/sessions/introduction/Cargo.toml
+++ b/examples/sessions/introduction/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 cookie = "0.11"

--- a/examples/sessions/introduction/Cargo.toml
+++ b/examples/sessions/introduction/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 cookie = "0.11"

--- a/examples/shared_state/Cargo.toml
+++ b/examples/shared_state/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../gotham" }
 gotham_derive = { path = "../../gotham_derive" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"

--- a/examples/shared_state/Cargo.toml
+++ b/examples/shared_state/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 gotham = { path = "../../gotham" }
 gotham_derive = { path = "../../gotham_derive" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"

--- a/examples/templating/askama/Cargo.toml
+++ b/examples/templating/askama/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 
 askama = "0.8.0"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3.12"

--- a/examples/templating/askama/Cargo.toml
+++ b/examples/templating/askama/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 gotham = { path = "../../../gotham" }
 
 askama = "0.8.0"
-hyper = "0.12.17"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3.12"

--- a/examples/templating/tera/Cargo.toml
+++ b/examples/templating/tera/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 mime = "0.3"
 tera = "0.11"
 lazy_static = "1.0"

--- a/examples/templating/tera/Cargo.toml
+++ b/examples/templating/tera/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 mime = "0.3"
 tera = "0.11"
 lazy_static = "1.0"

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../gotham" }
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
-futures-preview = "0.3.0-alpha.19"
+hyper = "0.13.1"
+futures = "0.3.1"
 tokio-tungstenite = "0.9"
 pretty_env_logger = "0.3"
 sha1 = "*"

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../gotham" }
-hyper = "0.12"
-futures = "0.1"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+futures-preview = "0.3.0-alpha.19"
 tokio-tungstenite = "0.9"
 pretty_env_logger = "0.3"
 sha1 = "*"

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -1,4 +1,4 @@
-use futures::{Future, Sink, Stream};
+use futures::prelude::*;
 use gotham::state::{request_id, FromState, State};
 use hyper::{Body, HeaderMap, Response, StatusCode};
 
@@ -36,7 +36,7 @@ fn handler(mut state: State) -> (State, Response<Body>) {
     }
 }
 
-fn connected<S>(req_id: String, stream: S) -> impl Future<Item = (), Error = ()>
+fn connected<S>(req_id: String, stream: S) -> impl Future<Output = Result<(), ()>>
 where
     S: Stream<Item = ws::Message, Error = ws::Error>
         + Sink<SinkItem = ws::Message, SinkError = ws::Error>,

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -1,5 +1,5 @@
 use base64;
-use futures::Future;
+use futures::prelude::*;
 use hyper::header::{HeaderValue, CONNECTION, UPGRADE};
 use hyper::{upgrade::Upgraded, Body, HeaderMap, Response, StatusCode};
 use sha1::Sha1;
@@ -27,7 +27,7 @@ pub fn accept(
 ) -> Result<
     (
         Response<Body>,
-        impl Future<Item = WebSocketStream<Upgraded>, Error = hyper::Error>,
+        impl Future<Output = Result<WebSocketStream<Upgraded>, hyper::Error>>,
     ),
     (),
 > {

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2018"
 
 [features]
 default = ["rustls"]
-rustls = ["futures-rustls"]
+rustls = ["tokio-rustls"]
 
 [dependencies]
 log = "0.4"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 serde = "1.0"
 serde_derive = "1.0"
 bincode = "1.0"
@@ -29,12 +29,13 @@ mime = "0.3"
 # Using alpha version of mime_guess until mime crate stabilizes (releases 1.0).
 # see https://github.com/hyperium/mime/issues/52
 mime_guess = "2.0.1"
-futures-preview = "0.3.0-alpha.19"
-tokio = "=0.2.0-alpha.6"
-bytes = "0.4"
+futures = "0.3.1"
+tokio = { version = "0.2.6", features = ["full"] }
+bytes = "0.5"
 mio = "0.6"
 borrow-bag = "1.0"
 percent-encoding = "2.1"
+pin-project = "0.4.2"
 uuid = { version = "0.7", features = ["v4"] }
 chrono = "0.4"
 base64 = "0.11"
@@ -44,12 +45,10 @@ linked-hash-map = "0.5"
 num_cpus = "1.8"
 regex = "1.0"
 cookie = "0.12"
-http = "0.1"
+http = "0.2"
 httpdate = "0.3"
 failure = "0.1"
-futures-rustls = { version = "0.12.0-alpha.2", optional = true }
-tower-service = "=0.3.0-alpha.2"
-futures-tokio-compat = { git = "https://github.com/nemo157/futures-tokio-compat/" }
+tokio-rustls = { version = "0.12.1", optional = true }
 
 [dev-dependencies]
 gotham_derive = "0.5.0-dev"

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2018"
 
 [features]
 default = ["rustls"]
-rustls = ["tokio-rustls"]
+rustls = ["futures-rustls"]
 
 [dependencies]
 log = "0.4"
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 serde = "1.0"
 serde_derive = "1.0"
 bincode = "1.0"
@@ -29,8 +29,8 @@ mime = "0.3"
 # Using alpha version of mime_guess until mime crate stabilizes (releases 1.0).
 # see https://github.com/hyperium/mime/issues/52
 mime_guess = "2.0.1"
-futures = "0.1"
-tokio = "0.1"
+futures-preview = "0.3.0-alpha.19"
+tokio = "=0.2.0-alpha.6"
 bytes = "0.4"
 mio = "0.6"
 borrow-bag = "1.0"
@@ -47,8 +47,9 @@ cookie = "0.12"
 http = "0.1"
 httpdate = "0.3"
 failure = "0.1"
-tokio-rustls = {version = "0.9", optional = true }
-tokio-io = "0.1"
+futures-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "futures-rustls", optional = true }
+tower-service = "=0.3.0-alpha.2"
+futures-tokio-compat = { git = "https://github.com/nemo157/futures-tokio-compat/" }
 
 [dev-dependencies]
 gotham_derive = "0.5.0-dev"

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -47,7 +47,7 @@ cookie = "0.12"
 http = "0.1"
 httpdate = "0.3"
 failure = "0.1"
-futures-rustls = { git = "https://github.com/quininer/tokio-rustls", branch = "futures-rustls", optional = true }
+futures-rustls = { version = "0.12.0-alpha.2", optional = true }
 tower-service = "=0.3.0-alpha.2"
 futures-tokio-compat = { git = "https://github.com/nemo157/futures-tokio-compat/" }
 

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -1,4 +1,4 @@
-use hyper::{body::Payload, Body, Response};
+use hyper::{body::HttpBody, Body, Response};
 use serde::{Deserialize, Deserializer};
 
 use crate::router::response::extender::StaticResponseExtender;
@@ -78,13 +78,13 @@ use crate::state::{State, StateData};
 pub trait PathExtractor<B>:
     for<'de> Deserialize<'de> + StaticResponseExtender<ResBody = B> + StateData
 where
-    B: Payload,
+    B: HttpBody,
 {
 }
 
 impl<T, B> PathExtractor<B> for T
 where
-    B: Payload,
+    B: HttpBody,
     for<'de> T: Deserialize<'de> + StaticResponseExtender<ResBody = B> + StateData,
 {
 }

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -1,4 +1,4 @@
-use hyper::{body::Payload, Body, Response};
+use hyper::{body::HttpBody, Body, Response};
 use serde::{Deserialize, Deserializer};
 
 use crate::router::response::extender::StaticResponseExtender;
@@ -86,13 +86,13 @@ use crate::state::{State, StateData};
 pub trait QueryStringExtractor<B>:
     for<'de> Deserialize<'de> + StaticResponseExtender<ResBody = B> + StateData
 where
-    B: Payload,
+    B: HttpBody,
 {
 }
 
 impl<T, B> QueryStringExtractor<B> for T
 where
-    B: Payload,
+    B: HttpBody,
     for<'de> T: Deserialize<'de> + StaticResponseExtender<ResBody = B> + StateData,
 {
 }

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -7,6 +7,7 @@
 mod accepted_encoding;
 
 use crate::error::Result;
+use bytes::Bytes;
 use bytes::{BufMut, BytesMut};
 use futures::prelude::*;
 use futures::ready;
@@ -14,7 +15,7 @@ use futures::task::Poll;
 use http;
 use httpdate::parse_http_date;
 use hyper::header::*;
-use hyper::{Body, Chunk, Response, StatusCode};
+use hyper::{Body, Response, StatusCode};
 use log::debug;
 use mime::{self, Mime};
 use mime_guess::from_path;
@@ -223,17 +224,17 @@ fn create_file_response(options: FileOptions, state: State) -> Pin<Box<HandlerFu
 
             let stream = file_stream(file, buf_size, len);
             let body = Body::wrap_stream(stream.into_stream());
-            let mut response = http::Response::builder();
-            response.status(StatusCode::OK);
-            response.header(CONTENT_LENGTH, len);
-            response.header(CONTENT_TYPE, mime_type.as_ref());
-            response.header(CACHE_CONTROL, options.cache_control);
+            let mut response = http::Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_LENGTH, len)
+                .header(CONTENT_TYPE, mime_type.as_ref())
+                .header(CACHE_CONTROL, options.cache_control);
 
             if let Some(etag) = entity_tag(&meta) {
-                response.header(ETAG, etag);
+                response = response.header(ETAG, etag);
             }
             if let Some(content_encoding) = encoding {
-                response.header(CONTENT_ENCODING, content_encoding);
+                response = response.header(CONTENT_ENCODING, content_encoding);
             }
 
             Ok(response.body(body).unwrap())
@@ -376,7 +377,7 @@ fn file_stream(
     mut f: File,
     buf_size: usize,
     mut len: u64,
-) -> impl TryStream<Ok = Chunk, Error = io::Error> + Send {
+) -> impl TryStream<Ok = Bytes, Error = io::Error> + Send {
     let mut buf = BytesMut::with_capacity(buf_size);
     stream::poll_fn(move |cx| {
         if len == 0 {
@@ -400,15 +401,16 @@ fn file_stream(
             ))));
         }
 
-        let mut chunk = buf.take().freeze();
-        if n > len {
-            chunk = chunk.split_to(len as usize);
+        let chunk = if n > len {
+            let chunk = buf.split_to(len as usize);
             len = 0;
+            chunk
         } else {
             len -= n;
-        }
+            buf.split()
+        };
 
-        Poll::Ready(Some(Ok(Chunk::from(chunk))))
+        Poll::Ready(Some(Ok(chunk.freeze())))
     })
 }
 

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -7,8 +7,7 @@
 mod accepted_encoding;
 
 use crate::error::Result;
-use bytes::Bytes;
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use futures::prelude::*;
 use futures::ready;
 use futures::task::Poll;

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -25,14 +25,15 @@ pub struct HandlerError {
 /// # extern crate futures;
 /// #
 /// # use std::fs::File;
+/// # use std::pin::Pin;
 /// # use gotham::state::State;
 /// # use gotham::handler::{IntoHandlerError, HandlerFuture};
-/// # use futures::future;
+/// # use futures::prelude::*;
 /// #
 /// # #[allow(dead_code)]
-/// fn my_handler(state: State) -> Box<HandlerFuture> {
+/// fn my_handler(state: State) -> Pin<Box<HandlerFuture>> {
 ///     match File::open("config.toml") {
-///         Err(e) => Box::new(future::err((state, e.into_handler_error()))),
+///         Err(e) => future::err((state, e.into_handler_error())).boxed(),
 ///         Ok(_) => // Create and return a response
 /// #                unimplemented!(),
 ///     }
@@ -95,13 +96,15 @@ impl HandlerError {
     /// # extern crate hyper;
     /// # extern crate futures;
     /// #
-    /// # use futures::future;
+    /// # use std::pin::Pin;
+    /// #
+    /// # use futures::prelude::*;
     /// # use hyper::StatusCode;
     /// # use gotham::state::State;
     /// # use gotham::handler::{IntoHandlerError, HandlerFuture};
     /// # use gotham::test::TestServer;
     /// #
-    /// fn handler(state: State) -> Box<HandlerFuture> {
+    /// fn handler(state: State) -> Pin<Box<HandlerFuture>> {
     ///     // It's OK if this is bogus, we just need something to convert into a `HandlerError`.
     ///     let io_error = std::io::Error::last_os_error();
     ///
@@ -109,7 +112,7 @@ impl HandlerError {
     ///         .into_handler_error()
     ///         .with_status(StatusCode::IM_A_TEAPOT);
     ///
-    ///     Box::new(future::err((state, handler_error)))
+    ///     future::err((state, handler_error)).boxed()
     /// }
     ///
     /// # fn main() {

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 
 use bytes::Bytes;
 use futures::prelude::*;
-use hyper::{Body, Chunk, Response, StatusCode};
+use hyper::{Body, Response, StatusCode};
 use mime::{self, Mime};
 
 use crate::helpers::http::response;
@@ -417,7 +417,6 @@ macro_rules! derive_into_response {
 // can't impl IntoResponse for Into<Body> due to Response<T>
 // and the potential it will add Into<Body> in the future
 derive_into_response!(Bytes);
-derive_into_response!(Chunk);
 derive_into_response!(String);
 derive_into_response!(Vec<u8>);
 derive_into_response!(&'static str);

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -5,9 +5,10 @@
 //! `Handler` trait for some examples of valid handlers.
 use std::borrow::Cow;
 use std::panic::RefUnwindSafe;
+use std::pin::Pin;
 
 use bytes::Bytes;
-use futures::{future, Future};
+use futures::prelude::*;
 use hyper::{Body, Chunk, Response, StatusCode};
 use mime::{self, Mime};
 
@@ -27,7 +28,7 @@ pub use self::error::{HandlerError, IntoHandlerError};
 /// When the `Future` resolves to an error, the `(State, HandlerError)` value is used to generate
 /// an appropriate HTTP error response.
 pub type HandlerFuture =
-    dyn Future<Item = (State, Response<Body>), Error = (State, HandlerError)> + Send;
+    dyn Future<Output = std::result::Result<(State, Response<Body>), (State, HandlerError)>> + Send;
 
 /// A `Handler` is an asynchronous function, taking a `State` value which represents the request
 /// and related runtime state, and returns a future which resolves to a response.
@@ -72,11 +73,13 @@ pub type HandlerFuture =
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// #
+/// # use std::pin::Pin;
+/// #
 /// # use gotham::handler::{Handler, HandlerFuture};
 /// # use gotham::state::State;
 /// #
 /// # fn main() {
-/// fn async_handler(_state: State) -> Box<HandlerFuture> {
+/// fn async_handler(_state: State) -> Pin<Box<HandlerFuture>> {
 ///     // Implementation elided.
 /// #   unimplemented!()
 /// }
@@ -95,15 +98,17 @@ pub type HandlerFuture =
 /// # extern crate hyper;
 /// # extern crate futures;
 /// #
-/// # use gotham::handler::{HandlerFuture, NewHandler};
+/// # use gotham::handler::{NewHandler, IntoHandlerFuture};
+/// # use gotham::helpers::http::response::create_empty_response;
 /// # use gotham::state::State;
-/// # use futures::future;
+/// # use hyper::StatusCode;
 /// #
 /// # fn main() {
 /// let new_handler = || {
-///     let handler = |_state: State| {
+///     let handler = |state: State| {
 ///         // Implementation elided.
-/// #       Box::new(future::empty()) as Box<HandlerFuture>
+/// #       let res = create_empty_response(&state, StatusCode::OK);
+/// #       (state, res).into_handler_future()
 ///     };
 ///     Ok(handler)
 /// };
@@ -122,6 +127,8 @@ pub type HandlerFuture =
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// #
+/// # use std::pin::Pin;
+/// #
 /// # use gotham::handler::{Handler, HandlerFuture, NewHandler};
 /// # use gotham::state::State;
 /// # use gotham::error::*;
@@ -139,7 +146,7 @@ pub type HandlerFuture =
 /// }
 ///
 /// impl Handler for MyCustomHandler {
-///     fn handle(self, _state: State) -> Box<HandlerFuture> {
+///     fn handle(self, _state: State) -> Pin<Box<HandlerFuture>> {
 ///         // Implementation elided.
 /// #       unimplemented!()
 ///     }
@@ -151,7 +158,7 @@ pub type HandlerFuture =
 /// ```
 pub trait Handler: Send {
     /// Handles the request, returning a boxed future which resolves to a response.
-    fn handle(self, state: State) -> Box<HandlerFuture>;
+    fn handle(self, state: State) -> Pin<Box<HandlerFuture>>;
 }
 
 impl<F, R> Handler for F
@@ -159,7 +166,7 @@ where
     F: FnOnce(State) -> R + Send,
     R: IntoHandlerFuture,
 {
-    fn handle(self, state: State) -> Box<HandlerFuture> {
+    fn handle(self, state: State) -> Pin<Box<HandlerFuture>> {
         self(state).into_handler_future()
     }
 }
@@ -178,6 +185,8 @@ where
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// #
+/// # use std::pin::Pin;
+/// #
 /// # use gotham::handler::{Handler, HandlerFuture, NewHandler};
 /// # use gotham::state::State;
 /// # use gotham::error::*;
@@ -195,7 +204,7 @@ where
 /// }
 ///
 /// impl Handler for MyCustomHandler {
-///     fn handle(self, _state: State) -> Box<HandlerFuture> {
+///     fn handle(self, _state: State) -> Pin<Box<HandlerFuture>> {
 ///         // Implementation elided.
 /// #       unimplemented!()
 ///     }
@@ -211,6 +220,8 @@ where
 /// ```rust
 /// # extern crate gotham;
 /// # extern crate hyper;
+/// #
+/// # use std::pin::Pin;
 /// #
 /// # use gotham::handler::{Handler, HandlerFuture, NewHandler};
 /// # use gotham::state::State;
@@ -231,7 +242,7 @@ where
 /// struct MyHandler;
 ///
 /// impl Handler for MyHandler {
-///     fn handle(self, _state: State) -> Box<HandlerFuture> {
+///     fn handle(self, _state: State) -> Pin<Box<HandlerFuture>> {
 ///         // Implementation elided.
 /// #       unimplemented!()
 ///     }
@@ -267,22 +278,22 @@ where
 /// bound via the generic function implementation.
 pub trait IntoHandlerFuture {
     /// Converts this value into a boxed future resolving to a state and response.
-    fn into_handler_future(self) -> Box<HandlerFuture>;
+    fn into_handler_future(self) -> Pin<Box<HandlerFuture>>;
 }
 
 impl<T> IntoHandlerFuture for (State, T)
 where
     T: IntoResponse,
 {
-    fn into_handler_future(self) -> Box<HandlerFuture> {
+    fn into_handler_future(self) -> Pin<Box<HandlerFuture>> {
         let (state, t) = self;
         let response = t.into_response(&state);
-        Box::new(future::ok((state, response)))
+        future::ok((state, response)).boxed()
     }
 }
 
-impl IntoHandlerFuture for Box<HandlerFuture> {
-    fn into_handler_future(self) -> Box<HandlerFuture> {
+impl IntoHandlerFuture for Pin<Box<HandlerFuture>> {
+    fn into_handler_future(self) -> Pin<Box<HandlerFuture>> {
         self
     }
 }

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -112,14 +112,12 @@ where
 /// ```
 pub fn create_empty_response(state: &State, status: StatusCode) -> Response<Body> {
     // new builder for the response
-    let mut builder = Response::builder();
-
-    // always add status and req-id
-    builder.status(status);
-    builder.header(X_REQUEST_ID, request_id(state));
-
-    // attach an empty body by default
-    let built = builder.body(Body::empty());
+    let built = Response::builder()
+        // always add status and req-id
+        .status(status)
+        .header(X_REQUEST_ID, request_id(state))
+        // attach an empty body by default
+        .body(Body::empty());
 
     // this expect should be safe due to generic bounds
     built.expect("Response built from a compatible type")

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -70,7 +70,7 @@ fn new_runtime(threads: usize) -> Runtime {
         .unwrap()
 }
 
-fn tcp_listener<A>(addr: A) -> impl Future<Output = std::io::Result<TcpListener>>
+async fn tcp_listener<A>(addr: A) -> std::io::Result<TcpListener>
 where
     A: ToSocketAddrs + 'static,
 {
@@ -80,7 +80,7 @@ where
         .next()
         .expect("unable to resolve listener address");
 
-    TcpListener::bind(addr)
+    TcpListener::bind(addr).await
 }
 
 /// Returns a `Future` used to spawn a Gotham application.

--- a/gotham/src/middleware/cookie/mod.rs
+++ b/gotham/src/middleware/cookie/mod.rs
@@ -1,5 +1,6 @@
 //! Defines a cookie parsing middleware to be attach cookies on requests.
 use std::io;
+use std::pin::Pin;
 
 use cookie::{Cookie, CookieJar};
 use hyper::header::{HeaderMap, HeaderValue, COOKIE};
@@ -36,9 +37,9 @@ impl CookieParser {
 /// `Middleware` trait implementation.
 impl Middleware for CookieParser {
     /// Attaches a set of parsed cookies to the request state.
-    fn call<Chain>(self, mut state: State, chain: Chain) -> Box<HandlerFuture>
+    fn call<Chain>(self, mut state: State, chain: Chain) -> Pin<Box<HandlerFuture>>
     where
-        Chain: FnOnce(State) -> Box<HandlerFuture>,
+        Chain: FnOnce(State) -> Pin<Box<HandlerFuture>>,
     {
         let cookies = { CookieParser::from_state(&state) };
         state.put(cookies);

--- a/gotham/src/middleware/state/mod.rs
+++ b/gotham/src/middleware/state/mod.rs
@@ -9,6 +9,7 @@ use crate::middleware::{Middleware, NewMiddleware};
 use crate::state::{State, StateData};
 use std::io;
 use std::panic::RefUnwindSafe;
+use std::pin::Pin;
 
 /// Middleware binding for generic types to enable easy shared state.
 ///
@@ -45,9 +46,9 @@ where
     /// Attaches the inner generic value to the request state.
     ///
     /// This will enable the `Handler` to borrow the value directly from the state.
-    fn call<Chain>(self, mut state: State, chain: Chain) -> Box<HandlerFuture>
+    fn call<Chain>(self, mut state: State, chain: Chain) -> Pin<Box<HandlerFuture>>
     where
-        Chain: FnOnce(State) -> Box<HandlerFuture>,
+        Chain: FnOnce(State) -> Pin<Box<HandlerFuture>>,
     {
         state.put(self.t);
         chain(state)

--- a/gotham/src/middleware/timer/mod.rs
+++ b/gotham/src/middleware/timer/mod.rs
@@ -4,7 +4,9 @@ use crate::helpers::http::header::X_RUNTIME_DURATION;
 use crate::helpers::timing::Timer;
 use crate::middleware::{Middleware, NewMiddleware};
 use crate::state::State;
-use futures::{future, Future};
+use futures::prelude::*;
+use std::pin::Pin;
+
 use std::io;
 
 /// Middleware binding to attach request execution times inside headers.
@@ -17,9 +19,9 @@ pub struct RequestTimer;
 /// `Middleware` trait implementation.
 impl Middleware for RequestTimer {
     /// Attaches the request execution time to the response headers.
-    fn call<Chain>(self, state: State, chain: Chain) -> Box<HandlerFuture>
+    fn call<Chain>(self, state: State, chain: Chain) -> Pin<Box<HandlerFuture>>
     where
-        Chain: FnOnce(State) -> Box<HandlerFuture>,
+        Chain: FnOnce(State) -> Pin<Box<HandlerFuture>>,
     {
         // start the timer
         let timer = Timer::new();
@@ -35,7 +37,7 @@ impl Middleware for RequestTimer {
             future::ok((state, response))
         });
 
-        Box::new(f)
+        f.boxed()
     }
 }
 

--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -2,30 +2,29 @@
 //!
 //! See the `TestServer` type for example usage.
 
+use http::Uri;
 use std::net::{self, IpAddr, SocketAddr};
 use std::panic::UnwindSafe;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use failure;
 use failure::ResultExt;
 use log::info;
 
 use futures::prelude::*;
-use hyper::client::{
-    connect::{Connect, Connected, Destination},
-    Client,
-};
+use hyper::client::Client;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
-use tokio::timer::{delay, Delay};
+use tokio::time::{delay_for, Delay};
 
+use hyper::service::Service;
 use tokio::net::TcpStream;
 
-use crate::handler::NewHandler;
-
 use crate::error::*;
+use crate::handler::NewHandler;
 
 use crate::test::{self, TestClient};
 
@@ -75,7 +74,9 @@ impl Clone for TestServer {
 
 impl test::Server for TestServer {
     fn request_expiry(&self) -> Delay {
-        delay(Instant::now() + Duration::from_secs(self.data.timeout))
+        // println!("{:?}", self.data.runtime.write().unwrap());
+        let runtime = self.data.runtime.write().unwrap();
+        runtime.enter(|| delay_for(Duration::from_secs(self.data.timeout)))
     }
 
     fn run_future<F, R, E>(&self, future: F) -> Result<R>
@@ -84,19 +85,21 @@ impl test::Server for TestServer {
         R: Send + 'static,
         E: failure::Fail,
     {
-        let (tx, rx) = futures::channel::oneshot::channel();
-        self.spawn(
-            future
-                .then(move |r| future::ready(tx.send(r).map_err(|_| unreachable!())))
-                .then(|_| future::ready(())), // ignore the result for spawn
-        );
+        let rx = future;
+        // let (tx, rx) = futures::channel::oneshot::channel();
+        // self.spawn(
+        //     future
+        //         .then(move |r| future::ready(tx.send(r).map_err(|_| unreachable!())))
+        //         .then(|_| future::ready(())), // ignore the result for spawn
+        // );
 
         self.data
             .runtime
             .write()
             .expect("unable to acquire write lock")
             .block_on(rx)
-            .unwrap()
+            // .map(|r| r.compat())
+            // .unwrap()
             .map_err(Into::into)
     }
 }
@@ -122,7 +125,7 @@ impl TestServer {
     where
         NH::Instance: UnwindSafe,
     {
-        let runtime = Runtime::new()?;
+        let mut runtime = Runtime::new()?;
         // TODO: Fix this into an async flow
         let listener = runtime.block_on(TcpListener::bind(
             "127.0.0.1:0".parse::<SocketAddr>().compat()?,
@@ -200,19 +203,19 @@ pub struct TestConnect {
     pub(crate) addr: SocketAddr,
 }
 
-impl Connect for TestConnect {
-    type Transport = TcpStream;
+impl Service<Uri> for TestConnect {
+    type Response = TcpStream;
     type Error = CompatError;
-    type Future = Pin<
-        Box<
-            dyn Future<Output = std::result::Result<(Self::Transport, Connected), Self::Error>>
-                + Send,
-        >,
-    >;
-    fn connect(&self, _dst: Destination) -> Self::Future {
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, _req: Uri) -> Self::Future {
         TcpStream::connect(self.addr)
             .inspect(|s| info!("Client TcpStream connected: {:?}", s))
-            .map_ok(|s| (s, Connected::new()))
             .map_err(|e| Error::from(e).compat())
             .boxed()
     }
@@ -222,11 +225,10 @@ impl Connect for TestConnect {
 mod tests {
     use super::*;
 
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use hyper::header::CONTENT_LENGTH;
-    use hyper::{Body, Response, StatusCode, Uri};
+    use hyper::{body, Body, Response, StatusCode, Uri};
     use mime;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
     use crate::helpers::http::response::create_response;
@@ -366,8 +368,7 @@ mod tests {
     #[test]
     fn async_echo() {
         fn handler(mut state: State) -> Pin<Box<HandlerFuture>> {
-            Body::take_from(&mut state)
-                .try_concat()
+            body::to_bytes(Body::take_from(&mut state))
                 .then(move |full_body| match full_body {
                     Ok(body) => {
                         let resp_data = body.to_vec();

--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -3,20 +3,23 @@
 //! See the `TestServer` type for example usage.
 
 use std::net::{self, IpAddr, SocketAddr};
+use std::panic::UnwindSafe;
+use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use failure;
+use failure::ResultExt;
 use log::info;
 
-use futures::{Future, IntoFuture};
+use futures::prelude::*;
 use hyper::client::{
     connect::{Connect, Connected, Destination},
     Client,
 };
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
-use tokio::timer::Delay;
+use tokio::timer::{delay, Delay};
 
 use tokio::net::TcpStream;
 
@@ -72,18 +75,29 @@ impl Clone for TestServer {
 
 impl test::Server for TestServer {
     fn request_expiry(&self) -> Delay {
-        Delay::new(Instant::now() + Duration::from_secs(self.data.timeout))
+        delay(Instant::now() + Duration::from_secs(self.data.timeout))
     }
 
     fn run_future<F, R, E>(&self, future: F) -> Result<R>
     where
-        F: Send + 'static + Future<Item = R, Error = E>,
+        F: Send + 'static + Future<Output = std::result::Result<R, E>>,
         R: Send + 'static,
         E: failure::Fail,
     {
-        let (tx, rx) = futures::sync::oneshot::channel();
-        self.spawn(future.then(move |r| tx.send(r).map_err(|_| unreachable!())));
-        rx.wait().unwrap().map_err(Into::into)
+        let (tx, rx) = futures::channel::oneshot::channel();
+        self.spawn(
+            future
+                .then(move |r| future::ready(tx.send(r).map_err(|_| unreachable!())))
+                .then(|_| future::ready(())), // ignore the result for spawn
+        );
+
+        self.data
+            .runtime
+            .write()
+            .expect("unable to acquire write lock")
+            .block_on(rx)
+            .unwrap()
+            .map_err(Into::into)
     }
 }
 
@@ -93,7 +107,10 @@ impl TestServer {
     /// for each connection.
     ///
     /// Timeout will be set to 10 seconds.
-    pub fn new<NH: NewHandler + 'static>(new_handler: NH) -> Result<TestServer> {
+    pub fn new<NH: NewHandler + 'static>(new_handler: NH) -> Result<TestServer>
+    where
+        NH::Instance: UnwindSafe,
+    {
         TestServer::with_timeout(new_handler, 10)
     }
 
@@ -101,13 +118,19 @@ impl TestServer {
     pub fn with_timeout<NH: NewHandler + 'static>(
         new_handler: NH,
         timeout: u64,
-    ) -> Result<TestServer> {
-        let mut runtime = Runtime::new()?;
-        let listener = TcpListener::bind(&"127.0.0.1:0".parse()?)?;
+    ) -> Result<TestServer>
+    where
+        NH::Instance: UnwindSafe,
+    {
+        let runtime = Runtime::new()?;
+        // TODO: Fix this into an async flow
+        let listener = runtime.block_on(TcpListener::bind(
+            "127.0.0.1:0".parse::<SocketAddr>().compat()?,
+        ))?;
         let addr = listener.local_addr()?;
 
-        let service_stream = super::bind_server(listener, new_handler, |tcp| Ok(tcp).into_future());
-        runtime.spawn(service_stream);
+        let service_stream = super::bind_server(listener, new_handler, future::ok);
+        runtime.spawn(service_stream.then(|_| future::ready(()))); // Ignore the result
 
         let data = TestServerData {
             addr,
@@ -132,7 +155,7 @@ impl TestServer {
     /// tests.
     pub fn spawn<F>(&self, fut: F)
     where
-        F: Future<Item = (), Error = ()> + Send + 'static,
+        F: Future<Output = ()> + Send + 'static,
     {
         self.data
             .runtime
@@ -172,6 +195,7 @@ impl TestServer {
 
 /// `TestConnect` represents the connection between a test client and the `TestServer` instance
 /// that created it. This type should never be used directly.
+#[derive(Clone)]
 pub struct TestConnect {
     pub(crate) addr: SocketAddr,
 }
@@ -179,16 +203,18 @@ pub struct TestConnect {
 impl Connect for TestConnect {
     type Transport = TcpStream;
     type Error = CompatError;
-    type Future =
-        Box<dyn Future<Item = (Self::Transport, Connected), Error = Self::Error> + Send + Sync>;
-
+    type Future = Pin<
+        Box<
+            dyn Future<Output = std::result::Result<(Self::Transport, Connected), Self::Error>>
+                + Send,
+        >,
+    >;
     fn connect(&self, _dst: Destination) -> Self::Future {
-        Box::new(
-            TcpStream::connect(&self.addr)
-                .inspect(|s| info!("Client TcpStream connected: {:?}", s))
-                .map(|s| (s, Connected::new()))
-                .map_err(|e| Error::from(e).compat()),
-        )
+        TcpStream::connect(self.addr)
+            .inspect(|s| info!("Client TcpStream connected: {:?}", s))
+            .map_ok(|s| (s, Connected::new()))
+            .map_err(|e| Error::from(e).compat())
+            .boxed()
     }
 }
 
@@ -205,7 +231,6 @@ mod tests {
     use crate::handler::{Handler, HandlerFuture, IntoHandlerError, NewHandler};
     use crate::helpers::http::response::create_response;
     use crate::state::{client_addr, FromState, State};
-    use futures::{future, Stream};
     use http::header::CONTENT_TYPE;
     use log::info;
 
@@ -215,7 +240,7 @@ mod tests {
     }
 
     impl Handler for TestHandler {
-        fn handle(self, state: State) -> Box<HandlerFuture> {
+        fn handle(self, state: State) -> Pin<Box<HandlerFuture>> {
             let path = Uri::borrow_from(&state).path().to_owned();
             match path.as_str() {
                 "/" => {
@@ -225,11 +250,17 @@ mod tests {
                         .body(self.response.clone().into())
                         .unwrap();
 
-                    Box::new(future::ok((state, response)))
+                    future::ok((state, response)).boxed()
                 }
                 "/timeout" => {
+                    // TODO: What is this supposed to return?  It previously returned nothing which isn't a timeout
+                    let response = Response::builder()
+                        .status(StatusCode::REQUEST_TIMEOUT)
+                        .body(Body::default())
+                        .unwrap();
+
                     info!("TestHandler responding to /timeout");
-                    Box::new(future::empty())
+                    future::ok((state, response)).boxed()
                 }
                 "/myaddr" => {
                     info!("TestHandler responding to /myaddr");
@@ -238,7 +269,7 @@ mod tests {
                         .body(format!("{}", client_addr(&state).unwrap()).into())
                         .unwrap();
 
-                    Box::new(future::ok((state, response)))
+                    future::ok((state, response)).boxed()
                 }
                 _ => unreachable!(),
             }
@@ -334,9 +365,9 @@ mod tests {
 
     #[test]
     fn async_echo() {
-        fn handler(mut state: State) -> Box<HandlerFuture> {
-            let f = Body::take_from(&mut state)
-                .concat2()
+        fn handler(mut state: State) -> Pin<Box<HandlerFuture>> {
+            Body::take_from(&mut state)
+                .try_concat()
                 .then(move |full_body| match full_body {
                     Ok(body) => {
                         let resp_data = body.to_vec();
@@ -346,9 +377,8 @@ mod tests {
                     }
 
                     Err(e) => future::err((state, e.into_handler_error())),
-                });
-
-            Box::new(f)
+                })
+                .boxed()
         }
 
         let server = TestServer::new(|| Ok(handler)).unwrap();

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -950,8 +950,9 @@ where
 #[cfg(test)]
 mod tests {
     use std::io;
+    use std::pin::Pin;
 
-    use futures::future;
+    use futures::prelude::*;
     use hyper::{Body, Response, StatusCode};
 
     use crate::handler::HandlerFuture;
@@ -975,9 +976,9 @@ mod tests {
     }
 
     impl Middleware for QuickExitMiddleware {
-        fn call<Chain>(self, state: State, _chain: Chain) -> Box<HandlerFuture>
+        fn call<Chain>(self, state: State, _chain: Chain) -> Pin<Box<HandlerFuture>>
         where
-            Chain: FnOnce(State) -> Box<HandlerFuture> + 'static,
+            Chain: FnOnce(State) -> Pin<Box<HandlerFuture>> + 'static,
         {
             let f = future::ok((
                 state,
@@ -987,7 +988,7 @@ mod tests {
                     .unwrap(),
             ));
 
-            Box::new(f)
+            f.boxed()
         }
     }
 

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -316,9 +316,8 @@ where
 mod tests {
     use super::*;
 
-    use futures::prelude::*;
     use hyper::service::Service;
-    use hyper::{Body, Request, Response, StatusCode};
+    use hyper::{body, Body, Request, Response, StatusCode};
     use serde_derive::Deserialize;
 
     use crate::middleware::cookie::CookieParser;
@@ -549,7 +548,7 @@ mod tests {
 
         let response = call(Request::get("/hello/world").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+        let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()
             .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "Hello, world!");
@@ -560,21 +559,21 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+        let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()
             .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "Globbed");
 
         let response = call(Request::get("/delegated/b").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+        let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()
             .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "Delegated");
 
         let response = call(Request::get("/goodbye/world").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+        let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()
             .to_vec();
         assert_eq!(
@@ -597,7 +596,7 @@ mod tests {
 
         let response = call(Request::get("/add?x=16&y=71").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+        let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()
             .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "16 + 71 = 87");
@@ -613,7 +612,7 @@ mod tests {
 
         let response = call(Request::get("/resource").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+        let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()
             .to_vec();
         assert_eq!(&response_bytes[..], b"It's a resource.");

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -316,7 +316,7 @@ where
 mod tests {
     use super::*;
 
-    use futures::{Future, Stream};
+    use futures::prelude::*;
     use hyper::service::Service;
     use hyper::{Body, Request, Response, StatusCode};
     use serde_derive::Deserialize;
@@ -538,7 +538,7 @@ mod tests {
 
         let call = move |req| {
             let mut service = new_service.connect("127.0.0.1:10000".parse().unwrap());
-            service.call(req).wait().unwrap()
+            futures::executor::block_on(service.call(req)).unwrap()
         };
 
         let response = call(Request::get("/").body(Body::empty()).unwrap());
@@ -549,7 +549,9 @@ mod tests {
 
         let response = call(Request::get("/hello/world").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = response.into_body().concat2().wait().unwrap().to_vec();
+        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+            .unwrap()
+            .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "Hello, world!");
 
         let response = call(
@@ -558,17 +560,23 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = response.into_body().concat2().wait().unwrap().to_vec();
+        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+            .unwrap()
+            .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "Globbed");
 
         let response = call(Request::get("/delegated/b").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = response.into_body().concat2().wait().unwrap().to_vec();
+        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+            .unwrap()
+            .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "Delegated");
 
         let response = call(Request::get("/goodbye/world").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = response.into_body().concat2().wait().unwrap().to_vec();
+        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+            .unwrap()
+            .to_vec();
         assert_eq!(
             &String::from_utf8(response_bytes).unwrap(),
             "Goodbye, world!"
@@ -589,7 +597,9 @@ mod tests {
 
         let response = call(Request::get("/add?x=16&y=71").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = response.into_body().concat2().wait().unwrap().to_vec();
+        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+            .unwrap()
+            .to_vec();
         assert_eq!(&String::from_utf8(response_bytes).unwrap(), "16 + 71 = 87");
 
         let response = call(Request::post("/resource").body(Body::empty()).unwrap());
@@ -603,7 +613,9 @@ mod tests {
 
         let response = call(Request::get("/resource").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
-        let response_bytes = response.into_body().concat2().wait().unwrap().to_vec();
+        let response_bytes = futures::executor::block_on(response.into_body().try_concat())
+            .unwrap()
+            .to_vec();
         assert_eq!(&response_bytes[..], b"It's a resource.");
 
         let response = call(

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -116,8 +116,10 @@ pub trait DefineSingleRoute {
     /// # extern crate hyper;
     /// # extern crate futures;
     /// #
+    /// # use std::pin::Pin;
+    /// #
     /// # use hyper::{Body, Response, StatusCode};
-    /// # use futures::future;
+    /// # use futures::prelude::*;
     /// # use gotham::handler::{Handler, HandlerFuture, NewHandler};
     /// # use gotham::state::State;
     /// # use gotham::router::Router;
@@ -140,10 +142,10 @@ pub trait DefineSingleRoute {
     /// }
     ///
     /// impl Handler for MyHandler {
-    ///     fn handle(self, state: State) -> Box<HandlerFuture> {
+    ///     fn handle(self, state: State) -> Pin<Box<HandlerFuture>> {
     ///         // Handler implementation elided.
     /// #       let response = Response::builder().status(StatusCode::ACCEPTED).body(Body::empty()).unwrap();
-    /// #       Box::new(future::ok((state, response)))
+    /// #       future::ok((state, response)).boxed()
     ///     }
     /// }
     /// #

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -1,14 +1,14 @@
 //! Defines functionality for extending a Response.
 
 use crate::state::{request_id, State};
-use hyper::{body::Payload, Body, Response};
+use hyper::{body::HttpBody, Body, Response};
 use log::trace;
 use std::panic::RefUnwindSafe;
 
 /// Extend the `Response` based on current `State` and `Response` data.
 pub trait StaticResponseExtender: RefUnwindSafe {
     /// The type of the response body. Almost always `hyper::Body`.
-    type ResBody: Payload;
+    type ResBody: HttpBody;
 
     /// Extend the response.
     fn extend(state: &mut State, response: &mut Response<Self::ResBody>);

--- a/gotham/src/router/response/finalizer.rs
+++ b/gotham/src/router/response/finalizer.rs
@@ -2,9 +2,10 @@
 //! and internal extenders have completed.
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::future;
+use futures::prelude::*;
 use hyper::{Body, Response, StatusCode};
 use log::trace;
 
@@ -63,7 +64,7 @@ impl ResponseFinalizerBuilder {
 impl ResponseFinalizer {
     /// Finalize the `Response` if a `ResponseFinalizer` has been supplied for the
     /// status code assigned to the `Response`.
-    pub fn finalize(&self, mut state: State, mut res: Response<Body>) -> Box<HandlerFuture> {
+    pub fn finalize(&self, mut state: State, mut res: Response<Body>) -> Pin<Box<HandlerFuture>> {
         match self.data.get(&res.status()) {
             Some(extender) => {
                 trace!(
@@ -82,6 +83,6 @@ impl ResponseFinalizer {
             }
         }
 
-        Box::new(future::ok((state, res)))
+        future::ok((state, res)).boxed()
     }
 }

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -51,7 +51,7 @@ pub enum Delegation {
 /// `Route` exists as a trait to allow abstraction over the generic types in `RouteImpl`. This
 /// trait should not be implemented outside of Gotham.
 pub trait Route: RefUnwindSafe {
-    /// The type of the response body. The requirements of Hyper are that this implements `Payload`.
+    /// The type of the response body. The requirements of Hyper are that this implements `HttpBody`.
     /// Almost always, it will want to be `hyper::Body`.
     type ResBody;
     /// Determines if this `Route` should be invoked, based on the request data in `State.

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -9,6 +9,7 @@ pub mod matcher;
 
 use std::marker::PhantomData;
 use std::panic::RefUnwindSafe;
+use std::pin::Pin;
 
 use hyper::{Body, Response, Uri};
 use log::debug;
@@ -81,7 +82,7 @@ pub trait Route: RefUnwindSafe {
 
     /// Dispatches the request to this `Route`, which will execute the pipelines and the handler
     /// assigned to the `Route.
-    fn dispatch(&self, state: State) -> Box<HandlerFuture>;
+    fn dispatch(&self, state: State) -> Pin<Box<HandlerFuture>>;
 }
 
 /// Returned in the `Err` variant from `extract_query_string` or `extract_request_path`, this
@@ -165,7 +166,7 @@ where
         self.delegation
     }
 
-    fn dispatch(&self, state: State) -> Box<HandlerFuture> {
+    fn dispatch(&self, state: State) -> Pin<Box<HandlerFuture>> {
         self.dispatcher.dispatch(state)
     }
 
@@ -220,7 +221,7 @@ where
 mod tests {
     use super::*;
 
-    use futures::Async;
+    use futures::prelude::*;
     use hyper::{HeaderMap, Method, StatusCode, Uri};
     use std::str::FromStr;
 
@@ -252,12 +253,10 @@ mod tests {
         state.put(Method::GET);
         set_request_id(&mut state);
 
-        match route.dispatch(state).poll() {
-            Ok(Async::Ready((_state, response))) => {
-                assert_eq!(response.status(), StatusCode::ACCEPTED)
-            }
-            Ok(Async::NotReady) => panic!("expected future to be completed already"),
-            Err((_state, e)) => panic!("error polling future: {}", e),
+        match route.dispatch(state).now_or_never() {
+            Some(Ok((_state, response))) => assert_eq!(response.status(), StatusCode::ACCEPTED),
+            Some(Err((_state, e))) => panic!("error polling future: {}", e),
+            None => panic!("expected future to be completed already"),
         }
     }
 
@@ -286,12 +285,10 @@ mod tests {
         state.put(RequestPathSegments::new("/"));
         set_request_id(&mut state);
 
-        match route.dispatch(state).poll() {
-            Ok(Async::Ready((_state, response))) => {
-                assert_eq!(response.status(), StatusCode::ACCEPTED)
-            }
-            Ok(Async::NotReady) => panic!("expected future to be completed already"),
-            Err((_state, e)) => panic!("error polling future: {}", e),
+        match route.dispatch(state).now_or_never() {
+            Some(Ok((_state, response))) => assert_eq!(response.status(), StatusCode::ACCEPTED),
+            Some(Err((_state, e))) => panic!("error polling future: {}", e),
+            None => panic!("expected future to be completed already"),
         }
     }
 }

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -12,9 +12,9 @@ use failure;
 use futures::prelude::*;
 use futures::task::{self, Poll};
 use http::request;
+use hyper::service::Service;
 use hyper::{Body, Request, Response};
 use log::debug;
-use tower_service::Service as TowerService;
 
 use crate::handler::NewHandler;
 
@@ -61,7 +61,7 @@ where
     client_addr: SocketAddr,
 }
 
-impl<T> TowerService<Request<Body>> for ConnectedGothamService<T>
+impl<T> Service<Request<Body>> for ConnectedGothamService<T>
 where
     T: NewHandler,
 {

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -1,6 +1,7 @@
 /// Test request behavior, shared between the tls::test and plain::test modules.
 pub mod request;
 
+use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
@@ -8,14 +9,13 @@ use failure::format_err;
 use failure::ResultExt;
 
 use futures::prelude::*;
-use http::HttpTryFrom;
 use hyper::client::connect::Connect;
 use hyper::client::Client;
 use hyper::header::CONTENT_TYPE;
-use hyper::{Body, Method, Response, Uri};
+use hyper::{body, Body, Method, Response, Uri};
 use log::warn;
 use mime;
-use tokio::timer::Delay;
+use tokio::time::Delay;
 
 use crate::error::*;
 
@@ -71,10 +71,7 @@ pub trait Server: Clone {
 
 impl<T: Server> BodyReader for T {
     fn read_body(&mut self, response: Response<Body>) -> Result<Vec<u8>> {
-        let f = response
-            .into_body()
-            .try_concat()
-            .map_ok(|chunk| chunk.into_iter().collect());
+        let f = body::to_bytes(response.into_body()).and_then(|b| future::ok(b.to_vec()));
         self.run_future(f)
     }
 }
@@ -85,11 +82,12 @@ pub struct TestClient<TS: Server, C: Connect> {
     pub(crate) test_server: TS,
 }
 
-impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
+impl<TS: Server + 'static, C: Connect + Clone + Send + Sync + 'static> TestClient<TS, C> {
     /// Begin constructing a HEAD request using this `TestClient`.
     pub fn head<U>(&self, uri: U) -> TestRequest<TS, C>
     where
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request(Method::HEAD, uri)
     }
@@ -97,7 +95,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     /// Begin constructing a GET request using this `TestClient`.
     pub fn get<U>(&self, uri: U) -> TestRequest<TS, C>
     where
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request(Method::GET, uri)
     }
@@ -105,7 +104,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     /// Begin constructing an OPTIONS request using this `TestClient`.
     pub fn options<U>(&self, uri: U) -> TestRequest<TS, C>
     where
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request(Method::OPTIONS, uri)
     }
@@ -114,7 +114,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     pub fn post<B, U>(&self, uri: U, body: B, mime: mime::Mime) -> TestRequest<TS, C>
     where
         B: Into<Body>,
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request_with_body(Method::POST, uri, body, mime)
     }
@@ -123,7 +124,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     pub fn put<B, U>(&self, uri: U, body: B, mime: mime::Mime) -> TestRequest<TS, C>
     where
         B: Into<Body>,
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request_with_body(Method::PUT, uri, body, mime)
     }
@@ -132,7 +134,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     pub fn patch<B, U>(&self, uri: U, body: B, mime: mime::Mime) -> TestRequest<TS, C>
     where
         B: Into<Body>,
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request_with_body(Method::PATCH, uri, body, mime)
     }
@@ -140,7 +143,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     /// Begin constructing a DELETE request using this `TestClient`.
     pub fn delete<U>(&self, uri: U) -> TestRequest<TS, C>
     where
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         self.build_request(Method::DELETE, uri)
     }
@@ -148,7 +152,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     /// Begin constructing a request with the given HTTP method and URI.
     pub fn build_request<U>(&self, method: Method, uri: U) -> TestRequest<TS, C>
     where
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         TestRequest::new(self, method, uri)
     }
@@ -163,7 +168,8 @@ impl<TS: Server + 'static, C: Connect + 'static> TestClient<TS, C> {
     ) -> TestRequest<TS, C>
     where
         B: Into<Body>,
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         let mut request = self.build_request(method, uri);
 

--- a/gotham/src/test/request.rs
+++ b/gotham/src/test/request.rs
@@ -1,7 +1,7 @@
+use std::convert::TryFrom;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
-use http::HttpTryFrom;
 use hyper::client::connect::Connect;
 use hyper::header::{HeaderValue, IntoHeaderName};
 use hyper::{Body, Method, Request, Uri};
@@ -32,10 +32,11 @@ impl<'a, S: Server, C: Connect> DerefMut for TestRequest<'a, S, C> {
     }
 }
 
-impl<'a, S: Server + 'static, C: Connect + 'static> TestRequest<'a, S, C> {
+impl<'a, S: Server + 'static, C: Connect + Clone + Send + Sync + 'static> TestRequest<'a, S, C> {
     pub(crate) fn new<U>(client: &'a TestClient<S, C>, method: Method, uri: U) -> Self
     where
-        Uri: HttpTryFrom<U>,
+        Uri: TryFrom<U>,
+        <Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
         TestRequest {
             client,

--- a/gotham/src/test/request.rs
+++ b/gotham/src/test/request.rs
@@ -2,12 +2,12 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 
 use http::HttpTryFrom;
+use hyper::client::connect::Connect;
 use hyper::header::{HeaderValue, IntoHeaderName};
 use hyper::{Body, Method, Request, Uri};
 
 use super::Server;
 use super::{TestClient, TestResponse};
-use hyper::client::connect::Connect;
 
 use crate::error::*;
 

--- a/gotham/src/tls/test.rs
+++ b/gotham/src/tls/test.rs
@@ -90,7 +90,6 @@ impl test::Server for TestServer {
     fn request_expiry(&self) -> Delay {
         let runtime = self.data.runtime.write().unwrap();
         runtime.enter(|| delay_for(Duration::from_secs(self.data.timeout)))
-        // delay_for(Duration::from_secs(self.data.timeout))
     }
 
     fn run_future<F, R, E>(&self, future: F) -> Result<R>

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "gotham", "diesel"]
 
 [dependencies]
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 gotham = "0.5.0-dev"
 gotham_derive = "0.5.0-dev"
 diesel = { version = "1.3", features = ["r2d2"] }
@@ -23,5 +23,5 @@ log = "0.4"
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }
 mime = "0.3"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
-tokio = "=0.2.0-alpha.6"
+hyper = "0.13.1"
+tokio = { version = "0.2.6", features = ["full"] }

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server"]
 keywords = ["http", "async", "web", "gotham", "diesel"]
 
 [dependencies]
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 gotham = "0.5.0-dev"
 gotham_derive = "0.5.0-dev"
 diesel = { version = "1.3", features = ["r2d2"] }
@@ -23,5 +23,5 @@ log = "0.4"
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }
 mime = "0.3"
-hyper = "0.12"
-tokio = "0.1"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+tokio = "=0.2.0-alpha.6"

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -17,7 +17,7 @@ gotham = "0.5.0-dev"
 gotham_derive = "0.5.0-dev"
 diesel = { version = "1.3", features = ["r2d2"] }
 r2d2 = "0.8"
-tokio-threadpool = "0.1"
+tokio = { version = "0.2.6", features = ["full"] }
 log = "0.4"
 
 [dev-dependencies]

--- a/middleware/jwt/Cargo.toml
+++ b/middleware/jwt/Cargo.toml
@@ -15,11 +15,11 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 gotham = "0.5.0-dev"
 gotham_derive = "0.5.0-dev"
 serde = "1.0"
 serde_derive = "1.0"
-hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
+hyper = "0.13.1"
 jsonwebtoken = "6.0"
 log = "0.4"

--- a/middleware/jwt/Cargo.toml
+++ b/middleware/jwt/Cargo.toml
@@ -15,11 +15,11 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 gotham = "0.5.0-dev"
 gotham_derive = "0.5.0-dev"
 serde = "1.0"
 serde_derive = "1.0"
-hyper = "0.12"
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 jsonwebtoken = "6.0"
 log = "0.4"

--- a/middleware/template/Cargo.toml
+++ b/middleware/template/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 log = "0.4"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.1"
 
 # Middlewares should reference the semantic versions of Gotham that are they compatible with
 # and not use relative references such as shown here.

--- a/middleware/template/Cargo.toml
+++ b/middleware/template/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 log = "0.4"
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 
 # Middlewares should reference the semantic versions of Gotham that are they compatible with
 # and not use relative references such as shown here.

--- a/middleware/template/src/lib.rs
+++ b/middleware/template/src/lib.rs
@@ -16,8 +16,9 @@ extern crate log;
 //extern crate gotham_derive;
 
 use std::io;
+use std::pin::Pin;
 
-use futures::{future, Future};
+use futures::prelude::*;
 
 use gotham::handler::HandlerFuture;
 use gotham::middleware::{Middleware, NewMiddleware};
@@ -45,9 +46,9 @@ impl NewMiddleware for MyMiddleware {
 }
 
 impl Middleware for MyMiddleware {
-    fn call<Chain>(self, state: State, chain: Chain) -> Box<HandlerFuture>
+    fn call<Chain>(self, state: State, chain: Chain) -> Pin<Box<HandlerFuture>>
     where
-        Chain: FnOnce(State) -> Box<HandlerFuture>,
+        Chain: FnOnce(State) -> Pin<Box<HandlerFuture>>,
     {
         debug!("[{}] pre chain", request_id(&state));
         // Do things prior to passing the request on to other middleware and the eventual Handler
@@ -55,16 +56,17 @@ impl Middleware for MyMiddleware {
         // For example store something in State
         // state.put(MyData { my_value: "abcdefg".to_owned() });
 
-        let f = chain(state).and_then(move |(state, response)| {
-            {
-                debug!("[{}] post chain", request_id(&state));
-                // Do things once a response has come back
-                // ..
-                // For example get our data back from State
-                // let data = state.borrow::<MyData>().unwrap();
-            }
-            future::ok((state, response))
-        });
-        Box::new(f)
+        chain(state)
+            .and_then(move |(state, response)| {
+                {
+                    debug!("[{}] post chain", request_id(&state));
+                    // Do things once a response has come back
+                    // ..
+                    // For example get our data back from State
+                    // let data = state.borrow::<MyData>().unwrap();
+                }
+                future::ok((state, response))
+            })
+            .boxed()
     }
 }


### PR DESCRIPTION
With the anticipated release of async-await in stable rust this week, I took an effort to migrate Gotham to run on std futures using the pre-release versions of the dependencies (tokio, hyper, etc).

*NOTE*: This doesn't attempt to introduce `await` or `async fn` into the codebase (there was a single unavoidable case due to an `tokio::File::metadata` API change).  That is designed as a future activity.

This migration involved a few key efforts:

1. Convert from Futures 0.1 to Futures-preview 0.3 (mostly `Future<Item=>` to `Future<Output=Result<>>`).
2. Update dependencies to pre-release versions (`tokio-0.2` and `hyper-0.13`).  There's still other dependencies that are outstanding and blocking the full release.
3. Migrate Handler trait to a pinned box HandlerFuture.

This is a **work-in-progress** with a few blockers before this would be ready:

Gotham Dependencies:

- [x] Update Futures from `futures-preview` to `futures = 0.3` when the other dependencies (hyper, tokio, etc) update in concert.
- [x] Update Tokio to `0.2` from alpha pre-releases
- [x] Update Hyper to `0.13` from alpha pre-releases
- [x] Update Tower-Service to `0.3` from alpha pre-releases.  Hyper is migrating many of its traits to `tower-service::Service` and so is now a direct dependency.
- [x] Released version of `futures_rustls` which is currently a branch of `tokio-rustls` ported to Futures-preview
- [x] Released version of `futures-tokio-compat` or suggested `tokio::compat` library for bridging `futures::AsyncRead` and `tokio::AsyncRead`.  See https://github.com/tokio-rs/tokio/issues/1297
    and https://github.com/async-rs/async-std/issues/54

Middleware Dependencies:

- [x] Diesel - Requires updated release of `tokio-threadpool`
- [ ] JWT - Requires updated release of `jsonwebtoken` since it's dependency `ring` conflicts withs `futures-rustls`.

The following examples were not updated (and thus commented out in `Cargo.toml`) due to incompatible dependencies:

- [x] `hello_world_until` is dependent on a compatible version of `tokio-signal`
- [x] `diesel` is dependent on the Diesel middleware
- [ ] `openssl` is dependent on `tokio-openssl`
- [ ] `websocket` is dependent on `tokio-tungstenite`