### PR TITLE
Remove unnecessary restrictions from test::Server::run_future

### DIFF
--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -114,12 +114,12 @@ macro_rules! single_value_type {
     ($trait_fn:ident, $visitor_fn:ident) => {
         fn $trait_fn<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
-            V: Visitor<'de>
+            V: Visitor<'de>,
         {
             let v = parse_single_value(self.values)?;
             visitor.$visitor_fn(v)
         }
-    }
+    };
 }
 
 /// Implements one `Deserializer` function (`$trait_fn`) to return the error defined by the `$err`

--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -78,18 +78,16 @@ impl test::Server for TestServer {
         runtime.enter(|| delay_for(Duration::from_secs(self.data.timeout)))
     }
 
-    fn run_future<F, R, E>(&self, future: F) -> Result<R>
+    fn run_future<F, O>(&self, future: F) -> O
     where
-        F: Send + 'static + Future<Output = std::result::Result<R, E>>,
-        R: Send + 'static,
-        E: failure::Fail,
+        F: Send + Future<Output = O>,
+        O: Send,
     {
         self.data
             .runtime
             .write()
             .expect("unable to acquire write lock")
             .block_on(future)
-            .map_err(Into::into)
     }
 }
 

--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -80,8 +80,7 @@ impl test::Server for TestServer {
 
     fn run_future<F, O>(&self, future: F) -> O
     where
-        F: Send + Future<Output = O>,
-        O: Send,
+        F: Future<Output = O>,
     {
         self.data
             .runtime

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -20,8 +20,8 @@ use tokio::time::Delay;
 use crate::error::*;
 
 pub use crate::plain::test::TestServer;
-pub use request::TestRequest;
 use futures::TryFutureExt;
+pub use request::TestRequest;
 
 pub(crate) trait BodyReader {
     /// Runs the underlying event loop until the response body has been fully read. An `Ok(_)`

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -34,8 +34,7 @@ pub trait Server: Clone {
     /// Runs a Future until it resolves.
     fn run_future<F, O>(&self, future: F) -> O
     where
-        F: Send + Future<Output = O>,
-        O: Send;
+        F: Future<Output = O>;
 
     /// Returns a Delay that will expire when a request should.
     fn request_expiry(&self) -> Delay;

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -21,6 +21,7 @@ use crate::error::*;
 
 pub use crate::plain::test::TestServer;
 pub use request::TestRequest;
+use futures::TryFutureExt;
 
 pub(crate) trait BodyReader {
     /// Runs the underlying event loop until the response body has been fully read. An `Ok(_)`
@@ -31,11 +32,10 @@ pub(crate) trait BodyReader {
 /// An in memory server for testing purposes.
 pub trait Server: Clone {
     /// Runs a Future until it resolves.
-    fn run_future<F, R, E>(&self, future: F) -> Result<R>
+    fn run_future<F, O>(&self, future: F) -> O
     where
-        F: Send + 'static + Future<Output = std::result::Result<R, E>>,
-        R: Send + 'static,
-        E: failure::Fail;
+        F: Send + Future<Output = O>,
+        O: Send;
 
     /// Returns a Delay that will expire when a request should.
     fn request_expiry(&self) -> Delay;
@@ -64,7 +64,7 @@ pub trait Server: Clone {
                 })
                 .into_future()
                 // Finally, make the fail error compatible
-                .map(|result| result.compat()),
+                .map_err(|error| error.into()),
         )
     }
 }
@@ -72,7 +72,7 @@ pub trait Server: Clone {
 impl<T: Server> BodyReader for T {
     fn read_body(&mut self, response: Response<Body>) -> Result<Vec<u8>> {
         let f = body::to_bytes(response.into_body()).and_then(|b| future::ok(b.to_vec()));
-        self.run_future(f)
+        self.run_future(f).map_err(|error| error.into())
     }
 }
 

--- a/gotham/src/tls/test.rs
+++ b/gotham/src/tls/test.rs
@@ -94,8 +94,7 @@ impl test::Server for TestServer {
 
     fn run_future<F, O>(&self, future: F) -> O
     where
-        F: Send + Future<Output = O>,
-        O: Send,
+        F: Future<Output = O>,
     {
         self.data
             .runtime

--- a/gotham/src/tls/test.rs
+++ b/gotham/src/tls/test.rs
@@ -92,18 +92,16 @@ impl test::Server for TestServer {
         runtime.enter(|| delay_for(Duration::from_secs(self.data.timeout)))
     }
 
-    fn run_future<F, R, E>(&self, future: F) -> Result<R>
+    fn run_future<F, O>(&self, future: F) -> O
     where
-        F: Send + 'static + Future<Output = std::result::Result<R, E>>,
-        R: Send + 'static,
-        E: failure::Fail,
+        F: Send + Future<Output = O>,
+        O: Send,
     {
         self.data
             .runtime
             .write()
             .expect("unable to acquire write lock")
             .block_on(future)
-            .map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
The requirements on the `test::Server` traits `run_future` method are unnecessarily strict in my opinion.

This removes the following:
* `'static` lifetime bound
* `Result` as output type (any output can be allowed)
* `Send` on the future and output (this is debatable, there are conceivable implementations of `Server` that might want this, so I'm okay for this to be left in if need be)

Removing these bounds is especially useful when working with the `TestClient`.

```rust
let client = server.client();
let foo: &SomeType = bar();
let first = server.run_future(async {
   foo.bar().await
});
let blub = client.get(something).perform(); // <- This can't be run inside of Server::run_future because blocking is not allowed in there
let second = server.run_future(async {
   foo.yadeyade(blub).await
});
```

This won't work without my change because `foo` doesn't have a static lifetime.

And having to manually wrap and unwrap `Result`s all the time isn't very ergonomic either, so removing `Result` is also quite useful.