### PR TITLE
Async borrowing (continuation of #449)

### DIFF
--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -63,20 +63,16 @@ fn sleep(seconds: u64) -> SleepFuture {
 async fn sleep_handler(state: &mut State) -> SimpleHandlerResult {
     let seconds = QueryStringExtractor::borrow_from(state).seconds;
     println!("sleep for {} seconds once: starting", seconds);
-    // Here, we call the sleep function and turn its old-style future into
-    // a new-style future. Note that this step doesn't block: it just sets
-    // up the timer so that we can use it later.
+    // Here, we call the sleep function. Note that this step doesn't block:
+    // it just sets up the timer so that we can use it later.
     let sleep_future = sleep(seconds);
 
     // Here is where the serious sleeping happens. We yield execution of
     // this block until sleep_future is resolved.
-    // The Ok("slept for x seconds") value is stored in result.
+    // The "slept for x seconds" value is stored in data.
     let data = sleep_future.await;
 
-    // Here, we convert the result from `sleep()` into the form that Gotham
-    // expects: `state` is owned by this block so we need to return it.
-    // We also convert any errors that we have into the form that Hyper
-    // expects, using the helper from IntoHandlerError.
+    // We return a `Result<Response<Body>, HandlerError>` directly
     let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, data);
     println!("sleep for {} seconds once: finished", seconds);
     Ok(res)

--- a/gotham/src/handler/mod.rs
+++ b/gotham/src/handler/mod.rs
@@ -27,6 +27,9 @@ pub use self::error::{HandlerError, MapHandlerError, MapHandlerErrorFuture};
 /// A type alias for the results returned by async fns that can be passed to to_async.
 pub type HandlerResult = std::result::Result<(State, Response<Body>), (State, HandlerError)>;
 
+/// A type alias for the results returned by async fns that can be passed to to_async_borrowing.
+pub type SimpleHandlerResult = std::result::Result<Response<Body>, HandlerError>;
+
 /// A type alias for the trait objects returned by `HandlerService`.
 ///
 /// When the `Future` resolves to an error, the `(State, HandlerError)` value is used to generate

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -23,16 +23,16 @@ trait FnHelper<'a> {
         + Send
         + Sync
         + 'a;
-    fn call(self, arg: &'a State) -> Self::Fut;
+    fn call(self, arg: &'a mut State) -> Self::Fut;
 }
 
 impl<'a, D, F> FnHelper<'a> for F
 where
-    F: FnOnce(&'a State) -> D,
+    F: FnOnce(&'a mut State) -> D,
     D: std::future::Future<Output = Result<Response<Body>, HandlerError>> + RefUnwindSafe + Copy + Send + Sync + 'a,
 {
     type Fut = D;
-    fn call(self, state: &'a State) -> D {
+    fn call(self, state: &'a mut State) -> D {
         self(state)
     }
 }
@@ -187,9 +187,9 @@ pub trait DefineSingleRoute {
         // Fut: Future<Output = HandlerResult> + Send + 'static
     {
         self.to_new_handler(move || {
-            Ok(move |state: State| {
+            Ok(move |mut state: State| {
                 async {
-                    let fut = handler.call(&state);
+                    let fut = handler.call(&mut state);
                     let result = fut.await;
                     match result {
                         Ok(response) => Ok((state, response)),

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -206,6 +206,49 @@ pub trait DefineSingleRoute {
         Fut: Future<Output = HandlerResult> + Send + 'static;
 
     /// Similar to `to_async`, but passes in State as a reference
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # extern crate gotham;
+    /// # extern crate hyper;
+    /// #
+    /// # use hyper::{Body, Response, StatusCode};
+    /// # use gotham::handler::{HandlerError, IntoResponse};
+    /// # use gotham::state::State;
+    /// # use gotham::router::Router;
+    /// # use gotham::router::builder::*;
+    /// # use gotham::pipeline::new_pipeline;
+    /// # use gotham::pipeline::single::*;
+    /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use gotham::test::TestServer;
+    /// #
+    /// async fn my_handler(state: &mut State) -> Result<impl IntoResponse, HandlerError> {
+    ///     // Handler implementation elided.
+    /// #   let _ = state;
+    /// #   Ok(Response::builder().status(StatusCode::ACCEPTED).body(Body::empty()).unwrap())
+    /// }
+    /// #
+    /// # fn router() -> Router {
+    /// #   let (chain, pipelines) = single_pipeline(
+    /// #       new_pipeline().add(NewSessionMiddleware::default()).build()
+    /// #   );
+    ///
+    /// build_router(chain, pipelines, |route| {
+    ///     route.get("/request/path").to_async_borrowing(my_handler);
+    /// })
+    /// #
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #   let test_server = TestServer::new(router()).unwrap();
+    /// #   let response = test_server.client()
+    /// #       .get("https://example.com/request/path")
+    /// #       .perform()
+    /// #       .unwrap();
+    /// #   assert_eq!(response.status(), StatusCode::ACCEPTED);
+    /// # }
+    /// ```
     fn to_async_borrowing<F>(self, handler: F)
     where
         Self: Sized,

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -188,7 +188,7 @@ pub trait DefineSingleRoute {
     {
         self.to_new_handler(move || {
             Ok(move |mut state: State| {
-                async {
+                async move {
                     let fut = handler.call(&mut state);
                     let result = fut.await;
                     match result {

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -21,13 +21,13 @@ pub trait AsyncHandlerFn<'a> {
     fn call(self, arg: &'a mut State) -> Self::Fut;
 }
 
-impl<'a, D, F> AsyncHandlerFn<'a> for F
+impl<'a, Fut, F> AsyncHandlerFn<'a> for F
 where
-    F: FnOnce(&'a mut State) -> D,
-    D: std::future::Future<Output = Result<Response<Body>, HandlerError>> + Send + 'a,
+    F: FnOnce(&'a mut State) -> Fut,
+    Fut: std::future::Future<Output = Result<Response<Body>, HandlerError>> + Send + 'a,
 {
-    type Fut = D;
-    fn call(self, state: &'a mut State) -> D {
+    type Fut = Fut;
+    fn call(self, state: &'a mut State) -> Fut {
         self(state)
     }
 }

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -1,10 +1,10 @@
-use hyper::Body;
+use hyper::{Body, Response};
 
 use std::panic::RefUnwindSafe;
 
 use crate::extractor::{PathExtractor, QueryStringExtractor};
 use crate::handler::assets::{DirHandler, FileHandler, FileOptions, FilePathExtractor};
-use crate::handler::{Handler, HandlerResult, NewHandler};
+use crate::handler::{Handler, HandlerError, HandlerResult, NewHandler};
 use crate::pipeline::chain::PipelineHandleChain;
 use crate::router::builder::{
     ExtendRouteMatcher, ReplacePathExtractor, ReplaceQueryStringExtractor, SingleRouteBuilder,
@@ -16,6 +16,26 @@ use crate::state::State;
 use core::future::Future;
 use futures::FutureExt;
 
+trait FnHelper<'a> {
+    type Fut: std::future::Future<Output = Result<Response<Body>, HandlerError>>
+        + RefUnwindSafe
+        + Copy
+        + Send
+        + Sync
+        + 'a;
+    fn call(self, arg: &'a State) -> Self::Fut;
+}
+
+impl<'a, D, F> FnHelper<'a> for F
+where
+    F: FnOnce(&'a State) -> D,
+    D: std::future::Future<Output = Result<Response<Body>, HandlerError>> + RefUnwindSafe + Copy + Send + Sync + 'a,
+{
+    type Fut = D;
+    fn call(self, state: &'a State) -> D {
+        self(state)
+    }
+}
 /// Describes the API for defining a single route, after determining which request paths will be
 /// dispatched here. The API here uses chained function calls to build and add the route into the
 /// `RouterBuilder` which created it.
@@ -157,6 +177,29 @@ pub trait DefineSingleRoute {
         Self: Sized,
         H: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
         Fut: Future<Output = HandlerResult> + Send + 'static;
+
+    /// Similar to `to_async`, but passes in State as a reference
+    fn to_async_borrowing<F>(self, handler: F)
+    where
+        Self: Sized,
+        // F: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
+        for<'a> F: FnHelper<'a> + RefUnwindSafe + Copy + Send + Sync + 'static,
+        // Fut: Future<Output = HandlerResult> + Send + 'static
+    {
+        self.to_new_handler(move || {
+            Ok(move |state: State| {
+                async {
+                    let fut = handler.call(&state);
+                    let result = fut.await;
+                    match result {
+                        Ok(response) => Ok((state, response)),
+                        Err(err) => Err((state, err)),
+                    }
+                }
+                .boxed()
+            })
+        })
+    }
     /// Directs the route to the given `NewHandler`. This gives more control over how `Handler`
     /// values are constructed.
     ///

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -16,7 +16,7 @@ use crate::state::State;
 use core::future::Future;
 use futures::FutureExt;
 
-trait FnHelper<'a> {
+pub trait AsyncHandlerFn<'a> {
     type Fut: std::future::Future<Output = Result<Response<Body>, HandlerError>>
         + RefUnwindSafe
         + Copy
@@ -26,7 +26,7 @@ trait FnHelper<'a> {
     fn call(self, arg: &'a mut State) -> Self::Fut;
 }
 
-impl<'a, D, F> FnHelper<'a> for F
+impl<'a, D, F> AsyncHandlerFn<'a> for F
 where
     F: FnOnce(&'a mut State) -> D,
     D: std::future::Future<Output = Result<Response<Body>, HandlerError>> + RefUnwindSafe + Copy + Send + Sync + 'a,
@@ -183,7 +183,7 @@ pub trait DefineSingleRoute {
     where
         Self: Sized,
         // F: (FnOnce(State) -> Fut) + RefUnwindSafe + Copy + Send + Sync + 'static,
-        for<'a> F: FnHelper<'a> + RefUnwindSafe + Copy + Send + Sync + 'static,
+        for<'a> F: AsyncHandlerFn<'a> + RefUnwindSafe + Copy + Send + Sync + 'static,
         // Fut: Future<Output = HandlerResult> + Send + 'static
     {
         self.to_new_handler(move || {

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -17,19 +17,14 @@ use core::future::Future;
 use futures::FutureExt;
 
 pub trait AsyncHandlerFn<'a> {
-    type Fut: std::future::Future<Output = Result<Response<Body>, HandlerError>>
-        + RefUnwindSafe
-        + Copy
-        + Send
-        + Sync
-        + 'a;
+    type Fut: std::future::Future<Output = Result<Response<Body>, HandlerError>> + Send + 'a;
     fn call(self, arg: &'a mut State) -> Self::Fut;
 }
 
 impl<'a, D, F> AsyncHandlerFn<'a> for F
 where
     F: FnOnce(&'a mut State) -> D,
-    D: std::future::Future<Output = Result<Response<Body>, HandlerError>> + RefUnwindSafe + Copy + Send + Sync + 'a,
+    D: std::future::Future<Output = Result<Response<Body>, HandlerError>> + Send + 'a,
 {
     type Fut = D;
     fn call(self, state: &'a mut State) -> D {


### PR DESCRIPTION
It seems to work as expected.

Todo:
- [x] Try to avoid mapping every error with `into_handler_error` before `?`

Feedback needed:
- [x] Could this allow for generic return types like `R: IntoResponse`? Yes.
- [x] Could this allow for handlers receiving either `&State` or `&mut State`? Not really.
- [x] Could this allow for returning the reponse without Ok-wrapping in the infallible case? Not really.

And "do we want that" for every question above :-)