### PR TITLE
doc(readme): added section about projects using rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ framework:
 * [Twitter](https://twitter.com/gotham_rs)
 * [The Gotham web framework website](https://gotham.rs)
 
+## Projects Using Gotham
+
+* [Template for local GUIs with Seed and Gotham](https://gitlab.com/liketechnik/local-gui-seed-gotham)
+
 ## Alternatives
 
 We hope you'll find the Gotham web framework is flexible enough to meet the


### PR DESCRIPTION
The addition of such a section to the readme was proposed in #411. 

It felt a little strange to only add my own project there :/, but I have to admit it's the only project using gotham I know of.