### PR TITLE
Update Tera example, macro compile_templates! is deprecated

### DIFF
--- a/examples/templating/tera/Cargo.toml
+++ b/examples/templating/tera/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2018"
 gotham = { path = "../../../gotham" }
 
 mime = "0.3"
-tera = "0.11"
+tera = "1.5"
 lazy_static = "1.0"

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -1,19 +1,22 @@
 //! An example usage of Tera template engine working with Gotham.
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
-extern crate tera;
 
 use gotham::state::State;
 use tera::{Context, Tera};
 
-// Assuming the Rust file is at the same level as the templates folder
-// we can get a Tera instance that way:
 lazy_static! {
-    pub static ref TERA: Tera =
-        compile_templates!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/**/*"));
+    pub static ref TERA: Tera = {
+        let tera = match Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/TEMPLATES/**/*")) {
+            Ok(t) => t,
+            Err(e) => {
+                println!("Parsing error(s): {}", e);
+                ::std::process::exit(1);
+            }
+        };
+        tera
+    };
 }
-
 /// Create a `Handler` which calls the Tera static reference, renders
 /// a template with a given Context, and returns the result as a String
 /// to be used as Response Body

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -6,7 +6,7 @@ use gotham::state::State;
 use tera::{Context, Tera};
 
 lazy_static! {
-    pub static ref TERA: Tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/TEMPLATES/**/*")).expect("Parsing error(s)");
+    pub static ref TERA: Tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/**/*")).expect("Parsing error(s)");
 }
 /// Create a `Handler` which calls the Tera static reference, renders
 /// a template with a given Context, and returns the result as a String

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -6,7 +6,8 @@ use gotham::state::State;
 use tera::{Context, Tera};
 
 lazy_static! {
-    pub static ref TERA: Tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/**/*")).expect("Parsing error(s)");
+    pub static ref TERA: Tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/**/*"))
+        .expect("Parsing error(s)");
 }
 /// Create a `Handler` which calls the Tera static reference, renders
 /// a template with a given Context, and returns the result as a String

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -6,10 +6,7 @@ use gotham::state::State;
 use tera::{Context, Tera};
 
 lazy_static! {
-    pub static ref TERA: Tera = {
-        let tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/TEMPLATES/**/*")).expect("Parsing error(s)");
-        tera
-    };
+    pub static ref TERA: Tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/TEMPLATES/**/*")).expect("Parsing error(s)");
 }
 /// Create a `Handler` which calls the Tera static reference, renders
 /// a template with a given Context, and returns the result as a String

--- a/examples/templating/tera/src/main.rs
+++ b/examples/templating/tera/src/main.rs
@@ -7,13 +7,7 @@ use tera::{Context, Tera};
 
 lazy_static! {
     pub static ref TERA: Tera = {
-        let tera = match Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/TEMPLATES/**/*")) {
-            Ok(t) => t,
-            Err(e) => {
-                println!("Parsing error(s): {}", e);
-                ::std::process::exit(1);
-            }
-        };
+        let tera = Tera::new(concat!(env!("CARGO_MANIFEST_DIR"), "/TEMPLATES/**/*")).expect("Parsing error(s)");
         tera
     };
 }


### PR DESCRIPTION
Update Tera example to comply with Tera 1.5

Close #464 