### PR TITLE
New implementation of Content-Type and Accept header route matchers

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -48,6 +48,7 @@ cookie = "0.13"
 http = "0.2"
 httpdate = "0.3"
 failure = "0.1"
+itertools = "0.9.0"
 tokio-rustls = { version = "0.12.1", optional = true }
 
 [dev-dependencies]

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -114,12 +114,12 @@ macro_rules! single_value_type {
     ($trait_fn:ident, $visitor_fn:ident) => {
         fn $trait_fn<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: Visitor<'de>
+            V: Visitor<'de>,
         {
             let v = parse_single_value(self.values)?;
             visitor.$visitor_fn(v)
         }
-    }
+    };
 }
 
 /// Implements one `Deserializer` function (`$trait_fn`) to return the error defined by the `$err`

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -1,10 +1,12 @@
 //! Defines the Gotham `Router` and supporting types.
 
 pub mod builder;
-pub mod non_match;
 pub mod response;
 pub mod route;
 pub mod tree;
+
+pub mod non_match;
+pub use self::non_match::RouteNonMatch;
 
 use std::pin::Pin;
 use std::sync::Arc;

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -160,7 +160,8 @@ impl RouteMatcher for AcceptHeaderRouteMatcher {
 
                         // check that the candidates have the same suffix - this is not included in the
                         // essence string
-                        if candidate.suffix() != qmime.mime.suffix() {
+                        if candidate.suffix() != qmime.mime.suffix() && qmime.mime.subtype() != "*"
+                        {
                             continue;
                         }
 
@@ -232,6 +233,17 @@ mod test {
     fn image_star() {
         let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
         with_state(Some("image/*"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+    }
+
+    #[test]
+    fn suffix_matched_by_wildcard() {
+        let matcher = AcceptHeaderRouteMatcher::new(vec!["application/rss+xml".parse().unwrap()]);
+        with_state(Some("*/*"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+        with_state(Some("application/*"), |state| {
             assert!(matcher.is_match(&state).is_ok())
         });
     }

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -1,20 +1,51 @@
 //! Defines the `AcceptHeaderRouterMatcher`.
 
-use hyper::header::{HeaderMap, HeaderValue, ACCEPT};
+use hyper::header::{HeaderMap, ACCEPT};
 use hyper::StatusCode;
 use log::trace;
 use mime;
+use mime::Mime;
 
+use super::{LookupTable, LookupTableFromTypes};
 use crate::error;
-use crate::router::non_match::RouteNonMatch;
 use crate::router::route::RouteMatcher;
+use crate::router::RouteNonMatch;
 use crate::state::{request_id, FromState, State};
+
+/// A mime type that is optionally weighted with a quality.
+struct QMime {
+    mime: Mime,
+    _weight: Option<f32>,
+}
+
+impl QMime {
+    fn new(mime: Mime, weight: Option<f32>) -> Self {
+        Self {
+            mime,
+            _weight: weight,
+        }
+    }
+}
+
+impl core::str::FromStr for QMime {
+    type Err = error::Error;
+
+    fn from_str(str: &str) -> error::Result<Self> {
+        match str.find(";q=") {
+            None => Ok(Self::new(str.parse()?, None)),
+            Some(index) => {
+                let mime = str[..index].parse()?;
+                let weight = str[index + 3..].parse()?;
+                Ok(Self::new(mime, Some(weight)))
+            }
+        }
+    }
+}
 
 /// A `RouteMatcher` that succeeds when the `Request` has been made with an `Accept` header that
 /// includes one or more supported media types. A missing `Accept` header, or the value of `*/*`
-/// will also positvely match.
-///
-/// Quality values within `Accept` header values are not considered by this matcher.
+/// will also positvely match. It supports the quality weighted syntax, but does not take the quality
+/// into consideration when matching.
 ///
 /// # Examples
 ///
@@ -73,15 +104,28 @@ use crate::state::{request_id, FromState, State};
 #[derive(Clone)]
 pub struct AcceptHeaderRouteMatcher {
     supported_media_types: Vec<mime::Mime>,
+    lookup_table: LookupTable,
 }
 
 impl AcceptHeaderRouteMatcher {
     /// Creates a new `AcceptHeaderRouteMatcher`
     pub fn new(supported_media_types: Vec<mime::Mime>) -> Self {
-        AcceptHeaderRouteMatcher {
+        let lookup_table = LookupTable::from_types(supported_media_types.iter(), true);
+        Self {
             supported_media_types,
+            lookup_table,
         }
     }
+}
+
+#[inline]
+fn err(state: &State) -> RouteNonMatch {
+    trace!(
+        "[{}] did not provide an Accept with media types supported by this Route",
+        request_id(&state)
+    );
+
+    RouteNonMatch::new(StatusCode::NOT_ACCEPTABLE)
 }
 
 impl RouteMatcher for AcceptHeaderRouteMatcher {
@@ -92,31 +136,114 @@ impl RouteMatcher for AcceptHeaderRouteMatcher {
     /// Quality values within `Accept` header values are not considered by the matcher, as the
     /// matcher is only able to indicate whether a successful match has been found.
     fn is_match(&self, state: &State) -> Result<(), RouteNonMatch> {
-        // Request method is valid, ensure valid Accept header
-        match HeaderMap::borrow_from(state).get(ACCEPT) {
-            // The client has not specified an `Accept` header.
-            None => Ok(()),
+        HeaderMap::borrow_from(state)
+            .get(ACCEPT)
+            .map(|header| {
+                // parse mime types from the accept header
+                let acceptable = header
+                    .to_str()
+                    .map_err(|_| err(state))?
+                    .split(',')
+                    .map(|str| str.trim().parse())
+                    .collect::<Result<Vec<QMime>, _>>()
+                    .map_err(|_| err(state))?;
 
-            // Or the header is any type, so it's fine.
-            Some(header) if header == "*/*" => Ok(()),
+                for qmime in acceptable {
+                    // get mime type candidates from the lookup table
+                    let essence = qmime.mime.essence_str();
+                    let candidates = match self.lookup_table.get(essence) {
+                        Some(candidates) => candidates,
+                        None => continue,
+                    };
+                    for i in candidates {
+                        let candidate = &self.supported_media_types[*i];
 
-            // Otherwise we have to validate the header is a match.
-            Some(mime_header) => parse_mime_type(mime_header)
-                .map_err(|_| RouteNonMatch::new(StatusCode::NOT_ACCEPTABLE))
-                .and_then(|mime_type| {
-                    if self.supported_media_types.contains(&mime_type) {
+                        // check that the candidates have the same suffix - this is not included in the
+                        // essence string
+                        if candidate.suffix() != qmime.mime.suffix() {
+                            continue;
+                        }
+
+                        // this candidate matches - params don't play a role in accept header matching
                         return Ok(());
                     }
-                    trace!(
-                        "[{}] did not provide an Accept with media types supported by this Route",
-                        request_id(&state)
-                    );
-                    Err(RouteNonMatch::new(StatusCode::NOT_ACCEPTABLE))
-                }),
-        }
+                }
+
+                // no candidates found
+                Err(err(state))
+            })
+            .unwrap_or_else(|| {
+                // no accept header - assume all types are acceptable
+                Ok(())
+            })
     }
 }
 
-fn parse_mime_type(hv: &HeaderValue) -> error::Result<mime::Mime> {
-    Ok(hv.to_str()?.parse()?)
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn with_state<F>(accept: Option<&str>, block: F)
+    where
+        F: FnOnce(&mut State) -> (),
+    {
+        State::with_new(|state| {
+            let mut headers = HeaderMap::new();
+            if let Some(acc) = accept {
+                headers.insert(ACCEPT, acc.parse().unwrap());
+            }
+            state.put(headers);
+            block(state);
+        });
+    }
+
+    #[test]
+    fn no_accept_header() {
+        let matcher = AcceptHeaderRouteMatcher::new(vec![mime::TEXT_PLAIN]);
+        with_state(None, |state| assert!(matcher.is_match(&state).is_ok()));
+    }
+
+    #[test]
+    fn single_mime_type() {
+        let matcher = AcceptHeaderRouteMatcher::new(vec![mime::TEXT_PLAIN, mime::IMAGE_PNG]);
+        with_state(Some("text/plain"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+        with_state(Some("text/html"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+        with_state(Some("image/png"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+        with_state(Some("image/webp"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+    }
+
+    #[test]
+    fn star_star() {
+        let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
+        with_state(Some("*/*"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+    }
+
+    #[test]
+    fn image_star() {
+        let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
+        with_state(Some("image/*"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+    }
+
+    #[test]
+    fn complex_header() {
+        let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
+        with_state(Some("text/html,image/webp;q=0.8"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+        with_state(Some("text/html,image/webp;q=0.8,*/*;q=0.1"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+    }
 }

--- a/gotham/src/router/route/matcher/content_type.rs
+++ b/gotham/src/router/route/matcher/content_type.rs
@@ -4,14 +4,16 @@ use hyper::header::{HeaderMap, CONTENT_TYPE};
 use hyper::StatusCode;
 use log::trace;
 use mime;
+use mime::Mime;
 
-use crate::router::non_match::RouteNonMatch;
+use super::{LookupTable, LookupTableFromTypes};
 use crate::router::route::RouteMatcher;
+use crate::router::RouteNonMatch;
 use crate::state::{request_id, FromState, State};
 
 /// A `RouteMatcher` that succeeds when the `Request` has been made with a `Content-Type` header
 /// that includes a supported media type. The matcher will fail if the Content-Type
-/// header is missing.
+/// header is missing, unless you call `allow_no_type` on it.
 ///
 /// # Examples
 ///
@@ -58,40 +60,165 @@ use crate::state::{request_id, FromState, State};
 /// ```
 #[derive(Clone)]
 pub struct ContentTypeHeaderRouteMatcher {
-    supported_media_types: Vec<mime::Mime>,
+    supported_media_types: Vec<Mime>,
+    lookup_table: LookupTable,
+    allow_no_type: bool,
 }
+
 impl ContentTypeHeaderRouteMatcher {
-    /// Creates a new `ContentTypeHeaderRouteMatcher`
-    pub fn new(supported_media_types: Vec<mime::Mime>) -> Self {
-        ContentTypeHeaderRouteMatcher {
+    /// Creates a new `ContentTypeHeaderRouteMatcher` that does not allow requests
+    /// that don't include a content-type header.
+    pub fn new(supported_media_types: Vec<Mime>) -> Self {
+        let lookup_table = LookupTable::from_types(supported_media_types.iter(), false);
+        Self {
             supported_media_types,
+            lookup_table,
+            allow_no_type: false,
         }
     }
+
+    /// Modify this matcher to allow requests that don't include a content-type header.
+    pub fn allow_no_type(mut self) -> Self {
+        self.allow_no_type = true;
+        self
+    }
+}
+
+#[inline]
+fn err(state: &State) -> RouteNonMatch {
+    trace!(
+        "[{}] did not specify a Content-Type with a media type supported by this Route",
+        request_id(&state)
+    );
+
+    RouteNonMatch::new(StatusCode::UNSUPPORTED_MEDIA_TYPE)
 }
 
 impl RouteMatcher for ContentTypeHeaderRouteMatcher {
     /// Determines if the `Request` was made using a `Content-Type` header that includes a
-    /// supported media type. A missing `Content-Type` header will not match.
+    /// supported media type.
     fn is_match(&self, state: &State) -> Result<(), RouteNonMatch> {
-        match HeaderMap::borrow_from(state).get(CONTENT_TYPE) {
-            // The client has not specified a `Content-Type` header.
-            None => Err(RouteNonMatch::new(StatusCode::UNSUPPORTED_MEDIA_TYPE)),
+        HeaderMap::borrow_from(state)
+            .get(CONTENT_TYPE)
+            .map(|ty| {
+                // parse mime type from the content type header
+                let mime: Mime = ty
+                    .to_str()
+                    .map_err(|_| err(state))?
+                    .parse()
+                    .map_err(|_| err(state))?;
 
-            // Header was provided.
-            Some(content_type) => {
-                let mime = content_type.to_str().unwrap().parse().unwrap();
+                // get mime type candidates from the lookup table
+                let essence = mime.essence_str();
+                let candidates = self.lookup_table.get(essence).ok_or_else(|| err(state))?;
+                for i in candidates {
+                    let candidate = &self.supported_media_types[*i];
 
-                if self.supported_media_types.contains(&mime) {
+                    // check that the candidates have the same suffix - this is not included in the
+                    // essence string
+                    if candidate.suffix() != mime.suffix() {
+                        continue;
+                    }
+
+                    // check that this candidate has at least the parameters that the content type
+                    // has and that their values are equal
+                    if candidate
+                        .params()
+                        .any(|(key, value)| mime.get_param(key) != Some(value))
+                    {
+                        continue;
+                    }
+
+                    // this candidate matches
                     return Ok(());
                 }
 
-                trace!(
-                    "[{}] did not specify a Content-Type with a media type supported by this Route",
-                    request_id(&state)
-                );
+                // no candidates found
+                Err(err(state))
+            })
+            .unwrap_or_else(|| {
+                // no type present
+                if self.allow_no_type {
+                    Ok(())
+                } else {
+                    Err(err(state))
+                }
+            })
+    }
+}
 
-                Err(RouteNonMatch::new(StatusCode::UNSUPPORTED_MEDIA_TYPE))
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn with_state<F>(content_type: Option<&str>, block: F)
+    where
+        F: FnOnce(&mut State) -> (),
+    {
+        State::with_new(|state| {
+            let mut headers = HeaderMap::new();
+            if let Some(ty) = content_type {
+                headers.insert(CONTENT_TYPE, ty.parse().unwrap());
             }
-        }
+            state.put(headers);
+            block(state);
+        });
+    }
+
+    #[test]
+    fn empty_type_list() {
+        let matcher = ContentTypeHeaderRouteMatcher::new(Vec::new());
+        with_state(None, |state| assert!(matcher.is_match(&state).is_err()));
+        with_state(Some("text/plain"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+
+        let matcher = matcher.allow_no_type();
+        with_state(None, |state| assert!(matcher.is_match(&state).is_ok()));
+    }
+
+    #[test]
+    fn simple_type() {
+        let matcher = ContentTypeHeaderRouteMatcher::new(vec![mime::TEXT_PLAIN]);
+        with_state(None, |state| assert!(matcher.is_match(&state).is_err()));
+        with_state(Some("text/plain"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+        with_state(Some("text/plain; charset=utf-8"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+    }
+
+    #[test]
+    fn complex_type() {
+        let matcher = ContentTypeHeaderRouteMatcher::new(vec!["image/svg+xml; charset=utf-8"
+            .parse()
+            .unwrap()]);
+        with_state(Some("image/svg"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+        with_state(Some("image/svg+xml"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+        with_state(Some("image/svg+xml; charset=utf-8"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+        with_state(Some("image/svg+xml; charset=utf-8; eol=lf"), |state| {
+            assert!(matcher.is_match(&state).is_ok())
+        });
+        with_state(Some("image/svg+xml; charset=us-ascii"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+        with_state(Some("image/svg+json; charset=utf-8"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
+    }
+
+    #[test]
+    fn type_mismatch() {
+        let matcher = ContentTypeHeaderRouteMatcher::new(vec![mime::TEXT_HTML]);
+        with_state(Some("text/plain"), |state| {
+            assert!(matcher.is_match(&state).is_err())
+        });
     }
 }

--- a/gotham/src/router/route/matcher/lookup_table.rs
+++ b/gotham/src/router/route/matcher/lookup_table.rs
@@ -1,0 +1,35 @@
+use itertools::Itertools;
+use mime::Mime;
+use std::collections::HashMap;
+
+/// This type is used to quickly lookup a non-hashed container of mime types by their essence string.
+pub type LookupTable = HashMap<String, Vec<usize>>;
+
+pub trait LookupTableFromTypes {
+    /// Create the lookup table from an iterator of mime types. If `include_stars` is set, the lookup
+    /// table will also, for every entry `type/subtype` contain `type/*` and `*/*`.
+    fn from_types<'a, I: Iterator<Item = &'a Mime>>(types: I, include_stars: bool) -> Self;
+}
+
+impl LookupTableFromTypes for LookupTable {
+    fn from_types<'a, I: Iterator<Item = &'a Mime>>(types: I, include_stars: bool) -> Self {
+        if include_stars {
+            types
+                .enumerate()
+                .flat_map(|(i, mime)| {
+                    vec![
+                        ("*/*".to_owned(), i),
+                        (format!("{}/*", mime.type_()), i),
+                        (mime.essence_str().to_owned(), i),
+                    ]
+                    .into_iter()
+                })
+                .into_group_map()
+        } else {
+            types
+                .enumerate()
+                .map(|(i, mime)| (mime.essence_str().to_owned(), i))
+                .into_group_map()
+        }
+    }
+}

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -8,6 +8,10 @@ pub mod content_type;
 pub use self::accept::AcceptHeaderRouteMatcher;
 pub use self::and::AndRouteMatcher;
 pub use self::any::AnyRouteMatcher;
+pub use self::content_type::ContentTypeHeaderRouteMatcher;
+
+mod lookup_table;
+use self::lookup_table::{LookupTable, LookupTableFromTypes};
 
 use std::panic::RefUnwindSafe;
 


### PR DESCRIPTION
I have reimplemented the Content-Type and Accept header matchers to suit more advanced needs. This includes a fix for #381. Both now use a `HashMap` for efficient lookup and also

**The Accept matcher**
- now supports more than one type from the header
- supports the quality-weighted syntax, although qualities are ignored
- will not only match `*/*` as a wildcard, but also types with subtype-wildcards like `image/*`
- will now ignore parameters like `charset=utf-8` as they are not supposed to be part of the Accept header, and conflict with the list syntax as both use commas as separators

**The Content-Type matcher**
- now matches content types in respect of their parameters, so that `text/plain; charset=utf-8` is considered a match when `text/plain` was expected, however, `text/plain; charset=utf-8` is not a match if `text/plain; charset=us-ascii` was expected
- allows the user to optionally specify that requests without a Content-Type header are acceptable, which is at least useful during development when your curl commands get shorter

Also, I have added public re-exports in their respective super mod for `ContentTypeHeaderRouteMatcher` and `RouteNonMatch` to simplify user code.