### PR TITLE
Remove DummyError from websocket example

### DIFF
--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -149,33 +149,32 @@ mod test {
         let mut body = Body::empty();
         std::mem::swap(&mut body, response.deref_mut().body_mut());
 
-        server
-            .run_future(async move {
-                let upgraded = body
-                    .on_upgrade()
-                    .await
-                    .expect("Failed to upgrade client websocket.");
-                let mut websocket_stream =
-                    WebSocketStream::from_raw_socket(upgraded, Role::Client, None).await;
+        server.run_future(async move {
+            let upgraded = body
+                .on_upgrade()
+                .await
+                .expect("Failed to upgrade client websocket.");
+            let mut websocket_stream =
+                WebSocketStream::from_raw_socket(upgraded, Role::Client, None).await;
 
-                let message = Message::Text("Hello".to_string());
-                websocket_stream
-                    .send(message.clone())
-                    .await
-                    .expect("Failed to send text message.");
+            let message = Message::Text("Hello".to_string());
+            websocket_stream
+                .send(message.clone())
+                .await
+                .expect("Failed to send text message.");
 
-                let response = websocket_stream
-                    .next()
-                    .await
-                    .expect("Socket was closed")
-                    .expect("Failed to receive response");
-                assert_eq!(message, response);
+            let response = websocket_stream
+                .next()
+                .await
+                .expect("Socket was closed")
+                .expect("Failed to receive response");
+            assert_eq!(message, response);
 
-                websocket_stream
-                    .send(Message::Close(None))
-                    .await
-                    .expect("Failed to send close message");
-            });
+            websocket_stream
+                .send(Message::Close(None))
+                .await
+                .expect("Failed to send close message");
+        });
     }
 
     #[test]

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -89,8 +89,6 @@ mod test {
     };
     use gotham::plain::test::TestServer;
     use gotham::test::Server;
-    use std::error::Error;
-    use std::fmt::{Display, Formatter};
     use std::ops::DerefMut;
     use tokio_tungstenite::WebSocketStream;
 
@@ -177,10 +175,7 @@ mod test {
                     .send(Message::Close(None))
                     .await
                     .expect("Failed to send close message");
-
-                Ok::<(), DummyError>(())
-            })
-            .unwrap();
+            });
     }
 
     #[test]
@@ -198,15 +193,4 @@ mod test {
         let body = response.read_body().expect("Failed to read response body");
         assert!(body.is_empty());
     }
-
-    #[derive(Debug)]
-    struct DummyError {}
-
-    impl Display for DummyError {
-        fn fmt(&self, _formatter: &mut Formatter) -> std::fmt::Result {
-            Ok(())
-        }
-    }
-
-    impl Error for DummyError {}
 }


### PR DESCRIPTION
Since #425 has been merged, this workaround isn't required anymore.