### PR TITLE
Re-Enable JWT Middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ members = [
     ## Middleware
     "middleware/template",
     "middleware/diesel",
-    # TODO: Re-enable middleware when their dependencies are updated
-    # "middleware/jwt",
+    "middleware/jwt",
 
     ## Examples (these crates are not published)
     "examples/hello_world",

--- a/middleware/jwt/Cargo.toml
+++ b/middleware/jwt/Cargo.toml
@@ -20,5 +20,5 @@ gotham = { path = "../../gotham", version = "0.5.0-dev" }
 gotham_derive = { path = "../../gotham_derive", version = "0.5.0-dev" }
 serde = "1.0"
 serde_derive = "1.0"
-jsonwebtoken = "6.0"
+jsonwebtoken = "^7.0"
 log = "0.4"

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -1,18 +1,18 @@
 use crate::state_data::AuthorizationToken;
-use futures::{future, Future};
+use futures::prelude::*;
+use gotham::hyper::{
+    header::{HeaderMap, AUTHORIZATION},
+    StatusCode,
+};
 use gotham::{
     handler::HandlerFuture,
     helpers::http::response::create_empty_response,
     middleware::{Middleware, NewMiddleware},
     state::{request_id, FromState, State},
 };
-use hyper::{
-    header::{HeaderMap, AUTHORIZATION},
-    StatusCode,
-};
-use jsonwebtoken::{decode, Validation};
+use jsonwebtoken::{decode, DecodingKey, Validation};
 use serde::de::Deserialize;
-use std::{io, marker::PhantomData, panic::RefUnwindSafe};
+use std::{io, marker::PhantomData, panic::RefUnwindSafe, pin::Pin};
 
 const DEFAULT_SCHEME: &str = "Bearer";
 
@@ -33,12 +33,11 @@ const DEFAULT_SCHEME: &str = "Bearer";
 /// extern crate futures;
 /// extern crate gotham;
 /// extern crate gotham_middleware_jwt;
-/// extern crate hyper;
 /// extern crate serde;
 /// #[macro_use]
 /// extern crate serde_derive;
 ///
-/// use futures::future;
+/// use futures::prelude::*;
 /// use gotham::{
 ///     helpers::http::response::create_empty_response,
 ///     handler::HandlerFuture,
@@ -49,8 +48,9 @@ const DEFAULT_SCHEME: &str = "Bearer";
 ///     router::{builder::*, Router},
 ///     state::{State, FromState},
 /// };
+/// use gotham::hyper::{Response, StatusCode};
 /// use gotham_middleware_jwt::{JWTMiddleware, AuthorizationToken};
-/// use hyper::{Response, StatusCode};
+/// use std::pin::Pin;
 ///
 /// #[derive(Deserialize, Debug)]
 /// struct Claims {
@@ -58,13 +58,13 @@ const DEFAULT_SCHEME: &str = "Bearer";
 ///     exp: usize,
 /// }
 ///
-/// fn handler(state: State) -> Box<HandlerFuture> {
+/// fn handler(state: State) -> Pin<Box<HandlerFuture>> {
 ///     {
 ///         let token = AuthorizationToken::<Claims>::borrow_from(&state);
 ///         // token -> TokenData
 ///     }
 ///     let res = create_empty_response(&state, StatusCode::OK);
-///     Box::new(future::ok((state, res)))
+///     future::ok((state, res)).boxed()
 /// }
 ///
 /// fn router() -> Router {
@@ -128,9 +128,9 @@ impl<T> Middleware for JWTMiddleware<T>
 where
     T: for<'de> Deserialize<'de> + Send + Sync + 'static,
 {
-    fn call<Chain>(self, mut state: State, chain: Chain) -> Box<HandlerFuture>
+    fn call<Chain>(self, mut state: State, chain: Chain) -> Pin<Box<HandlerFuture>>
     where
-        Chain: FnOnce(State) -> Box<HandlerFuture>,
+        Chain: FnOnce(State) -> Pin<Box<HandlerFuture>>,
     {
         trace!("[{}] pre-chain jwt middleware", request_id(&state));
 
@@ -145,10 +145,14 @@ where
         if token.is_none() {
             trace!("[{}] bad request jwt middleware", request_id(&state));
             let res = create_empty_response(&state, StatusCode::BAD_REQUEST);
-            return Box::new(future::ok((state, res)));
+            return future::ok((state, res)).boxed();
         }
 
-        match decode::<T>(&token.unwrap(), self.secret.as_ref(), &self.validation) {
+        match decode::<T>(
+            &token.unwrap(),
+            &DecodingKey::from_secret(self.secret.as_ref()),
+            &self.validation,
+        ) {
             Ok(token) => {
                 state.put(AuthorizationToken(token));
 
@@ -157,12 +161,12 @@ where
                     future::ok((state, res))
                 });
 
-                Box::new(res)
+                res.boxed()
             }
             Err(e) => {
                 trace!("[{}] error jwt middleware", e);
                 let res = create_empty_response(&state, StatusCode::UNAUTHORIZED);
-                Box::new(future::ok((state, res)))
+                future::ok((state, res)).boxed()
             }
         }
     }
@@ -195,7 +199,7 @@ mod tests {
         state::State,
         test::TestServer,
     };
-    use jsonwebtoken::{encode, Algorithm, Header};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 
     const SECRET: &str = "some-secret";
 
@@ -216,19 +220,19 @@ mod tests {
         header.kid = Some("signing-key".to_owned());
         header.alg = alg;
 
-        match encode(&header, &claims, SECRET.as_ref()) {
+        match encode(&header, &claims, &EncodingKey::from_secret(SECRET.as_ref())) {
             Ok(t) => t,
             Err(_) => panic!(),
         }
     }
 
-    fn handler(state: State) -> Box<HandlerFuture> {
+    fn handler(state: State) -> Pin<Box<HandlerFuture>> {
         {
             // If this compiles, the token is available.
             let _ = AuthorizationToken::<Claims>::borrow_from(&state);
         }
         let res = create_empty_response(&state, StatusCode::OK);
-        Box::new(future::ok((state, res)))
+        future::ok((state, res)).boxed()
     }
 
     fn default_jwt_middleware() -> JWTMiddleware<Claims> {


### PR DESCRIPTION
`jsonwebtoken` updated to `v0.7` which is compatible with the `ring`
depeendency in the current master trunk.

Fixes #390.