### PR TITLE
Bump hyper to 0.14.3

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -22,7 +22,7 @@ rustls = ["tokio-rustls"]
 
 [dependencies]
 log = "0.4"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14.3", features = ["full"] }
 serde = "1.0"
 serde_derive = "1.0"
 bincode = "1.0"


### PR DESCRIPTION
The previous versions are marked insecure: https://rustsec.org/advisories/RUSTSEC-2021-0020.html