### PR TITLE
Implement Into<Response> for the TestResponse

### DIFF
--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -255,6 +255,12 @@ impl fmt::Debug for TestResponse {
     }
 }
 
+impl Into<Response<Body>> for TestResponse {
+    fn into(self) -> Response<Body> {
+        self.response
+    }
+}
+
 impl TestResponse {
     /// Awaits the body of the underlying `Response`, and returns it. This will cause the event
     /// loop to execute until the `Response` body has been fully read into the `Vec<u8>`.

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -194,7 +194,7 @@ impl<TS: Server + 'static, C: Connect + Clone + Send + Sync + 'static> TestClien
 }
 
 /// Wrapping struct for the `Response` returned by a `TestClient`. Provides access to the
-/// `Response` value via the `Deref` and `DerefMut` traits, and also provides a function for
+/// `Response` value via the `Deref`, `DerefMut` and `Into` traits, and also provides a function for
 /// awaiting a completed response body.
 ///
 /// # Examples


### PR DESCRIPTION
This makes working with the `TestResponse` much easier to work with if direct access to the underlying `Response` is required.