### PR TITLE
Return proper error from init_server methods.

### DIFF
--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -96,10 +96,9 @@ pub async fn bind_server<'a, NH, F, Wrapped, Wrap>(
     mut listener: TcpListener,
     new_handler: NH,
     wrap: Wrap,
-) -> Result<(), ()>
-where
+) where
     NH: NewHandler + 'static,
-    F: Future<Output = Result<Wrapped, ()>> + Unpin + Send + 'static,
+    F: Future<Output = Result<Wrapped, ()>> + Send + 'static,
     Wrapped: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     Wrap: Fn(TcpStream) -> F,
 {
@@ -139,6 +138,4 @@ where
             future::ready(())
         })
         .await;
-
-    Ok(())
 }

--- a/gotham/src/plain.rs
+++ b/gotham/src/plain.rs
@@ -32,12 +32,14 @@ where
 /// This is used internally, but exposed in case the developer intends on doing any
 /// manual wiring that isn't supported by the Gotham API. It's unlikely that this will
 /// be required in most use cases; it's mainly exposed for shutdown handling.
-pub async fn init_server<NH, A>(addr: A, new_handler: NH) -> Result<(), ()>
+///
+/// Returns an error if the server failed to bind to `addr`.
+pub async fn init_server<NH, A>(addr: A, new_handler: NH) -> std::io::Result<()>
 where
     NH: NewHandler + 'static,
     A: ToSocketAddrs + 'static + Send,
 {
-    let listener = tcp_listener(addr).map_err(|_| ()).await?;
+    let listener = tcp_listener(addr).await?;
     let addr = listener.local_addr().unwrap();
 
     info!(
@@ -46,5 +48,7 @@ where
     addr
     );
 
-    bind_server(listener, new_handler, future::ok).await
+    bind_server(listener, new_handler, future::ok).await;
+
+    Ok(())
 }


### PR DESCRIPTION
The only error condition that would result in the method returning was if binding to the address failed. We can just return that error instead of empty tuple.

Also, I considered adding documentation that these methods never return, but I wanted to leave the changes small for now. If you like this change I will probably follow up with that separately.