### PR TITLE
Replace "blockchain" by "server" in Cargo.toml

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://gotham.rs"
 repository = "https://github.com/gotham-rs/gotham"
 readme = "README.md"
 categories = ["web-programming::http-server"]
-keywords = ["http", "async", "web", "framework", "blockchain"]
+keywords = ["http", "async", "web", "framework", "server"]
 edition = "2018"
 
 [features]


### PR DESCRIPTION
Since gotham is becoming more mature product, I replaced keyword blockchain by server.
Main reason for this is the ending of blockchain hype. Also, it was absolutely unrelated to this webserver.

Relates: https://github.com/gotham-rs/gotham/issues/371