### PR TITLE
Update the websocket example using async blocks

### DIFF
--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -24,11 +24,16 @@ fn handler(mut state: State) -> (State, Response<Body>) {
         };
 
         let req_id = request_id(&state).to_owned();
-        let ws = ws
-            .map_err(|err| eprintln!("websocket init error: {}", err))
-            .and_then(move |ws| connected(req_id, ws));
 
-        tokio::spawn(ws);
+        tokio::spawn(async move {
+            match ws.await {
+                Ok(ws) => connected(req_id, ws).await,
+                Err(err) => {
+                    eprintln!("websocket init error: {}", err);
+                    Err(())
+                }
+            }
+        });
 
         (state, response)
     } else {

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -32,9 +32,10 @@ pub fn accept(
     (),
 > {
     let res = response(headers)?;
-    let ws = body.on_upgrade().and_then(|upgraded| {
-        WebSocketStream::from_raw_socket(upgraded, Role::Server, None).map(Ok)
-    });
+    let ws = async move {
+        let upgraded = body.on_upgrade().await?;
+        Ok(WebSocketStream::from_raw_socket(upgraded, Role::Server, None).await)
+    };
 
     Ok((res, ws))
 }


### PR DESCRIPTION
There are a few uses of future combinator functions, like "map()" and "and_then()" that I believe are more readable as straight-line code in async blocks.