### PR TITLE
Allow giving param names to globs thus allowing multiple

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,3 @@ members = [
 
 
 ]
-
-[patch.crates-io]
-gotham = { path = "gotham" }
-gotham_derive = { path = "gotham_derive" }
-borrow-bag = { path = "misc/borrow_bag" }

--- a/examples/path/globs/README.md
+++ b/examples/path/globs/README.md
@@ -24,7 +24,7 @@ Terminal 2:
   > Host: localhost:7878
   > User-Agent: curl/7.54.0
   > Accept: */*
-  > 
+  >
   < HTTP/1.1 200 OK
   < Content-Length: 39
   < Content-Type: text/plain
@@ -34,10 +34,56 @@ Terminal 2:
   < X-Content-Type-Options: nosniff
   < X-Runtime-Microseconds: 165
   < Date: Mon, 19 Mar 2018 22:17:17 GMT
-  < 
+  <
   Got 4 parts:
   heads
   shoulders
+  knees
+  * Connection #0 to host localhost left intact
+  toes
+
+  curl -vvv http://localhost:7878/middle/heads/shoulders/knees/toes/foobar
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to localhost (127.0.0.1) port 7878 (#0)
+  > GET /middle/heads/shoulders/knees/toes/foobar HTTP/1.1
+  > Host: localhost:7878
+  > User-Agent: curl/7.54.0
+  > Accept: */*
+  >
+  < HTTP/1.1 200 OK
+  < x-request-id: 8449a2ed-2b00-4fbf-98af-63e17d65a345
+  < content-type: text/plain
+  < content-length: 39
+  < date: Sat, 23 May 2020 09:00:40 GMT
+  <
+  Got 4 parts:
+  heads
+  shoulders
+  knees
+  * Connection #0 to host localhost left intact
+  toes
+
+  curl -vvv http://localhost:7878/multi/heads/shoulders/foobar/knees/toes
+  *   Trying 127.0.0.1...
+  * TCP_NODELAY set
+  * Connected to localhost (127.0.0.1) port 7878 (#0)
+  > GET /multi/heads/shoulders/foobar/knees/toes HTTP/1.1
+  > Host: localhost:7878
+  > User-Agent: curl/7.54.0
+  > Accept: */*
+  >
+  < HTTP/1.1 200 OK
+  < x-request-id: 4cbcf782-9dbb-4fcd-b12e-55661d3309a4
+  < content-type: text/plain
+  < content-length: 72
+  < date: Sat, 23 May 2020 09:09:51 GMT
+  <
+  Got 2 parts for top:
+  heads
+  shoulders
+
+  Got 2 parts for bottom:
   knees
   * Connection #0 to host localhost left intact
   toes

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -10,10 +10,20 @@ use gotham::state::{FromState, State};
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct PathExtractor {
-    // If there is exactly one * in the route, and it is the last path segment, this will be a Vec
-    // containing each path segment as a separate String, with no /s.
+    // This will be a Vec containing each path segment as a separate String, with no '/'s.
     #[serde(rename = "*")]
     parts: Vec<String>,
+}
+
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct NamedPathExtractor {
+    parts: Vec<String>,
+}
+
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct MultiGlobExtractor {
+    top: Vec<String>,
+    bottom: Vec<String>,
 }
 
 fn parts_handler(state: State) -> (State, String) {
@@ -37,13 +47,79 @@ fn parts_handler(state: State) -> (State, String) {
     (state, res)
 }
 
+fn named_parts_handler(state: State) -> (State, String) {
+    let res = {
+        let path = NamedPathExtractor::borrow_from(&state);
+
+        let mut response_string = format!(
+            "Got {} part{}:",
+            path.parts.len(),
+            if path.parts.len() == 1 { "" } else { "s" }
+        );
+
+        for part in path.parts.iter() {
+            response_string.push_str("\n");
+            response_string.push_str(&part);
+        }
+
+        response_string
+    };
+
+    (state, res)
+}
+
+fn multi_parts_handler(state: State) -> (State, String) {
+    let res = {
+        let path = MultiGlobExtractor::borrow_from(&state);
+
+        let mut top = format!(
+            "Got {} part{} for top:",
+            path.top.len(),
+            if path.top.len() == 1 { "" } else { "s" }
+        );
+
+        for part in path.top.iter() {
+            top.push_str("\n");
+            top.push_str(&part);
+        }
+
+        let mut bottom = format!(
+            "Got {} part{} for bottom:",
+            path.bottom.len(),
+            if path.bottom.len() == 1 { "" } else { "s" }
+        );
+
+        for part in path.bottom.iter() {
+            bottom.push_str("\n");
+            bottom.push_str(&part);
+        }
+
+        vec![top, bottom].join("\n\n")
+    };
+
+    (state, res)
+}
+
 fn router() -> Router {
     build_simple_router(|route| {
         route
-            // The last path segment is allowed to be a *, and it will match one or more path segments.
+            // A path segment is allowed to be a *, and it will match one or more path segments.
             .get("/parts/*")
             .with_path_extractor::<PathExtractor>()
             .to(parts_handler);
+
+        route
+            // You can provide a param name for this glob segment.
+            // It doesn't need to be the last segment
+            .get("/middle/*parts/foobar")
+            .with_path_extractor::<NamedPathExtractor>()
+            .to(named_parts_handler);
+
+        route
+            // You can even have multiple glob segments
+            .get("/multi/*top/foobar/*bottom")
+            .with_path_extractor::<MultiGlobExtractor>()
+            .to(multi_parts_handler);
     })
 }
 
@@ -113,6 +189,42 @@ mod tests {
         assert_eq!(
             &body[..],
             &b"Got 4 parts:\nhead\nshoulders\nknees\ntoes"[..]
+        );
+    }
+
+    #[test]
+    fn extracts_named_multiple_components_from_middle() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/middle/head/shoulders/knees/toes/foobar")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(
+            &body[..],
+            &b"Got 4 parts:\nhead\nshoulders\nknees\ntoes"[..]
+        );
+    }
+
+    #[test]
+    fn extracts_multiple_multiple_components() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost/multi/head/shoulders/foobar/knees/toes")
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.read_body().unwrap();
+        assert_eq!(
+            &body[..],
+            &b"Got 2 parts for top:\nhead\nshoulders\n\nGot 2 parts for bottom:\nknees\ntoes"[..]
         );
     }
 }

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -25,7 +25,7 @@ hyper = "0.13.1"
 serde = "1.0"
 serde_derive = "1.0"
 bincode = "1.0"
-mime = "0.3"
+mime = "0.3.15"
 # Using alpha version of mime_guess until mime crate stabilizes (releases 1.0).
 # see https://github.com/hyperium/mime/issues/52
 mime_guess = "2.0.1"
@@ -33,7 +33,7 @@ futures = "0.3.1"
 tokio = { version = "0.2.6", features = ["full"] }
 bytes = "0.5"
 mio = "0.7"
-borrow-bag = "1.0"
+borrow-bag = { path = "../misc/borrow_bag", version = "1.0" }
 percent-encoding = "2.1"
 pin-project = "0.4.2"
 uuid = { version = "0.7", features = ["v4"] }

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -901,6 +901,7 @@ where
                     }
                 }
                 Some('*') if segment.len() == 1 => (segment, SegmentType::Glob),
+                Some('*') => (&segment[1..], SegmentType::Glob),
                 Some('\\') => (&segment[1..], SegmentType::Static),
                 _ => (segment, SegmentType::Static),
             };

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -22,5 +22,5 @@ log = "0.4"
 
 [dev-dependencies]
 diesel = { version = "1", features = ["sqlite"] }
-mime = "0.3"
+mime = "0.3.15"
 tokio = { version = "0.2.6", features = ["full"] }


### PR DESCRIPTION
@colinbankier @nyarly As you guys know, I had recently published [this blog post](https://pksunkara.com/posts/state-of-routing-in-rust/) comparing routing capabilities.

This was the only deficiency in gotham when compared to Rails router. So, I fixed it.