### PR TITLE
Give priority to static children that are delegated

### DIFF
--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -663,11 +663,11 @@ mod tests {
     #[test]
     fn test_delegated_priority_after_delegated_children() {
         let delegated_router = build_simple_router(|route| {
-            route.get("/b").to(welcome::delegated);
+            route.get("/b/a").to(welcome::delegated);
         });
 
         let child_delegated_router = build_simple_router(|route| {
-            route.get("/").to(welcome::index);
+            route.get("/a").to(welcome::index);
         });
 
         let router = build_simple_router(|route| {
@@ -678,7 +678,7 @@ mod tests {
 
         let call = get_call(router);
 
-        let response = call(Request::get("/b").body(Body::empty()).unwrap());
+        let response = call(Request::get("/b/a").body(Body::empty()).unwrap());
         assert_eq!(response.status(), StatusCode::OK);
         let response_bytes = futures::executor::block_on(body::to_bytes(response.into_body()))
             .unwrap()


### PR DESCRIPTION
The following code is a pretty common case when people are trying to do different apps with mix and match pipelines.

```rust
let delegated_router = build_simple_router(|route| {
    route.get("/b/a").to(welcome::delegated);
});

let child_delegated_router = build_simple_router(|route| {
    route.get("/a").to(welcome::index);
});

let router = build_simple_router(|route| {
    route.delegate("/").to_router(delegated_router);

    route.delegate("/b").to_router(child_delegated_router);
});
```

When I go to `/b/a`, the `welcome::delegated` is being run. Static children types should be given priority if they are delegated too. (Note: non-delegated children won't have priority, so, it still works as before)

Router tree and `match_node` needs a bigger overhaul if we want to support other type of children that are being delegated too. But that's for later. 
