### PR TITLE
Bump hyper to 0.14.3 and some best practises

### DIFF
--- a/examples/custom_service/Cargo.toml
+++ b/examples/custom_service/Cargo.toml
@@ -10,5 +10,5 @@ anyhow = "1.0"
 futures = "0.3"
 gotham = { path = "../../gotham" }
 http = "0.2"
-hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1.0", features = ["full"] }
+hyper = { version = "0.14.4", features = ["full"] }
+tokio = { version = "1.3.0", features = ["full"] }

--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -18,9 +18,8 @@ diesel = { version = "1.4", features = ["sqlite", "extras"] }
 diesel_migrations = { version = "1.4", features = ["sqlite"] }
 r2d2 = "0.8"
 r2d2-diesel = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 
 [dev-dependencies]
 diesel_migrations = "1.4.0"

--- a/examples/diesel/src/main.rs
+++ b/examples/diesel/src/main.rs
@@ -17,7 +17,7 @@ use gotham::pipeline::{new_pipeline, single::single_pipeline};
 use gotham::router::{builder::*, Router};
 use gotham::state::{FromState, State};
 use gotham_middleware_diesel::DieselMiddleware;
-use serde_derive::Serialize;
+use serde::Serialize;
 use std::pin::Pin;
 use std::str::from_utf8;
 

--- a/examples/diesel/src/models.rs
+++ b/examples/diesel/src/models.rs
@@ -1,7 +1,7 @@
 //! Holds the two possible structs that are `Queryable` and
 //! `Insertable` in the DB
 use diesel::{Insertable, Queryable};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::schema::products;
 

--- a/examples/handlers/async_handlers/Cargo.toml
+++ b/examples/handlers/async_handlers/Cargo.toml
@@ -12,5 +12,4 @@ gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
 futures = "0.3.1"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -1,8 +1,4 @@
 //! A basic example showing the request components
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use futures::prelude::*;
 use std::pin::Pin;
@@ -17,6 +13,9 @@ use gotham::router::builder::DefineSingleRoute;
 use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+
+use serde::Deserialize;
+use gotham_derive::{StateData, StaticResponseExtender};
 
 type ResponseContentFuture =
     Pin<Box<dyn Future<Output = Result<Vec<u8>, gotham::hyper::Error>> + Send>>;

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -14,8 +14,8 @@ use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-use serde::Deserialize;
 use gotham_derive::{StateData, StaticResponseExtender};
+use serde::Deserialize;
 
 type ResponseContentFuture =
     Pin<Box<dyn Future<Output = Result<Vec<u8>, gotham::hyper::Error>> + Send>>;

--- a/examples/handlers/simple_async_handlers/Cargo.toml
+++ b/examples/handlers/simple_async_handlers/Cargo.toml
@@ -12,6 +12,5 @@ gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
 futures = "0.3.1"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -1,8 +1,4 @@
 //! A basic example showing the request components
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use futures::prelude::*;
 use std::pin::Pin;
@@ -16,6 +12,9 @@ use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 use tokio::time::sleep;
+
+use serde::Deserialize;
+use gotham_derive::{StateData, StaticResponseExtender};
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -13,8 +13,8 @@ use gotham::router::Router;
 use gotham::state::{FromState, State};
 use tokio::time::sleep;
 
-use serde::Deserialize;
 use gotham_derive::{StateData, StaticResponseExtender};
+use serde::Deserialize;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -12,6 +12,5 @@ gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
 futures = "0.3.1"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 tokio = "1.0"

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -10,7 +10,7 @@ use gotham::router::builder::{build_simple_router, DrawRoutes};
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 use gotham_derive::{StateData, StaticResponseExtender};
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use tokio::time::sleep;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]

--- a/examples/into_response/introduction/Cargo.toml
+++ b/examples/into_response/introduction/Cargo.toml
@@ -11,6 +11,5 @@ gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/examples/into_response/introduction/src/main.rs
+++ b/examples/into_response/introduction/src/main.rs
@@ -1,6 +1,4 @@
 //! An introduction to the Gotham web framework's `IntoResponse` trait.
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::hyper::{Body, Response, StatusCode};
 
@@ -9,6 +7,8 @@ use gotham::helpers::http::response::create_response;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
+
+use serde::Serialize;
 
 /// A Product
 #[derive(Serialize)]

--- a/examples/middleware/introduction/src/main.rs
+++ b/examples/middleware/introduction/src/main.rs
@@ -13,7 +13,7 @@ use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
-use gotham_derive::{StateData, NewMiddleware};
+use gotham_derive::{NewMiddleware, StateData};
 
 /// A simple struct which holds an identifier for the user agent which made the request.
 ///

--- a/examples/middleware/introduction/src/main.rs
+++ b/examples/middleware/introduction/src/main.rs
@@ -1,6 +1,4 @@
 //! Introduces the Middleware and Pipeline concepts provided by the Gotham web framework.
-#[macro_use]
-extern crate gotham_derive;
 
 use futures::prelude::*;
 use std::pin::Pin;
@@ -15,6 +13,7 @@ use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+use gotham_derive::{StateData, NewMiddleware};
 
 /// A simple struct which holds an identifier for the user agent which made the request.
 ///

--- a/examples/middleware/multiple_pipelines/Cargo.toml
+++ b/examples/middleware/multiple_pipelines/Cargo.toml
@@ -11,5 +11,4 @@ gotham_derive = { path = "../../../gotham_derive" }
 
 futures = "0.3.1"
 mime = "0.3"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/middleware/multiple_pipelines/src/main.rs
+++ b/examples/middleware/multiple_pipelines/src/main.rs
@@ -10,10 +10,6 @@
 //! Our app also has some admin functionality, so we'll also override admin paths
 //! to require an additional admin session.
 //! Finally, our app exposes an JSON endpoint, which needs its own middleware.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use futures::prelude::*;
 use gotham::hyper::header::{HeaderMap, ACCEPT};
@@ -30,6 +26,8 @@ use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+use gotham_derive::NewMiddleware;
+use serde::{Serialize, Deserialize};
 
 /// A simple struct to represent our default session data.
 #[derive(Default, Serialize, Deserialize)]

--- a/examples/middleware/multiple_pipelines/src/main.rs
+++ b/examples/middleware/multiple_pipelines/src/main.rs
@@ -27,7 +27,7 @@ use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 use gotham_derive::NewMiddleware;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// A simple struct to represent our default session data.
 #[derive(Default, Serialize, Deserialize)]

--- a/examples/path/globs/Cargo.toml
+++ b/examples/path/globs/Cargo.toml
@@ -11,5 +11,4 @@ gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -1,12 +1,12 @@
 //! Shows how to match arbitrarily many path segments.
 #[macro_use]
 extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+
+use serde::Deserialize;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct PathExtractor {

--- a/examples/path/introduction/Cargo.toml
+++ b/examples/path/introduction/Cargo.toml
@@ -11,5 +11,4 @@ gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -5,8 +5,8 @@ use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-use serde::Deserialize;
 use gotham_derive::{StateData, StaticResponseExtender};
+use serde::Deserialize;
 
 /// Holds data extracted from the Request path.
 ///

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -1,13 +1,12 @@
 //! An introduction to extracting request path segments, in a type safe way, with the
 //! Gotham web framework
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+
+use serde::Deserialize;
+use gotham_derive::{StateData, StaticResponseExtender};
 
 /// Holds data extracted from the Request path.
 ///

--- a/examples/path/regex/Cargo.toml
+++ b/examples/path/regex/Cargo.toml
@@ -10,5 +10,4 @@ gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -1,12 +1,11 @@
 //! An example of the Gotham web framework `Router` that shows how to use Regex patterns in path segments.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+use gotham_derive::{StateData, StaticResponseExtender};
+
+use serde::Deserialize;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct PathExtractor {

--- a/examples/query_string/introduction/Cargo.toml
+++ b/examples/query_string/introduction/Cargo.toml
@@ -11,6 +11,5 @@ gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -2,12 +2,12 @@
 //! Gotham web framework
 #[macro_use]
 extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+
+use serde::{Serialize, Deserialize};
 
 /// Holds data extracted from the Request query string.
 ///

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -7,7 +7,7 @@ use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Holds data extracted from the Request query string.
 ///

--- a/examples/sessions/custom_data_type/Cargo.toml
+++ b/examples/sessions/custom_data_type/Cargo.toml
@@ -11,7 +11,6 @@ gotham = { path = "../../../gotham" }
 gotham_derive = { path = "../../../gotham_derive" }
 
 mime = "0.3"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }
 time = "0.1"
 cookie = "0.15"

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -8,8 +8,8 @@ use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
 
-use serde::{Serialize, Deserialize};
 use gotham_derive::StateData;
+use serde::{Deserialize, Serialize};
 
 // A custom type for storing data associated with the user's session.
 #[derive(Clone, Deserialize, Serialize, StateData)]

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -1,9 +1,5 @@
 //! Storing and retrieving session data with a custom data type, in a type safe
 //! way, with the Gotham web framework.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::new_pipeline;
@@ -11,6 +7,9 @@ use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+
+use serde::{Serialize, Deserialize};
+use gotham_derive::StateData;
 
 // A custom type for storing data associated with the user's session.
 #[derive(Clone, Deserialize, Serialize, StateData)]

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -22,14 +22,13 @@ rustls = ["tokio-rustls"]
 
 [dependencies]
 log = "0.4"
-hyper = { version = "0.14", features = ["full"] }
-serde = "1.0"
-serde_derive = "1.0"
+hyper = { version = "0.14.4", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
 bincode = "1.0"
 mime = "0.3.15"
 mime_guess = "2.0.1"
 futures = "0.3.1"
-tokio = { version = "1.0", features = ["net", "rt-multi-thread", "time", "fs", "io-util"] }
+tokio = { version = "1.3", features = ["net", "rt-multi-thread", "time", "fs", "io-util"] }
 bytes = "1.0"
 borrow-bag = { path = "../misc/borrow_bag", version = "1.0" }
 percent-encoding = "2.1"

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -704,7 +704,7 @@ impl<'de> VariantAccess<'de> for UnitVariant {
 mod tests {
     use super::*;
     use crate::helpers::http::{FormUrlDecoded, PercentDecoded};
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
     use std;
 
     #[derive(Deserialize)]

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -25,8 +25,6 @@ use crate::state::{State, StateData};
 /// # extern crate hyper;
 /// # extern crate mime;
 /// # extern crate serde;
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// #
 /// # use hyper::{Body, Response, StatusCode};
 /// # use gotham::state::{FromState, State};

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -25,8 +25,6 @@ use crate::state::{State, StateData};
 /// # extern crate hyper;
 /// # extern crate mime;
 /// # extern crate serde;
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// #
 /// # use hyper::{Body, Response, StatusCode};
 /// # use gotham::state::{FromState, State};
@@ -34,6 +32,7 @@ use crate::state::{State, StateData};
 /// # use gotham::router::Router;
 /// # use gotham::router::builder::*;
 /// # use gotham::test::TestServer;
+/// # use serde::Deserialize;
 /// #
 /// #[derive(Deserialize, StateData, StaticResponseExtender)]
 /// struct MyQueryParams {

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -17,7 +17,7 @@ use hyper::{Body, Response, StatusCode};
 use log::debug;
 use mime::{self, Mime};
 use mime_guess::from_path;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use tokio::fs::File;
 use tokio::io::{AsyncRead, ReadBuf};
 

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -1047,7 +1047,7 @@ mod tests {
     use hyper::header::{HeaderMap, COOKIE};
     use hyper::{Response, StatusCode};
     use rand;
-    use serde_derive::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
     use std::sync::Mutex;
     use std::time::Duration;
 

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -334,7 +334,7 @@ mod tests {
 
     use hyper::service::Service;
     use hyper::{body, Body, Request, Response, StatusCode};
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
 
     use crate::middleware::cookie::CookieParser;
     use crate::middleware::session::NewSessionMiddleware;

--- a/gotham_derive/src/extenders.rs
+++ b/gotham_derive/src/extenders.rs
@@ -1,6 +1,4 @@
-use proc_macro;
 use quote::quote;
-use syn;
 
 pub(crate) fn bad_request_static_response_extender(
     ast: &syn::DeriveInput,

--- a/gotham_derive/src/new_middleware.rs
+++ b/gotham_derive/src/new_middleware.rs
@@ -1,6 +1,4 @@
-use proc_macro;
 use quote::quote;
-use syn;
 
 pub(crate) fn new_middleware(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
     let name = &ast.ident;

--- a/gotham_derive/src/state.rs
+++ b/gotham_derive/src/state.rs
@@ -1,6 +1,4 @@
-use proc_macro;
 use quote::quote;
-use syn;
 
 pub(crate) fn state_data(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
     let name = &ast.ident;

--- a/middleware/jwt/Cargo.toml
+++ b/middleware/jwt/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2018"
 futures = "0.3.1"
 gotham = { path = "../../gotham", version = "0.5.0", default-features = false }
 gotham_derive = { path = "../../gotham_derive", version = "0.5.0" }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 jsonwebtoken = "7.0"
 log = "0.4"

--- a/middleware/jwt/README.md
+++ b/middleware/jwt/README.md
@@ -13,9 +13,7 @@ Second, create a struct you wish to deserialize into. For our example below,
 we've used `Claims`:
 
 ```rust
-#[macro_use]
-extern crate serde_derive;
-
+use serde::Deserialize;
 use futures::future;
 use gotham::{
   helpers::http::response::create_empty_response,

--- a/middleware/jwt/src/lib.rs
+++ b/middleware/jwt/src/lib.rs
@@ -9,14 +9,9 @@
 #![warn(missing_docs, deprecated)]
 #[macro_use]
 extern crate gotham_derive;
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
 
 mod middleware;
 mod state_data;
 
-pub use self::middleware::JWTMiddleware;
-pub use self::state_data::AuthorizationToken;
+pub use middleware::JWTMiddleware;
+pub use state_data::AuthorizationToken;

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -214,9 +214,11 @@ mod tests {
             exp: 10_000_000_000,
         };
 
-        let mut header = Header::default();
-        header.kid = Some("signing-key".to_owned());
-        header.alg = alg;
+        let header = Header {
+            kid: Some("signing-key".to_owned()),
+            alg: alg,
+            ..Header::default()
+        };
 
         match encode(&header, &claims, &EncodingKey::from_secret(SECRET.as_ref())) {
             Ok(t) => t,

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -197,8 +197,8 @@ mod tests {
         test::TestServer,
     };
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
-    use serde::{Serialize, Deserialize};
-    
+    use serde::{Deserialize, Serialize};
+
     const SECRET: &str = "some-secret";
 
     #[derive(Debug, Deserialize, Serialize)]

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -12,7 +12,8 @@ use gotham::{
     state::{request_id, FromState, State},
 };
 use jsonwebtoken::{decode, DecodingKey, Validation};
-use serde::de::Deserialize;
+use log::trace;
+use serde::Deserialize;
 use std::pin::Pin;
 use std::{marker::PhantomData, panic::RefUnwindSafe};
 
@@ -196,7 +197,8 @@ mod tests {
         test::TestServer,
     };
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
-
+    use serde::{Serialize, Deserialize};
+    
     const SECRET: &str = "some-secret";
 
     #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
- reacting to: https://rustsec.org/advisories/RUSTSEC-2021-0020.html
- additional code cleanup to use `serde` instead of `serde_derive`.
- additional code cleanup to remove deprecated pre-rust2018 `extern crate`.
- updated some other crate versions.