### PR TITLE
Don't require default features for the JWT middleware

### DIFF
--- a/middleware/jwt/Cargo.toml
+++ b/middleware/jwt/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.1"
-gotham = { path = "../../gotham", version = "0.5.0-rc.1" }
+gotham = { path = "../../gotham", version = "0.5.0-rc.1", default-features = false }
 gotham_derive = { path = "../../gotham_derive", version = "0.5.0-rc.1" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/middleware/template/Cargo.toml
+++ b/middleware/template/Cargo.toml
@@ -15,5 +15,5 @@ futures = "0.3.1"
 
 # Middlewares should reference the semantic versions of Gotham that are they compatible with
 # and not use relative references such as shown here.
-gotham = { path = "../../gotham" }
+gotham = { path = "../../gotham", default-features = false }
 gotham_derive = { path = "../../gotham_derive" }


### PR DESCRIPTION
Fixes #365. Gotham requires `rustls` by default, but the JWT middleware can work without it, so should not require default features to be enabled.