### PR TITLE
Rename `JWTMiddleware` to `JwtMiddleware`

### DIFF
--- a/middleware/jwt/src/lib.rs
+++ b/middleware/jwt/src/lib.rs
@@ -6,7 +6,8 @@
 //! Status Code `400: Bad Request`. Tokens that fail
 //! validation cause the middleware to return Status Code
 //! `401: Unauthorized`.
-#![warn(missing_docs, deprecated)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 extern crate gotham_derive;
 #[macro_use]
@@ -18,5 +19,10 @@ extern crate serde_derive;
 mod middleware;
 mod state_data;
 
-pub use self::middleware::JWTMiddleware;
+pub use self::middleware::JwtMiddleware;
 pub use self::state_data::AuthorizationToken;
+
+/// This type alias is deprecated. Use `JwtMiddleware` instead.
+#[deprecated(since = "0.6.1", note = "Please use `JwtMiddleware` instead")]
+#[allow(clippy::upper_case_acronyms)]
+pub type JWTMiddleware<T> = JwtMiddleware<T>;

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -47,7 +47,7 @@ const DEFAULT_SCHEME: &str = "Bearer";
 ///     router::{builder::*, Router},
 ///     state::{FromState, State},
 /// };
-/// use gotham_middleware_jwt::{AuthorizationToken, JWTMiddleware};
+/// use gotham_middleware_jwt::{AuthorizationToken, JwtMiddleware};
 /// use std::pin::Pin;
 ///
 /// #[derive(Deserialize, Debug)]
@@ -69,7 +69,7 @@ const DEFAULT_SCHEME: &str = "Bearer";
 ///     let pipelines = new_pipeline_set();
 ///     let (pipelines, defaults) = pipelines.add(
 ///         new_pipeline()
-///             .add(JWTMiddleware::<Claims>::new("secret"))
+///             .add(JwtMiddleware::<Claims>::new("secret"))
 ///             .build(),
 ///     );
 ///     let default_chain = (defaults, ());
@@ -83,15 +83,14 @@ const DEFAULT_SCHEME: &str = "Bearer";
 /// #    let _ = router();
 /// # }
 /// ```
-#[allow(clippy::upper_case_acronyms)]
-pub struct JWTMiddleware<T> {
+pub struct JwtMiddleware<T> {
     secret: String,
     validation: Validation,
     scheme: String,
     claims: PhantomData<T>,
 }
 
-impl<T> JWTMiddleware<T>
+impl<T> JwtMiddleware<T>
 where
     T: for<'de> Deserialize<'de> + Send + Sync,
 {
@@ -100,7 +99,7 @@ where
     pub fn new<S: Into<String>>(secret: S) -> Self {
         let validation = Validation::default();
 
-        JWTMiddleware {
+        Self {
             secret: secret.into(),
             validation,
             scheme: DEFAULT_SCHEME.into(),
@@ -111,19 +110,19 @@ where
     /// Create a new instance of the middleware by appending new
     /// validation constraints.
     pub fn validation(self, validation: Validation) -> Self {
-        JWTMiddleware { validation, ..self }
+        Self { validation, ..self }
     }
 
     /// Create a new instance of the middleware with a custom scheme
     pub fn scheme<S: Into<String>>(self, scheme: S) -> Self {
-        JWTMiddleware {
+        Self {
             scheme: scheme.into(),
             ..self
         }
     }
 }
 
-impl<T> Middleware for JWTMiddleware<T>
+impl<T> Middleware for JwtMiddleware<T>
 where
     T: for<'de> Deserialize<'de> + Send + Sync + 'static,
 {
@@ -169,14 +168,14 @@ where
     }
 }
 
-impl<T> NewMiddleware for JWTMiddleware<T>
+impl<T> NewMiddleware for JwtMiddleware<T>
 where
     T: for<'de> Deserialize<'de> + RefUnwindSafe + Send + Sync + 'static,
 {
-    type Instance = JWTMiddleware<T>;
+    type Instance = Self;
 
     fn new_middleware(&self) -> anyhow::Result<Self::Instance> {
-        Ok(JWTMiddleware {
+        Ok(Self {
             secret: self.secret.clone(),
             validation: self.validation.clone(),
             scheme: self.scheme.clone(),
@@ -234,17 +233,17 @@ mod tests {
         future::ok((state, res)).boxed()
     }
 
-    fn default_jwt_middleware() -> JWTMiddleware<Claims> {
-        JWTMiddleware::<Claims>::new(SECRET).validation(Validation::default())
+    fn default_jwt_middleware() -> JwtMiddleware<Claims> {
+        JwtMiddleware::<Claims>::new(SECRET).validation(Validation::default())
     }
 
-    fn jwt_middleware_with_scheme(scheme: &str) -> JWTMiddleware<Claims> {
-        JWTMiddleware::<Claims>::new(SECRET)
+    fn jwt_middleware_with_scheme(scheme: &str) -> JwtMiddleware<Claims> {
+        JwtMiddleware::<Claims>::new(SECRET)
             .validation(Validation::default())
             .scheme(scheme)
     }
 
-    fn router(middleware: JWTMiddleware<Claims>) -> Router {
+    fn router(middleware: JwtMiddleware<Claims>) -> Router {
         // Create JWTMiddleware with HS256 algorithm (default).
 
         let (chain, pipelines) = single_pipeline(new_pipeline().add(middleware).build());


### PR DESCRIPTION
This brings our API in line with the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case). Follow-Up for #534

The old name is now a type alias that I marked deprecated as of 0.6.1. We should then probably publish 0.6.1 straight away so that people using the middleware get the deprecation warning and have time to update their code before the next breaking release.