### PR TITLE
Use mime_guess's built in defaulting method

### DIFF
--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -296,8 +296,7 @@ fn get_extension(encoding: &str, options: &FileOptions) -> Option<String> {
 
 fn mime_for_path(path: &Path) -> Mime {
     from_path(path)
-        .first()
-        .unwrap_or_else(|| mime::APPLICATION_OCTET_STREAM)
+        .first_or_octet_stream()
 }
 
 fn normalize_path(path: &Path) -> PathBuf {

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -295,8 +295,7 @@ fn get_extension(encoding: &str, options: &FileOptions) -> Option<String> {
 }
 
 fn mime_for_path(path: &Path) -> Mime {
-    from_path(path)
-        .first_or_octet_stream()
+    from_path(path).first_or_octet_stream()
 }
 
 fn normalize_path(path: &Path) -> PathBuf {


### PR DESCRIPTION
Use `mime_guess`'s built in method for defaulting to `application/octet-stream` for undetermined mime types