### PR TITLE
Add a PathTemplate derive

### DIFF
--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -25,7 +25,7 @@ use crate::router::tree::Tree;
 use crate::router::Router;
 
 pub use self::associated::{AssociatedRouteBuilder, AssociatedSingleRouteBuilder};
-pub use self::draw::DrawRoutes;
+pub use self::draw::{DrawRoutes, PathTemplate};
 pub use self::modify::{ExtendRouteMatcher, ReplacePathExtractor, ReplaceQueryStringExtractor};
 pub use self::single::DefineSingleRoute;
 

--- a/gotham_derive/Cargo.toml
+++ b/gotham_derive/Cargo.toml
@@ -15,8 +15,9 @@ keywords = ["http", "async", "web", "framework", "gotham"]
 edition = "2018"
 
 [dependencies]
-syn = "1.0"
+proc-macro2 = "1.0"
 quote = "1.0"
+syn = "1.0"
 
 [lib]
 proc-macro = true

--- a/gotham_derive/src/lib.rs
+++ b/gotham_derive/src/lib.rs
@@ -1,24 +1,36 @@
 #![recursion_limit = "256"]
 extern crate proc_macro;
 
+use proc_macro::TokenStream;
+use syn::parse_macro_input;
+
 mod extenders;
 mod new_middleware;
+mod path_template;
 mod state;
 
 #[proc_macro_derive(StaticResponseExtender)]
-pub fn static_response_extender(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ast = syn::parse(input).unwrap();
+pub fn static_response_extender(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input);
     extenders::bad_request_static_response_extender(&ast)
 }
 
 #[proc_macro_derive(StateData)]
-pub fn state_data(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ast = syn::parse(input).unwrap();
+pub fn state_data(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input);
     state::state_data(&ast)
 }
 
 #[proc_macro_derive(NewMiddleware)]
-pub fn new_middleware(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let ast = syn::parse(input).unwrap();
+pub fn new_middleware(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input);
     new_middleware::new_middleware(&ast)
+}
+
+#[proc_macro_derive(PathTemplate, attributes(path_template))]
+pub fn path_template(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input);
+    path_template::path_template(&ast)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }

--- a/gotham_derive/src/path_template.rs
+++ b/gotham_derive/src/path_template.rs
@@ -1,0 +1,55 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{DeriveInput, Error, Lit, LitStr, Meta, Result};
+
+pub fn path_template(ast: &DeriveInput) -> Result<TokenStream> {
+    let ty_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    // parse attributes
+    let mut path_template: Option<LitStr> = None;
+    for attr in ast.attrs.iter() {
+        let attr = match attr.parse_meta() {
+            Ok(Meta::NameValue(nv)) => nv,
+            _ => continue,
+        };
+        if attr
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+            .as_deref()
+            != Some("path_template")
+        {
+            continue;
+        }
+
+        path_template = Some(match attr.lit {
+            Lit::Str(str) => str,
+            lit => {
+                return Err(Error::new(
+                    lit.span(),
+                    "Expected string literal, e.g. #[path_template = \"/foo/:bar\"]",
+                ))
+            }
+        });
+    }
+    let path_template = path_template.ok_or_else(|| {
+        Error::new(
+            Span::call_site(),
+            "#[derive(PathTemplate)] requires a #[path_template = \"/foo/:bar\"] attribute",
+        )
+    })?;
+
+    // TODO verify that the path parameters match the types fields
+
+    // generate the implementation
+    Ok(quote! {
+        impl #impl_generics ::gotham::router::builder::PathTemplate for #ty_name #ty_generics #where_clause {
+            fn path_template() -> ::std::borrow::Cow<'static, str> {
+                let path_template: &'static str = #path_template;
+                path_template.into()
+            }
+        }
+    })
+}


### PR DESCRIPTION
This PR aims at replacing the current path extractor logic with a new, safer `PathTemplate` derive. This allows us to ensure that the template string and the path extracting struct match each other, so no runtime errors can occur.

## TODO

- [x] Add a `PathTemplate` trait that returns the template string
- [ ] Verify the template string against the input struct fields
- [ ] Create a struct instance from the request URI and put it into the state
- [ ] Update documentation and examples

## Open Questions

- [ ] Do we want to continue using serde or do we want our own logic?