### PR TITLE
feat: lower 'full' tokio feature-set

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -29,7 +29,7 @@ bincode = "1.0"
 mime = "0.3.15"
 mime_guess = "2.0.1"
 futures = "0.3.1"
-tokio = { version = "0.2.6", features = ["full"] }
+tokio = { version = "0.2", features = ["tcp", "rt-threaded", "time", "fs", "io-util"] }
 bytes = "0.5"
 borrow-bag = { path = "../misc/borrow_bag", version = "1.0" }
 percent-encoding = "2.1"


### PR DESCRIPTION
Closes #499 

Inspecting the imports in `gotham` (`tokio::` search), I found the following results:
```
19 results - 6 files

gotham/src/lib.rs:
   60  use std::sync::Arc;
   61: use tokio::io::{AsyncRead, AsyncWrite};
   62: use tokio::net::{TcpListener, TcpStream};
   63  
   64: use tokio::runtime::{self, Runtime};
   65  

  141  
  142:         tokio::spawn(task);
  143      }

gotham/src/test.rs:
  15  use mime;
  16: use tokio::time::Delay;
  17  

gotham/src/tls.rs:
  5  
  6: use tokio::net::TcpListener;
  7  use tokio_rustls::{rustls, TlsAcceptor};

gotham/src/handler/assets/mod.rs:
  20  use serde_derive::Deserialize;
  21: use tokio::fs::File;
  22: use tokio::io::AsyncRead;
  23  

gotham/src/plain/test.rs:
   16  use hyper::client::Client;
   17: use tokio::net::TcpListener;
   18: use tokio::runtime::Runtime;
   19: use tokio::time::{delay_for, Delay};
   20  
   21  use hyper::service::Service;
   22: use tokio::net::TcpStream;
   23  

  187      type Response = TcpStream;
  188:     type Error = tokio::io::Error;
  189      type Future =

gotham/src/tls/test.rs:
   21  use rustls::Session;
   22: use tokio::io::{AsyncRead, AsyncWrite};
   23: use tokio::net::TcpListener;
   24: use tokio::net::TcpStream;
   25: use tokio::runtime::Runtime;
   26: use tokio::time::{delay_for, Delay};
   27  use tokio_rustls::client::TlsStream;

  270      type Response = TlsConnectionStream<TcpStream>;
  271:     type Error = tokio::io::Error;
  272      type Future =
```

I then checked the [tokio documentation page](https://docs.rs/tokio/0.2.22) and inspected all the imports and the required feature flags:
* `tokio::io::Error` -> `io-util`
* `tokio::net::Tcp*` -> `tcp`
* `tokio::runtime` -> `rt-core` (for single-threaded Runtime) or `rt-threaded` (multi-threaded Runtime)
* `tokio::time` -> `time` (although this is only used for tests, I would put it in `dev-dependencies` maybe, but idk)
* `tokio::fs` -> `fs`

In the code, I replaced `full` with all these features instead (and opted for `rt-threaded`, but we can discuss about that). I guess if the code compiles in CI it should be good to go :+1:  