### PR TITLE
Fix clippy lints and make clippy check required

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,6 @@ jobs:
   
   clippy:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,10 @@ You agree to license your contribution under the
 
 ## Submission guidelines
 
-1. Format your contribution with
-   [rustfmt](https://github.com/rust-lang-nursery/rustfmt) version 0.9 or later.
-1. Consider using [clippy](https://github.com/rust-lang-nursery/rust-clippy).
+1. Format your contribution with [rustfmt](https://github.com/rust-lang/rustfmt#quick-start).
+1. Resolve all warnings from [clippy](https://github.com/rust-lang/rust-clippy#usage).
 1. Document your contribution per the
-   [Rust documentation guidelines](https://doc.rust-lang.org/book/first-edition/documentation.html).
+   [Rust documentation guidelines](https://doc.rust-lang.org/1.30.0/book/first-edition/documentation.html).
 
 Provide tests that prove the functionality you're contributing is correct.
 

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -193,7 +193,6 @@ fn loop_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
 ///
 /// In summary:
 ///     Don't do this at home kids. It is only included as a cautionary tale.
-///
 fn parallel_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
     let length = QueryStringExtractor::take_from(&mut state).length;
     println!("parallel length: {} starting", length);

--- a/examples/handlers/multipart/src/main.rs
+++ b/examples/handlers/multipart/src/main.rs
@@ -34,11 +34,10 @@ fn form_handler(mut state: State) -> Pin<Box<HandlerFuture>> {
                         let mut data = Vec::new();
                         field.data.read_to_end(&mut data).expect("can't read");
                         let res_result = String::from_utf8(data);
-                        let res_body;
-                        match res_result {
-                            Ok(r) => res_body = r.to_string(),
-                            Err(e) => res_body = format!("{:?}", e),
-                        }
+                        let res_body = match res_result {
+                            Ok(r) => r,
+                            Err(e) => format!("{:?}", e),
+                        };
                         let res =
                             create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, res_body);
                         future::ok((state, res))

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -37,7 +37,7 @@ fn parts_handler(state: State) -> (State, String) {
         );
 
         for part in path.parts.iter() {
-            response_string.push_str("\n");
+            response_string.push('\n');
             response_string.push_str(&part);
         }
 
@@ -58,7 +58,7 @@ fn named_parts_handler(state: State) -> (State, String) {
         );
 
         for part in path.parts.iter() {
-            response_string.push_str("\n");
+            response_string.push('\n');
             response_string.push_str(&part);
         }
 
@@ -79,7 +79,7 @@ fn multi_parts_handler(state: State) -> (State, String) {
         );
 
         for part in path.top.iter() {
-            top.push_str("\n");
+            top.push('\n');
             top.push_str(&part);
         }
 
@@ -90,7 +90,7 @@ fn multi_parts_handler(state: State) -> (State, String) {
         );
 
         for part in path.bottom.iter() {
-            bottom.push_str("\n");
+            bottom.push('\n');
             bottom.push_str(&part);
         }
 

--- a/examples/websocket/src/ws.rs
+++ b/examples/websocket/src/ws.rs
@@ -1,4 +1,3 @@
-use base64;
 use futures::prelude::*;
 use gotham::hyper::header::{
     HeaderValue, CONNECTION, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, UPGRADE,

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -960,7 +960,7 @@ mod tests {
 
         let p = from_segment_mapping::<WithBorrowedBytes>(sm).unwrap();
 
-        assert_eq!(&p.bytes_val[..], b"borrowed_bytes");
+        assert_eq!(p.bytes_val, b"borrowed_bytes");
     }
 
     #[test]
@@ -973,7 +973,7 @@ mod tests {
 
         let p = from_query_string_mapping::<WithBorrowedBytes>(&qsm).unwrap();
 
-        assert_eq!(&p.bytes_val[..], b"borrowed_bytes");
+        assert_eq!(p.bytes_val, b"borrowed_bytes");
     }
 
     // This is **not** a realistic use case here, as `StateData` must also be `'static`. However,

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -19,6 +19,7 @@ use crate::router::tree::segment::SegmentMapping;
 /// Describes the error cases which can result from deserializing a `ExtractorDeserializer` into a
 /// `PathExtractor` provided by the application.
 #[derive(Debug)]
+#[non_exhaustive]
 pub(crate) enum ExtractorError {
     /// The `PathExtractor` type is not one which can be deserialized from a
     /// `ExtractorDeserializer`.  This deserializer requires a structured type (usually a custom
@@ -81,10 +82,6 @@ pub(crate) enum ExtractorError {
     /// in the implementation of the `serde::de::Error` trait for external types to provide
     /// informative error messages.
     Custom(String),
-
-    // Variants may be added in future, and it will not be considered a breaking change.
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Display for ExtractorError {
@@ -705,7 +702,6 @@ mod tests {
     use super::*;
     use crate::helpers::http::{FormUrlDecoded, PercentDecoded};
     use serde_derive::Deserialize;
-    use std;
 
     #[derive(Deserialize)]
     struct SimpleValues {

--- a/gotham/src/handler/assets/accepted_encoding.rs
+++ b/gotham/src/handler/assets/accepted_encoding.rs
@@ -32,13 +32,13 @@ impl FromStr for AcceptedEncoding {
         let mut iter = s.split(';');
         iter.next()
             .map(str::trim)
-            .and_then(|encoding_str| {
+            .map(|encoding_str| {
                 let encoding = encoding_str.to_string();
                 let quality = iter
                     .next()
                     .and_then(|qval| qval.replace("q=", "").trim().parse::<f32>().ok())
                     .unwrap_or(1f32);
-                Some(AcceptedEncoding { encoding, quality })
+                AcceptedEncoding { encoding, quality }
             })
             .ok_or(ParseEncodingError::InvalidEncoding)
     }

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -10,7 +10,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 use futures::prelude::*;
 use futures::ready;
 use futures::task::Poll;
-use http;
 use httpdate::parse_http_date;
 use hyper::header::*;
 use hyper::{Body, Response, StatusCode};

--- a/gotham/src/handler/error.rs
+++ b/gotham/src/handler/error.rs
@@ -61,8 +61,7 @@ impl HandlerError {
     ///     // It's OK if this is bogus, we just need something to convert into a `HandlerError`.
     ///     let io_error = std::io::Error::last_os_error();
     ///
-    ///     let handler_error = HandlerError::from(io_error)
-    ///         .with_status(StatusCode::IM_A_TEAPOT);
+    ///     let handler_error = HandlerError::from(io_error).with_status(StatusCode::IM_A_TEAPOT);
     ///
     ///     future::err((state, handler_error)).boxed()
     /// }
@@ -70,7 +69,11 @@ impl HandlerError {
     /// # fn main() {
     /// #
     /// let test_server = TestServer::new(|| Ok(handler)).unwrap();
-    /// let response = test_server.client().get("http://example.com/").perform().unwrap();
+    /// let response = test_server
+    ///     .client()
+    ///     .get("http://example.com/")
+    ///     .perform()
+    ///     .unwrap();
     /// assert_eq!(response.status(), StatusCode::IM_A_TEAPOT);
     /// #
     /// # }
@@ -125,9 +128,9 @@ impl IntoResponse for HandlerError {
 /// # use gotham::handler::{HandlerError, MapHandlerError};
 /// # use gotham::hyper::StatusCode;
 /// fn handler() -> Result<(), HandlerError> {
-/// 	let result = Err(anyhow!("just a test"));
-/// 	result.map_err_with_status(StatusCode::IM_A_TEAPOT)?;
-/// 	unreachable!()
+///     let result = Err(anyhow!("just a test"));
+///     result.map_err_with_status(StatusCode::IM_A_TEAPOT)?;
+///     unreachable!()
 /// }
 ///
 /// # #[allow(non_snake_case)]
@@ -136,7 +139,10 @@ impl IntoResponse for HandlerError {
 /// # }
 /// # fn main() {
 /// let response = handler();
-/// assert_eq!(response.map_err(|err| err.status()), Err(StatusCode::IM_A_TEAPOT));
+/// assert_eq!(
+///     response.map_err(|err| err.status()),
+///     Err(StatusCode::IM_A_TEAPOT)
+/// );
 /// # }
 /// ```
 pub trait MapHandlerError<T> {
@@ -228,8 +234,8 @@ where
 /// # use gotham::hyper::StatusCode;
 /// # use std::future::Future;
 /// fn handler() -> impl Future<Output = Result<(), HandlerError>> {
-/// 	let result = async { Err(anyhow!("just a test")) };
-/// 	result.map_err_with_status(StatusCode::IM_A_TEAPOT)
+///     let result = async { Err(anyhow!("just a test")) };
+///     result.map_err_with_status(StatusCode::IM_A_TEAPOT)
 /// }
 ///
 /// # #[allow(non_snake_case)]
@@ -238,7 +244,10 @@ where
 /// # }
 /// # fn main() {
 /// let response = block_on(handler());
-/// assert_eq!(response.map_err(|err| err.status()), Err(StatusCode::IM_A_TEAPOT));
+/// assert_eq!(
+///     response.map_err(|err| err.status()),
+///     Err(StatusCode::IM_A_TEAPOT)
+/// );
 /// # }
 /// ```
 pub trait MapHandlerErrorFuture {

--- a/gotham/src/helpers/http/mod.rs
+++ b/gotham/src/helpers/http/mod.rs
@@ -6,7 +6,6 @@ pub mod response;
 
 use log::trace;
 use percent_encoding::percent_decode;
-use std;
 
 /// Represents data that has been successfully percent decoded and is valid UTF-8
 #[derive(Clone, PartialEq, Debug)]

--- a/gotham/src/helpers/http/request/query_string.rs
+++ b/gotham/src/helpers/http/request/query_string.rs
@@ -48,7 +48,7 @@ mod tests {
             .iter()
             .map(|(k, v)| {
                 let mut values: Vec<&str> = v.iter().map(AsRef::as_ref).collect();
-                values.sort();
+                values.sort_unstable();
 
                 (k.as_str(), values)
             })

--- a/gotham/src/helpers/http/response/mod.rs
+++ b/gotham/src/helpers/http/response/mod.rs
@@ -31,12 +31,7 @@ use crate::state::{request_id, FromState, State};
 /// static BODY: &'static [u8] = b"Hello, world!";
 ///
 /// fn handler(state: State) -> (State, Response<Body>) {
-///     let response = create_response(
-///         &state,
-///         StatusCode::OK,
-///         mime::TEXT_PLAIN,
-///         BODY,
-///     );
+///     let response = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, BODY);
 ///
 ///     (state, response)
 /// }

--- a/gotham/src/middleware/session/backend/memory.rs
+++ b/gotham/src/middleware/session/backend/memory.rs
@@ -193,8 +193,6 @@ fn cleanup_once(
 mod tests {
     use super::*;
 
-    use rand;
-
     #[test]
     fn cleanup_test() {
         let mut storage = LinkedHashMap::new();
@@ -237,7 +235,7 @@ mod tests {
             new_backend
                 .new_backend()
                 .expect("can't create backend for read")
-                .read_session(identifier.clone()),
+                .read_session(identifier),
         )
         .expect("no response from backend")
         .expect("session data missing");

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -7,8 +7,6 @@ use std::panic::RefUnwindSafe;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, PoisonError};
 
-use base64;
-use bincode;
 use cookie::{Cookie, CookieJar};
 use futures::prelude::*;
 use hyper::header::SET_COOKIE;
@@ -41,14 +39,12 @@ pub struct SessionIdentifier {
 
 /// The kind of failure which occurred trying to perform a session operation.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SessionError {
     /// The backend failed, and the included message describes the problem.
     Backend(String),
     /// The session was unable to be deserialized.
     Deserialize,
-    /// Exhaustive match against this enum is unsupported.
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 enum SessionCookieState {
@@ -306,7 +302,7 @@ where
         let identifier = middleware.random_identifier();
         let value = T::default();
         let backend = Box::new(middleware.backend);
-        let cookie_config = middleware.cookie_config.clone();
+        let cookie_config = middleware.cookie_config;
 
         trace!(
             " no existing session, assigning new identifier ({})",
@@ -340,7 +336,7 @@ where
                 match bincode::deserialize::<T>(&val[..]) {
                     Ok(value) => {
                         let backend = Box::new(middleware.backend);
-                        let cookie_config = middleware.cookie_config.clone();
+                        let cookie_config = middleware.cookie_config;
 
                         trace!(
                             " successfully deserialized session data ({})",
@@ -1046,7 +1042,6 @@ mod tests {
     use cookie::Cookie;
     use hyper::header::{HeaderMap, COOKIE};
     use hyper::{Response, StatusCode};
-    use rand;
     use serde_derive::{Deserialize, Serialize};
     use std::sync::Mutex;
     use std::time::Duration;
@@ -1091,7 +1086,7 @@ mod tests {
     #[test]
     fn enforce_secure_cookie_prefix_attributes() {
         let backend = MemoryBackend::new(Duration::from_secs(1));
-        let nm = NewSessionMiddleware::new(backend.clone())
+        let nm = NewSessionMiddleware::new(backend)
             .with_cookie_name("__Secure-my_session")
             .insecure()
             .with_session_type::<TestSession>();
@@ -1103,7 +1098,7 @@ mod tests {
     #[test]
     fn enforce_host_cookie_prefix_attributes() {
         let backend = MemoryBackend::new(Duration::from_secs(1));
-        let nm = NewSessionMiddleware::new(backend.clone())
+        let nm = NewSessionMiddleware::new(backend)
             .with_cookie_name("__Host-my_session")
             .insecure()
             .with_cookie_domain("example.com")

--- a/gotham/src/pipeline/mod.rs
+++ b/gotham/src/pipeline/mod.rs
@@ -42,7 +42,7 @@ use crate::state::{request_id, State};
 /// #
 /// #[derive(StateData)]
 /// struct MiddlewareData {
-///     vec: Vec<i32>
+///     vec: Vec<i32>,
 /// }
 ///
 /// #[derive(NewMiddleware, Copy, Clone)]
@@ -89,14 +89,11 @@ use crate::state::{request_id, State};
 ///
 /// fn handler(state: State) -> (State, Response<Body>) {
 ///     let body = {
-///        let data = state.borrow::<MiddlewareData>();
-///        format!("{:?}", data.vec)
+///         let data = state.borrow::<MiddlewareData>();
+///         format!("{:?}", data.vec)
 ///     };
 ///
-///     let res = create_response(&state,
-///                               StatusCode::OK,
-///                               mime::TEXT_PLAIN,
-///                               body);
+///     let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, body);
 ///
 ///     (state, res)
 /// }
@@ -107,7 +104,7 @@ use crate::state::{request_id, State};
 ///             .add(MiddlewareOne)
 ///             .add(MiddlewareTwo)
 ///             .add(MiddlewareThree)
-///             .build()
+///             .build(),
 ///     );
 ///
 ///     let router = build_router(chain, pipelines, |route| {
@@ -115,7 +112,11 @@ use crate::state::{request_id, State};
 ///     });
 ///
 ///     let test_server = TestServer::new(router).unwrap();
-///     let response = test_server.client().get("http://example.com/").perform().unwrap();
+///     let response = test_server
+///         .client()
+///         .get("http://example.com/")
+///         .perform()
+///         .unwrap();
 ///     assert_eq!(response.status(), StatusCode::OK);
 ///     assert_eq!(response.read_utf8_body().unwrap(), "[1, 2, 3]");
 /// }
@@ -329,7 +330,7 @@ mod tests {
             Chain: FnOnce(State) -> Pin<Box<HandlerFuture>> + Send + 'static,
             Self: Sized,
         {
-            state.put(self.clone());
+            state.put(self);
             chain(state)
         }
     }

--- a/gotham/src/pipeline/single.rs
+++ b/gotham/src/pipeline/single.rs
@@ -39,7 +39,7 @@ pub type SinglePipelineChain<C> = (SinglePipelineHandle<C>, ());
 /// let (chain, pipelines) = single_pipeline(
 ///     new_pipeline()
 ///         .add(NewSessionMiddleware::default().with_session_type::<Session>())
-///         .build()
+///         .build(),
 /// );
 ///
 /// build_router(chain, pipelines, |route| {

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -872,12 +872,7 @@ where
 fn descend<'n>(node_builder: &'n mut Node, path: &str) -> &'n mut Node {
     trace!("[walking to: {}]", path);
 
-    let path = if path.starts_with('/') {
-        &path[1..]
-    } else {
-        path
-    };
-
+    let path = path.strip_prefix('/').unwrap_or(path);
     if path.is_empty() {
         node_builder
     } else {
@@ -899,7 +894,7 @@ where
                     match segment.find(':') {
                         Some(n) => {
                             let (segment, pattern) = segment.split_at(n);
-                            let regex = ConstrainedSegmentRegex::new(&pattern[1..]);
+                            let regex = Box::new(ConstrainedSegmentRegex::new(&pattern[1..]));
                             (segment, SegmentType::Constrained { regex })
                         }
                         None => (segment, SegmentType::Dynamic),

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -230,8 +230,8 @@ pub trait DefineSingleRoute {
     /// # use gotham::test::TestServer;
     /// #
     /// async fn my_handler(_state: &mut State) -> Result<impl IntoResponse, HandlerError> {
-    ///     let flavors = std::fs::read("coffee-flavors.txt")
-    ///         .map_err_with_status(StatusCode::IM_A_TEAPOT)?;
+    ///     let flavors =
+    ///         std::fs::read("coffee-flavors.txt").map_err_with_status(StatusCode::IM_A_TEAPOT)?;
     ///     Ok(flavors)
     /// }
     /// #

--- a/gotham/src/router/non_match.rs
+++ b/gotham/src/router/non_match.rs
@@ -25,10 +25,8 @@ use hyper::{Method, StatusCode};
 ///     fn is_match(&self, state: &State) -> Result<(), RouteNonMatch> {
 ///         match state.borrow::<Method>() {
 ///             &Method::GET => Ok(()),
-///             _ => Err(
-///                 RouteNonMatch::new(StatusCode::METHOD_NOT_ALLOWED)
-///                     .with_allow_list(&[Method::GET]),
-///             ),
+///             _ => Err(RouteNonMatch::new(StatusCode::METHOD_NOT_ALLOWED)
+///                 .with_allow_list(&[Method::GET])),
 ///         }
 ///     }
 /// }

--- a/gotham/src/router/route/dispatch.rs
+++ b/gotham/src/router/route/dispatch.rs
@@ -116,7 +116,7 @@ mod tests {
             Chain: FnOnce(State) -> Pin<Box<HandlerFuture>> + Send + 'static,
             Self: Sized,
         {
-            state.put(self.clone());
+            state.put(self);
             chain(state)
         }
     }

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -3,7 +3,6 @@
 use hyper::header::{HeaderMap, ACCEPT};
 use hyper::StatusCode;
 use log::trace;
-use mime;
 use mime::Mime;
 
 use super::{LookupTable, LookupTableFromTypes};
@@ -185,7 +184,7 @@ mod test {
 
     fn with_state<F>(accept: Option<&str>, block: F)
     where
-        F: FnOnce(&mut State) -> (),
+        F: FnOnce(&mut State),
     {
         State::with_new(|state| {
             let mut headers = HeaderMap::new();

--- a/gotham/src/router/route/matcher/access_control_request_method.rs
+++ b/gotham/src/router/route/matcher/access_control_request_method.rs
@@ -22,14 +22,16 @@ use hyper::{
 ///
 /// # build_simple_router(|route| {
 /// // use the matcher for your request
-/// route.options("/foo")
-/// 	.extend_route_matcher(matcher)
-/// 	.to(|state| {
-/// 		// we know that this is a CORS preflight for a PUT request
-/// 		let mut res = create_empty_response(&state, StatusCode::NO_CONTENT);
-/// 		res.headers_mut().insert(ACCESS_CONTROL_ALLOW_METHODS, "PUT".parse().unwrap());
-/// 		(state, res)
-/// 	});
+/// route
+///     .options("/foo")
+///     .extend_route_matcher(matcher)
+///     .to(|state| {
+///         // we know that this is a CORS preflight for a PUT request
+///         let mut res = create_empty_response(&state, StatusCode::NO_CONTENT);
+///         res.headers_mut()
+///             .insert(ACCESS_CONTROL_ALLOW_METHODS, "PUT".parse().unwrap());
+///         (state, res)
+///     });
 /// # });
 /// ```
 #[derive(Clone, Debug)]
@@ -68,7 +70,7 @@ mod test {
 
     fn with_state<F>(accept: Option<&str>, block: F)
     where
-        F: FnOnce(&mut State) -> (),
+        F: FnOnce(&mut State),
     {
         State::with_new(|state| {
             let mut headers = HeaderMap::new();

--- a/gotham/src/router/route/matcher/and.rs
+++ b/gotham/src/router/route/matcher/and.rs
@@ -24,7 +24,7 @@ use crate::state::State;
 ///   let methods = vec![Method::GET, Method::HEAD];
 ///   let supported_media_types = vec![mime::APPLICATION_JSON];
 ///   let method_matcher = MethodOnlyRouteMatcher::new(methods);
-///	  let accept_matcher = AcceptHeaderRouteMatcher::new(supported_media_types);
+///   let accept_matcher = AcceptHeaderRouteMatcher::new(supported_media_types);
 ///   let matcher = AndRouteMatcher::new(method_matcher, accept_matcher);
 ///
 ///   state.put(Method::GET);

--- a/gotham/src/router/route/matcher/any.rs
+++ b/gotham/src/router/route/matcher/any.rs
@@ -18,9 +18,9 @@ use crate::state::State;
 /// #
 /// #   State::with_new(|state| {
 /// #
-///   let matcher = AnyRouteMatcher::new();
+/// let matcher = AnyRouteMatcher::new();
 ///
-///   assert!(matcher.is_match(&state).is_ok());
+/// assert!(matcher.is_match(&state).is_ok());
 /// #
 /// #   });
 /// # }

--- a/gotham/src/router/route/matcher/content_type.rs
+++ b/gotham/src/router/route/matcher/content_type.rs
@@ -3,7 +3,6 @@
 use hyper::header::{HeaderMap, CONTENT_TYPE};
 use hyper::StatusCode;
 use log::trace;
-use mime;
 use mime::Mime;
 
 use super::{LookupTable, LookupTableFromTypes};
@@ -153,7 +152,7 @@ mod test {
 
     fn with_state<F>(content_type: Option<&str>, block: F)
     where
-        F: FnOnce(&mut State) -> (),
+        F: FnOnce(&mut State),
     {
         State::with_new(|state| {
             let mut headers = HeaderMap::new();

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -73,14 +73,14 @@ where
 /// #
 /// #   State::with_new(|state| {
 /// #
-///   let methods = vec![Method::GET, Method::HEAD];
-///   let matcher = MethodOnlyRouteMatcher::new(methods);
+/// let methods = vec![Method::GET, Method::HEAD];
+/// let matcher = MethodOnlyRouteMatcher::new(methods);
 ///
-///   state.put(Method::GET);
-///   assert!(matcher.is_match(&state).is_ok());
+/// state.put(Method::GET);
+/// assert!(matcher.is_match(&state).is_ok());
 ///
-///   state.put(Method::POST);
-///   assert!(matcher.is_match(&state).is_err());
+/// state.put(Method::POST);
+/// assert!(matcher.is_match(&state).is_err());
 /// #   });
 /// # }
 /// ```

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -205,7 +205,7 @@ impl Node {
                 SegmentType::Glob => {
                     params
                         .entry(&child.segment)
-                        .or_insert_with(|| vec![])
+                        .or_insert_with(Vec::new)
                         .push(&segment);
                 }
 
@@ -387,7 +387,7 @@ mod tests {
         let mut seg_id = Node::new(
             "id",
             SegmentType::Constrained {
-                regex: ConstrainedSegmentRegex::new("[0-9]+"),
+                regex: Box::new(ConstrainedSegmentRegex::new("[0-9]+")),
             },
         );
         seg_id.add_route(get_route(pipeline_set.clone()));
@@ -413,7 +413,7 @@ mod tests {
         let mut seg9 = Node::new("seg9", SegmentType::Static);
 
         let mut seg10 = Node::new("seg10", SegmentType::Glob);
-        seg10.add_route(get_route(pipeline_set.clone()));
+        seg10.add_route(get_route(pipeline_set));
 
         segdyn1.add_child(seg7);
         seg5.add_child(seg6);

--- a/gotham/src/router/tree/segment.rs
+++ b/gotham/src/router/tree/segment.rs
@@ -19,7 +19,7 @@ pub enum SegmentType {
     /// Uses the supplied regex to determine match against incoming request paths.
     Constrained {
         /// Regex used to match against a single segment of a request path.
-        regex: ConstrainedSegmentRegex,
+        regex: Box<ConstrainedSegmentRegex>,
     },
 
     /// Matches any corresponding segment for incoming request paths.

--- a/gotham/src/service/mod.rs
+++ b/gotham/src/service/mod.rs
@@ -3,9 +3,9 @@
 
 use std::net::SocketAddr;
 use std::panic::AssertUnwindSafe;
-use std::pin::Pin;
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures::task::{self, Poll};
 use hyper::service::Service;
@@ -61,7 +61,7 @@ where
 {
     type Response = Response<Body>;
     type Error = anyhow::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(
         &mut self,

--- a/gotham/src/state/from_state.rs
+++ b/gotham/src/state/from_state.rs
@@ -23,7 +23,9 @@ pub trait FromState: StateData + Sized {
     /// }
     ///
     /// # State::with_new(|state| {
-    /// state.put(MyStruct { val: "This is the value!" });
+    /// state.put(MyStruct {
+    ///     val: "This is the value!",
+    /// });
     ///
     /// match MyStruct::try_borrow_from(&state) {
     ///     Some(&MyStruct { val }) => assert_eq!(val, "This is the value!"),
@@ -56,7 +58,9 @@ pub trait FromState: StateData + Sized {
     /// }
     ///
     /// # State::with_new(|state| {
-    /// state.put(MyStruct { val: "This is the value!" });
+    /// state.put(MyStruct {
+    ///     val: "This is the value!",
+    /// });
     ///
     /// let my_struct = MyStruct::borrow_from(&state);
     /// assert_eq!(my_struct.val, "This is the value!");
@@ -83,7 +87,9 @@ pub trait FromState: StateData + Sized {
     /// }
     ///
     /// # State::with_new(|mut state| {
-    /// state.put(MyStruct { val: "This is the value!" });
+    /// state.put(MyStruct {
+    ///     val: "This is the value!",
+    /// });
     ///
     /// match MyStruct::try_borrow_mut_from(&mut state) {
     ///     Some(&mut MyStruct { ref mut val }) => *val = "This is the new value!",
@@ -118,7 +124,9 @@ pub trait FromState: StateData + Sized {
     /// }
     ///
     /// # State::with_new(|mut state| {
-    /// state.put(MyStruct { val: "This is the value!" });
+    /// state.put(MyStruct {
+    ///     val: "This is the value!",
+    /// });
     ///
     /// # {
     /// let my_struct = MyStruct::borrow_mut_from(&mut state);
@@ -148,7 +156,9 @@ pub trait FromState: StateData + Sized {
     /// }
     ///
     /// # State::with_new(|mut state| {
-    /// state.put(MyStruct { val: "This is the value!" });
+    /// state.put(MyStruct {
+    ///     val: "This is the value!",
+    /// });
     ///
     /// match MyStruct::try_take_from(&mut state) {
     ///     Some(MyStruct { val }) => assert_eq!(val, "This is the value!"),
@@ -181,7 +191,9 @@ pub trait FromState: StateData + Sized {
     /// }
     ///
     /// # State::with_new(|mut state| {
-    /// state.put(MyStruct { val: "This is the value!" });
+    /// state.put(MyStruct {
+    ///     val: "This is the value!",
+    /// });
     ///
     /// let my_struct = MyStruct::take_from(&mut state);
     /// assert_eq!(my_struct.val, "This is the value!");

--- a/gotham/src/state/mod.rs
+++ b/gotham/src/state/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use crate::state::request_id::set_request_id;
 ///
 /// #[derive(StateData)]
 /// struct MyStruct {
-///   value: i32
+///     value: i32,
 /// }
 ///
 /// # fn main() {

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -261,9 +261,9 @@ impl fmt::Debug for TestResponse {
     }
 }
 
-impl Into<Response<Body>> for TestResponse {
-    fn into(self) -> Response<Body> {
-        self.response
+impl From<TestResponse> for Response<Body> {
+    fn from(response: TestResponse) -> Response<Body> {
+        response.response
     }
 }
 

--- a/gotham/src/test.rs
+++ b/gotham/src/test.rs
@@ -12,7 +12,6 @@ use hyper::client::Client;
 use hyper::header::CONTENT_TYPE;
 use hyper::{body, Body, Method, Response, Uri};
 use log::warn;
-use mime;
 use tokio::time::Sleep;
 
 pub use crate::plain::test::TestServer;
@@ -62,8 +61,7 @@ pub trait Server: Clone {
                         future::Either::Right(_) => Err(anyhow!("timed out")),
                     })
                 })
-                .into_future()
-                .map_err(|error| error.into()),
+                .into_future(),
         )
     }
 }
@@ -71,7 +69,7 @@ pub trait Server: Clone {
 impl<T: Server> BodyReader for T {
     fn read_body(&mut self, response: Response<Body>) -> Result<Vec<u8>, hyper::Error> {
         let f = body::to_bytes(response.into_body()).and_then(|b| future::ok(b.to_vec()));
-        self.run_future(f).map_err(|error| error.into())
+        self.run_future(f)
     }
 }
 
@@ -228,13 +226,16 @@ impl<TS: Server + 'static, C: Connect + Clone + Send + Sync + 'static> TestClien
 ///
 /// let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 ///
-/// let response = test_server.client().get("http://localhost/").perform().unwrap();
+/// let response = test_server
+///     .client()
+///     .get("http://localhost/")
+///     .perform()
+///     .unwrap();
 /// assert_eq!(response.status(), StatusCode::OK);
 /// let body = response.read_body().unwrap();
 /// assert_eq!(&body[..], b"This is the body content.");
 /// # }
 /// ```
-///
 pub struct TestResponse {
     response: Response<Body>,
     reader: Box<dyn BodyReader>,

--- a/gotham_derive/src/extenders.rs
+++ b/gotham_derive/src/extenders.rs
@@ -1,6 +1,4 @@
-use proc_macro;
 use quote::quote;
-use syn;
 
 pub(crate) fn bad_request_static_response_extender(
     ast: &syn::DeriveInput,

--- a/gotham_derive/src/lib.rs
+++ b/gotham_derive/src/lib.rs
@@ -1,6 +1,3 @@
-#![recursion_limit = "256"]
-extern crate proc_macro;
-
 mod extenders;
 mod new_middleware;
 mod state;

--- a/gotham_derive/src/new_middleware.rs
+++ b/gotham_derive/src/new_middleware.rs
@@ -1,6 +1,4 @@
-use proc_macro;
 use quote::quote;
-use syn;
 
 pub(crate) fn new_middleware(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
     let name = &ast.ident;

--- a/gotham_derive/src/state.rs
+++ b/gotham_derive/src/state.rs
@@ -1,6 +1,4 @@
-use proc_macro;
 use quote::quote;
-use syn;
 
 pub(crate) fn state_data(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
     let name = &ast.ident;

--- a/middleware/diesel/src/lib.rs
+++ b/middleware/diesel/src/lib.rs
@@ -43,20 +43,23 @@
 //!     // As an example, we perform the query:
 //!     // `SELECT 1`
 //!     async move {
-//!         let result = repo.run(move |conn| {
-//!             diesel::select(diesel::dsl::sql("1"))
-//!             .load::<i64>(&conn)
-//!             .map(|v| v.into_iter().next().expect("no results"))
-//!         }).await;
+//!         let result = repo
+//!             .run(move |conn| {
+//!                 diesel::select(diesel::dsl::sql("1"))
+//!                     .load::<i64>(&conn)
+//!                     .map(|v| v.into_iter().next().expect("no results"))
+//!             })
+//!             .await;
 //!         match result {
 //!             Ok(n) => {
 //!                 let body = format!("result: {}", n);
 //!                 let res = create_response(&state, StatusCode::OK, mime::TEXT_PLAIN, body);
 //!                 Ok((state, res))
-//!             },
+//!             }
 //!             Err(e) => Err((state, e.into())),
 //!         }
-//!     }.boxed()
+//!     }
+//!     .boxed()
 //! }
 //!
 //! # fn main() {

--- a/middleware/diesel/src/repo.rs
+++ b/middleware/diesel/src/repo.rs
@@ -43,11 +43,12 @@ use tokio::task;
 /// #         name VARCHAR NOT NULL
 /// #         )")
 /// # })).unwrap();
-/// let result = runtime.block_on(repo.run(|conn| {
-///     use schema::users::dsl::*;
-///     users.load::<User>(&conn)
-/// })).unwrap();
-///
+/// let result = runtime
+///     .block_on(repo.run(|conn| {
+///         use schema::users::dsl::*;
+///         users.load::<User>(&conn)
+///     }))
+///     .unwrap();
 /// ```
 #[derive(StateData)]
 pub struct Repo<T>
@@ -92,15 +93,16 @@ where
     ///
     /// ```rust
     /// # use diesel::sqlite::SqliteConnection;
-    /// use r2d2::Pool;
     /// use core::time::Duration;
+    /// use r2d2::Pool;
     ///
     /// type Repo = gotham_middleware_diesel::Repo<SqliteConnection>;
     /// let database_url = ":memory:";
-    /// let repo = Repo::from_pool_builder(database_url,
+    /// let repo = Repo::from_pool_builder(
+    ///     database_url,
     ///     Pool::builder()
     ///         .connection_timeout(Duration::from_secs(120))
-    ///         .max_size(100)
+    ///         .max_size(100),
     /// );
     /// ```
     pub fn from_pool_builder(

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -83,6 +83,7 @@ const DEFAULT_SCHEME: &str = "Bearer";
 /// #    let _ = router();
 /// # }
 /// ```
+#[allow(clippy::upper_case_acronyms)]
 pub struct JWTMiddleware<T> {
     secret: String,
     validation: Validation,

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -36,18 +36,18 @@ const DEFAULT_SCHEME: &str = "Bearer";
 /// extern crate serde_derive;
 ///
 /// use futures::prelude::*;
+/// use gotham::hyper::{Response, StatusCode};
 /// use gotham::{
-///     helpers::http::response::create_empty_response,
 ///     handler::HandlerFuture,
+///     helpers::http::response::create_empty_response,
 ///     pipeline::{
 ///         new_pipeline,
 ///         set::{finalize_pipeline_set, new_pipeline_set},
 ///     },
 ///     router::{builder::*, Router},
-///     state::{State, FromState},
+///     state::{FromState, State},
 /// };
-/// use gotham_middleware_jwt::{JWTMiddleware, AuthorizationToken};
-/// use gotham::hyper::{Response, StatusCode};
+/// use gotham_middleware_jwt::{AuthorizationToken, JWTMiddleware};
 /// use std::pin::Pin;
 ///
 /// #[derive(Deserialize, Debug)]
@@ -212,9 +212,11 @@ mod tests {
             exp: 10_000_000_000,
         };
 
-        let mut header = Header::default();
-        header.kid = Some("signing-key".to_owned());
-        header.alg = alg;
+        let header = Header {
+            kid: Some("signing-key".to_owned()),
+            alg,
+            ..Default::default()
+        };
 
         match encode(&header, &claims, &EncodingKey::from_secret(SECRET.as_ref())) {
             Ok(t) => t,

--- a/misc/borrow_bag/src/lookup.rs
+++ b/misc/borrow_bag/src/lookup.rs
@@ -9,7 +9,8 @@ use handle::{Skip, Take};
 /// # use borrow_bag::*;
 /// #
 /// fn borrow_from<V, T, N>(bag: &BorrowBag<V>, handle: Handle<T, N>) -> &T
-///     where V: Lookup<T, N>
+/// where
+///     V: Lookup<T, N>,
 /// {
 ///     bag.borrow(handle)
 /// }


### PR DESCRIPTION
- Fixed all clippy lints currently in the code
- Formated all examples in doc comments (using a nightly version of rustfmt)
- Make the clippy check required in GitHub Actions

I opted to not fix the `upper_case_acronyms` lint as renaming `JWTMiddleware` to `JwtMiddleware` would be a breaking change.