### PR TITLE
Bump insecure diesel dependency

### DIFF
--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -14,10 +14,8 @@ gotham_middleware_diesel = { path = "../../middleware/diesel"}
 futures = "0.3.1"
 mime = "0.3"
 log = "0.4"
-diesel = { version = "1.4", features = ["sqlite", "extras"] }
+diesel = { version = "1.4.6", features = ["r2d2", "sqlite"] }
 diesel_migrations = { version = "1.4", features = ["sqlite"] }
-r2d2 = "0.8"
-r2d2-diesel = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -15,11 +15,11 @@ keywords = ["http", "async", "web", "gotham", "diesel"]
 futures = "0.3.1"
 gotham = { path = "../../gotham", version = "0.6.0", default-features = false }
 gotham_derive = { path = "../../gotham_derive", version = "0.6.0" }
-diesel = { version = "1.4", features = ["r2d2"] }
+diesel = { version = "1.4.6", features = ["r2d2"] }
 r2d2 = "0.8"
 tokio = { version = "1.0", features = ["full"] }
 log = "0.4"
 
 [dev-dependencies]
-diesel = { version = "1", features = ["sqlite"] }
+diesel = { version = "1.4.6", features = ["sqlite"] }
 mime = "0.3.15"


### PR DESCRIPTION
Diesel versions below 1.4.6 are marked insecure: https://rustsec.org/advisories/RUSTSEC-2021-0037.html

Also, I found two unused dependencies in the diesel example, which I removed.