### PR TITLE
Don't require default features of gotham for diesel middleware

### DIFF
--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["http", "async", "web", "gotham", "diesel"]
 
 [dependencies]
 futures = "0.3.1"
-gotham = { path = "../../gotham", version = "0.5.0-dev" }
+gotham = { path = "../../gotham", version = "0.5.0-dev", default-features = false }
 gotham_derive = { path = "../../gotham_derive", version = "0.5.0-dev" }
 diesel = { version = "1.3", features = ["r2d2"] }
 r2d2 = "0.8"


### PR DESCRIPTION
This allows to use the diesel middleware without unnecessary features like rustls when behind a reverse proxy.