### PR TITLE
Remove hyper dependency from example

### DIFF
--- a/examples/custom_service/Cargo.toml
+++ b/examples/custom_service/Cargo.toml
@@ -10,5 +10,4 @@ anyhow = "1.0"
 futures = "0.3"
 gotham = { path = "../../gotham" }
 http = "0.2"
-hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/custom_service/src/main.rs
+++ b/examples/custom_service/src/main.rs
@@ -3,12 +3,12 @@
 use anyhow::{Context as _, Error};
 use futures::future::{BoxFuture, FutureExt};
 use gotham::{
+    hyper::{server::conn::Http, service::Service, Body},
     router::{builder::*, Router},
     service::call_handler,
     state::State,
 };
 use http::{Request, Response};
-use hyper::{server::conn::Http, service::Service, Body};
 use std::net::SocketAddr;
 use std::panic::AssertUnwindSafe;
 use std::task;


### PR DESCRIPTION
gotham re-exports hyper, so that dependency is not necessary.