### PR TITLE
Fix the websocket example (and reenable hyper connection upgrades as a prerequisite)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ members = [
     "examples/example_contribution_template/name",
 
     # TODO: Re-enable when tokio-tungstenite is updated
-    # "examples/websocket",
+    "examples/websocket",
 
     # finalizer
     "examples/finalizers/",

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2018"
 [dependencies]
 gotham = { path = "../../gotham" }
 futures = "0.3.1"
-tokio-tungstenite = "0.9"
+tokio-tungstenite = "0.10"
+tokio = "0.2"
 pretty_env_logger = "0.3"
 sha1 = "*"
 base64 = "*"

--- a/examples/websocket/src/index.html
+++ b/examples/websocket/src/index.html
@@ -10,7 +10,7 @@
     sock.onopen = recv.bind(window, "Connected");
     sock.onclose = recv.bind(window, "Disconnected");
     sock.onmessage = function(msg) { recv(msg.data) };
-    sock.onerror = function(err) { recv("Error: " + e); };
+    sock.onerror = function(err) { recv("Error: " + err); };
 
     function recv(msg) {
         var e = document.createElement("PRE");

--- a/examples/websocket/src/index.html
+++ b/examples/websocket/src/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<body>
+<h1>Websocket Echo Server</h1>
+<form id="ws" onsubmit="return send(this.message);">
+    <input name="message">
+    <input type="submit" value="Send">
+</form>
+<script>
+    var sock = new WebSocket("ws://" + window.location.host);
+    sock.onopen = recv.bind(window, "Connected");
+    sock.onclose = recv.bind(window, "Disconnected");
+    sock.onmessage = function(msg) { recv(msg.data) };
+    sock.onerror = function(err) { recv("Error: " + e); };
+
+    function recv(msg) {
+        var e = document.createElement("PRE");
+        e.innerText = msg;
+        document.body.appendChild(e);
+    }
+
+    function send(msg) {
+        sock.send(msg.value);
+        msg.value = "";
+        return false;
+    }
+</script>
+</body>

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -103,3 +103,24 @@ const INDEX_HTML: &str = r#"
 </script>
 </body>
 "#;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use gotham::plain::test::TestServer;
+
+    fn create_test_server() -> TestServer {
+        TestServer::new(|| Ok(handler)).expect("Failed to create TestServer")
+    }
+
+    #[test]
+    fn server_should_respond_with_html_if_no_websocket_was_requested() {
+        let server = create_test_server();
+        let client = server.client();
+
+        let response = client.get("http://localhost:10000").perform().expect("Failed to request HTML");
+        let body = response.read_utf8_body().expect("Failed to read response body.");
+
+        assert_eq!(body, INDEX_HTML);
+    }
+}

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -74,35 +74,7 @@ fn bad_request(state: State) -> (State, Response<Body>) {
     (state, response)
 }
 
-const INDEX_HTML: &str = r#"
-<!DOCTYPE html>
-<body>
-<h1>Websocket Echo Server</h1>
-<form id="ws" onsubmit="return send(this.message);">
-    <input name="message">
-    <input type="submit" value="Send">
-</form>
-<script>
-    var sock = new WebSocket("ws://" + window.location.host);
-    sock.onopen = recv.bind(window, "Connected");
-    sock.onclose = recv.bind(window, "Disconnected");
-    sock.onmessage = function(msg) { recv(msg.data) };
-    sock.onerror = function(err) { recv("Error: " + e); };
-
-    function recv(msg) {
-        var e = document.createElement("PRE");
-        e.innerText = msg;
-        document.body.appendChild(e);
-    }
-
-    function send(msg) {
-        sock.send(msg.value);
-        msg.value = "";
-        return false;
-    }
-</script>
-</body>
-"#;
+const INDEX_HTML: &str = include_str!("index.html");
 
 #[cfg(test)]
 mod test {

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -1,7 +1,7 @@
 use base64;
 use futures::prelude::*;
 use gotham::hyper::header::{HeaderValue, CONNECTION, UPGRADE};
-use gotham::hyper::{upgrade::Upgraded, Body, HeaderMap, Response, StatusCode};
+use gotham::hyper::{self, upgrade::Upgraded, Body, HeaderMap, Response, StatusCode};
 use sha1::Sha1;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
 
@@ -32,9 +32,9 @@ pub fn accept(
     (),
 > {
     let res = response(headers)?;
-    let ws = body
-        .on_upgrade()
-        .map(|upgraded| WebSocketStream::from_raw_socket(upgraded, Role::Server, None));
+    let ws = body.on_upgrade().and_then(|upgraded| {
+        WebSocketStream::from_raw_socket(upgraded, Role::Server, None).map(Ok)
+    });
 
     Ok((res, ws))
 }

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -58,3 +58,15 @@ fn accept_key(key: &[u8]) -> String {
     sha1.update(WS_GUID);
     base64::encode(&sha1.digest().bytes())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_accept_key_from_rfc6455() {
+        // From https://tools.ietf.org/html/rfc6455#section-1.2
+        let key = accept_key("dGhlIHNhbXBsZSBub25jZQ==".as_bytes());
+        assert_eq!(key, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    }
+}

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -1,6 +1,6 @@
 use base64;
 use futures::prelude::*;
-use gotham::hyper::header::{HeaderValue, CONNECTION, UPGRADE};
+use gotham::hyper::header::{HeaderValue, CONNECTION, UPGRADE, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_ACCEPT};
 use gotham::hyper::{self, upgrade::Upgraded, Body, HeaderMap, Response, StatusCode};
 use sha1::Sha1;
 use tokio_tungstenite::{tungstenite, WebSocketStream};
@@ -9,8 +9,6 @@ pub use tungstenite::protocol::{Message, Role};
 pub use tungstenite::Error;
 
 const PROTO_WEBSOCKET: &str = "websocket";
-const SEC_WEBSOCKET_KEY: &str = "Sec-WebSocket-Key";
-const SEC_WEBSOCKET_ACCEPT: &str = "Sec-WebSocket-Accept";
 
 /// Check if a WebSocket upgrade was requested.
 pub fn requested(headers: &HeaderMap) -> bool {

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -1,6 +1,8 @@
 use base64;
 use futures::prelude::*;
-use gotham::hyper::header::{HeaderValue, CONNECTION, UPGRADE, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_ACCEPT};
+use gotham::hyper::header::{
+    HeaderValue, CONNECTION, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, UPGRADE,
+};
 use gotham::hyper::{self, upgrade::Upgraded, Body, HeaderMap, Response, StatusCode};
 use sha1::Sha1;
 use tokio_tungstenite::{tungstenite, WebSocketStream};

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -127,6 +127,7 @@ where
 
                 accepted_protocol
                     .serve_connection(socket, service)
+                    .with_upgrades()
                     .map_err(|_| ())
                     .await?;
 


### PR DESCRIPTION
Fixes #392 #376 #353 by incorporating the change from #372 and updating the websocket example to futures 0.3 and tokio 0.2.