### PR TITLE
Re-export gotham_derive macros

### DIFF
--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -9,16 +9,14 @@ publish = false
 
 [dependencies]
 gotham = { path = "../../gotham/"}
-gotham_derive = { path = "../../gotham_derive/" }
 gotham_middleware_diesel = { path = "../../middleware/diesel"}
 futures-util = "0.3.14"
 
 log = "0.4"
 diesel = { version = "1.4.6", features = ["r2d2", "sqlite"] }
 diesel_migrations = { version = "1.4", features = ["sqlite"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 
 [dev-dependencies]
 diesel_migrations = "1.4.0"

--- a/examples/diesel/src/main.rs
+++ b/examples/diesel/src/main.rs
@@ -18,7 +18,7 @@ use gotham::pipeline::{new_pipeline, single::single_pipeline};
 use gotham::router::{builder::*, Router};
 use gotham::state::{FromState, State};
 use gotham_middleware_diesel::DieselMiddleware;
-use serde_derive::Serialize;
+use serde::Serialize;
 use std::pin::Pin;
 use std::str::from_utf8;
 

--- a/examples/diesel/src/models.rs
+++ b/examples/diesel/src/models.rs
@@ -1,7 +1,7 @@
 //! Holds the two possible structs that are `Queryable` and
 //! `Insertable` in the DB
 use diesel::{Insertable, Queryable};
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::schema::products;
 

--- a/examples/finalizers/Cargo.toml
+++ b/examples/finalizers/Cargo.toml
@@ -7,5 +7,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../gotham" }
-
-mime = "0.3"

--- a/examples/handlers/async_handlers/Cargo.toml
+++ b/examples/handlers/async_handlers/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
 
 futures-util = "0.3.14"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/handlers/async_handlers/src/main.rs
+++ b/examples/handlers/async_handlers/src/main.rs
@@ -1,25 +1,22 @@
 //! A basic example showing the request components
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use futures_util::future::{self, FutureExt, TryFutureExt};
 use futures_util::stream::{self, StreamExt, TryStreamExt};
+use serde::Deserialize;
 use std::future::Future;
 use std::pin::Pin;
 
+use gotham::handler::HandlerFuture;
+use gotham::helpers::http::response::create_response;
 use gotham::hyper::StatusCode;
 #[cfg(not(test))]
 use gotham::hyper::{body, Client, Uri};
 use gotham::mime::TEXT_PLAIN;
-
-use gotham::handler::HandlerFuture;
-use gotham::helpers::http::response::create_response;
 use gotham::router::builder::DefineSingleRoute;
 use gotham::router::builder::{build_simple_router, DrawRoutes};
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
 
 type ResponseContentFuture =
     Pin<Box<dyn Future<Output = Result<Vec<u8>, gotham::hyper::Error>> + Send>>;

--- a/examples/handlers/simple_async_handlers/Cargo.toml
+++ b/examples/handlers/simple_async_handlers/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
 
 futures-util = "0.3.14"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/handlers/simple_async_handlers/src/main.rs
+++ b/examples/handlers/simple_async_handlers/src/main.rs
@@ -1,11 +1,8 @@
 //! A basic example showing the request components
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use futures_util::stream::{self, StreamExt};
 use futures_util::FutureExt;
+use serde::Deserialize;
 use std::pin::Pin;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -16,8 +13,9 @@ use gotham::hyper::StatusCode;
 use gotham::mime::TEXT_PLAIN;
 use gotham::router::builder::DefineSingleRoute;
 use gotham::router::builder::{build_simple_router, DrawRoutes};
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct QueryStringExtractor {

--- a/examples/handlers/simple_async_handlers_await/Cargo.toml
+++ b/examples/handlers/simple_async_handlers_await/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
-
 
 serde = "1.0"
-serde_derive = "1.0"
 tokio = "1.0"

--- a/examples/handlers/simple_async_handlers_await/src/main.rs
+++ b/examples/handlers/simple_async_handlers_await/src/main.rs
@@ -6,10 +6,10 @@ use gotham::hyper::{Body, StatusCode};
 use gotham::mime::TEXT_PLAIN;
 use gotham::router::builder::DefineSingleRoute;
 use gotham::router::builder::{build_simple_router, DrawRoutes};
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
-use gotham_derive::{StateData, StaticResponseExtender};
-use serde_derive::Deserialize;
+use gotham::state::{FromState, State, StateData};
+use serde::Deserialize;
 use std::time::Duration;
 use tokio::time::sleep;
 

--- a/examples/into_response/introduction/Cargo.toml
+++ b/examples/into_response/introduction/Cargo.toml
@@ -8,7 +8,5 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
 serde = "1"
-serde_derive = "1"
 serde_json = "1"

--- a/examples/into_response/introduction/src/main.rs
+++ b/examples/into_response/introduction/src/main.rs
@@ -1,6 +1,4 @@
 //! An introduction to the Gotham web framework's `IntoResponse` trait.
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::handler::IntoResponse;
 use gotham::helpers::http::response::create_response;
@@ -9,6 +7,7 @@ use gotham::mime::APPLICATION_JSON;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::State;
+use serde::Serialize;
 
 /// A Product
 #[derive(Serialize)]

--- a/examples/middleware/introduction/Cargo.toml
+++ b/examples/middleware/introduction/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
 
 futures-util = "0.3.14"

--- a/examples/middleware/introduction/src/main.rs
+++ b/examples/middleware/introduction/src/main.rs
@@ -1,6 +1,4 @@
 //! Introduces the Middleware and Pipeline concepts provided by the Gotham web framework.
-#[macro_use]
-extern crate gotham_derive;
 
 use futures_util::future::{self, FutureExt, TryFutureExt};
 use std::pin::Pin;
@@ -9,12 +7,12 @@ use gotham::handler::HandlerFuture;
 use gotham::helpers::http::response::create_empty_response;
 use gotham::hyper::header::{HeaderMap, USER_AGENT};
 use gotham::hyper::{Body, Response, StatusCode};
-use gotham::middleware::Middleware;
+use gotham::middleware::{Middleware, NewMiddleware};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
 
 /// A simple struct which holds an identifier for the user agent which made the request.
 ///

--- a/examples/middleware/multiple_pipelines/Cargo.toml
+++ b/examples/middleware/multiple_pipelines/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
 
 futures-util = "0.3.14"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/middleware/multiple_pipelines/src/main.rs
+++ b/examples/middleware/multiple_pipelines/src/main.rs
@@ -10,10 +10,6 @@
 //! Our app also has some admin functionality, so we'll also override admin paths
 //! to require an additional admin session.
 //! Finally, our app exposes an JSON endpoint, which needs its own middleware.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use futures_util::future::{self, FutureExt};
 use gotham::hyper::header::{HeaderMap, ACCEPT};
@@ -24,13 +20,14 @@ use std::pin::Pin;
 use gotham::handler::HandlerFuture;
 use gotham::helpers::http::response::create_response;
 use gotham::middleware::session::NewSessionMiddleware;
-use gotham::middleware::Middleware;
+use gotham::middleware::{Middleware, NewMiddleware};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::set::{finalize_pipeline_set, new_pipeline_set};
 use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
+use serde::{Deserialize, Serialize};
 
 /// A simple struct to represent our default session data.
 #[derive(Default, Serialize, Deserialize)]

--- a/examples/path/globs/Cargo.toml
+++ b/examples/path/globs/Cargo.toml
@@ -8,6 +8,4 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -1,12 +1,10 @@
 //! Shows how to match arbitrarily many path segments.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
+use serde::Deserialize;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct PathExtractor {

--- a/examples/path/introduction/Cargo.toml
+++ b/examples/path/introduction/Cargo.toml
@@ -8,6 +8,4 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/path/introduction/src/main.rs
+++ b/examples/path/introduction/src/main.rs
@@ -1,13 +1,11 @@
 //! An introduction to extracting request path segments, in a type safe way, with the
 //! Gotham web framework
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
+use serde::Deserialize;
 
 /// Holds data extracted from the Request path.
 ///

--- a/examples/path/regex/Cargo.toml
+++ b/examples/path/regex/Cargo.toml
@@ -7,6 +7,4 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/path/regex/src/main.rs
+++ b/examples/path/regex/src/main.rs
@@ -1,12 +1,10 @@
 //! An example of the Gotham web framework `Router` that shows how to use Regex patterns in path segments.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::router::builder::*;
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
+use serde::Deserialize;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct PathExtractor {

--- a/examples/query_string/introduction/Cargo.toml
+++ b/examples/query_string/introduction/Cargo.toml
@@ -8,7 +8,5 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
-serde = "1"
-serde_derive = "1"
-serde_json = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/examples/query_string/introduction/src/main.rs
+++ b/examples/query_string/introduction/src/main.rs
@@ -1,14 +1,12 @@
 //! An introduction to extracting query string name/value pairs, in a type safe way, with the
 //! Gotham web framework
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::mime::{Mime, APPLICATION_JSON};
 use gotham::router::builder::*;
+use gotham::router::response::extender::StaticResponseExtender;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
+use serde::{Deserialize, Serialize};
 
 /// Holds data extracted from the Request query string.
 ///

--- a/examples/routing/associations/Cargo.toml
+++ b/examples/routing/associations/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }

--- a/examples/routing/http_verbs/Cargo.toml
+++ b/examples/routing/http_verbs/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }

--- a/examples/routing/scopes/Cargo.toml
+++ b/examples/routing/scopes/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }

--- a/examples/sessions/custom_data_type/Cargo.toml
+++ b/examples/sessions/custom_data_type/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-gotham_derive = { path = "../../../gotham_derive" }
-serde = "1"
-serde_derive = "1"
+serde = { version = "1.0", features = ["derive"] }
 time = "0.2.23"
 cookie = "0.15"

--- a/examples/sessions/custom_data_type/src/main.rs
+++ b/examples/sessions/custom_data_type/src/main.rs
@@ -1,16 +1,13 @@
 //! Storing and retrieving session data with a custom data type, in a type safe
 //! way, with the Gotham web framework.
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate serde_derive;
 
 use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::new_pipeline;
 use gotham::pipeline::single::single_pipeline;
 use gotham::router::builder::*;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
+use serde::{Deserialize, Serialize};
 use time::{Format, OffsetDateTime};
 
 // A custom type for storing data associated with the user's session.

--- a/examples/shared_state/Cargo.toml
+++ b/examples/shared_state/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../gotham" }
-gotham_derive = { path = "../../gotham_derive" }

--- a/examples/shared_state/src/main.rs
+++ b/examples/shared_state/src/main.rs
@@ -6,15 +6,12 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::mutex_atomic))]
 
-#[macro_use]
-extern crate gotham_derive;
-
 use gotham::middleware::state::StateMiddleware;
 use gotham::pipeline::single::single_pipeline;
 use gotham::pipeline::single_middleware;
 use gotham::router::builder::*;
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
 
 use std::sync::{Arc, Mutex};
 

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -17,41 +17,42 @@ keywords = ["http", "async", "web", "framework", "server"]
 edition = "2018"
 
 [features]
-default = ["rustls"]
+default = ["derive", "rustls"]
+derive = ["gotham_derive"]
 rustls = ["tokio-rustls"]
 
 [dependencies]
-log = "0.4"
-hyper = { version = "0.14.3", features = ["full"] }
-serde = "1.0"
-serde_derive = "1.0"
-bincode = "1.0"
-mime = "0.3.15"
-mime_guess = "2.0.1"
-futures-util = "0.3.14"
-tokio = { version = "1.0", features = ["net", "rt-multi-thread", "time", "fs", "io-util"] }
-bytes = "1.0"
 borrow-bag = { path = "../misc/borrow_bag", version = "1.1" }
-percent-encoding = "2.1"
-pin-project = "1.0.0"
-uuid = { version = "0.8", features = ["v4"] }
-chrono = "0.4"
+gotham_derive = { path = "../gotham_derive", version = "0.6", optional = true }
+
+anyhow = "1.0"
 base64 = "0.13"
-rand = "0.8"
-rand_chacha = "0.3"
-linked-hash-map = "0.5.3"
-num_cpus = "1.8"
-regex = "1.0"
+bincode = "1.0"
+bytes = "1.0"
+chrono = "0.4"
 cookie = "0.15"
+futures-util = "0.3.14"
 http = "0.2"
 httpdate = "1.0"
+hyper = { version = "0.14.3", features = ["full"] }
 itertools = "0.10.0"
-anyhow = "1.0"
+linked-hash-map = "0.5.3"
+log = "0.4"
+mime = "0.3.15"
+mime_guess = "2.0.1"
+num_cpus = "1.8"
+percent-encoding = "2.1"
+pin-project = "1.0.0"
+rand = "0.8"
+rand_chacha = "0.3"
+regex = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["net", "rt-multi-thread", "time", "fs", "io-util"] }
 tokio-rustls = { version = "0.22", optional = true }
+uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 futures-executor = "0.3.14"
-gotham_derive = { path = "../gotham_derive" }
 thiserror = "1.0"
 
 [badges]

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -701,7 +701,7 @@ impl<'de> VariantAccess<'de> for UnitVariant {
 mod tests {
     use super::*;
     use crate::helpers::http::{FormUrlDecoded, PercentDecoded};
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
 
     #[derive(Deserialize)]
     struct SimpleValues {

--- a/gotham/src/extractor/path.rs
+++ b/gotham/src/extractor/path.rs
@@ -20,20 +20,18 @@ use crate::state::{State, StateData};
 ///
 /// ```rust
 /// # extern crate gotham;
-/// # #[macro_use]
-/// # extern crate gotham_derive;
 /// # extern crate hyper;
 /// # extern crate mime;
 /// # extern crate serde;
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// #
 /// # use hyper::{Body, Response, StatusCode};
-/// # use gotham::state::{FromState, State};
+/// # use gotham::state::{FromState, State, StateData};
 /// # use gotham::helpers::http::response::create_response;
 /// # use gotham::router::Router;
 /// # use gotham::router::builder::*;
+/// # use gotham::router::response::extender::StaticResponseExtender;
 /// # use gotham::test::TestServer;
+/// # use serde::Deserialize;
 /// #
 /// #[derive(Deserialize, StateData, StaticResponseExtender)]
 /// struct MyPathParams {

--- a/gotham/src/extractor/query_string.rs
+++ b/gotham/src/extractor/query_string.rs
@@ -20,20 +20,18 @@ use crate::state::{State, StateData};
 ///
 /// ```rust
 /// # extern crate gotham;
-/// # #[macro_use]
-/// # extern crate gotham_derive;
 /// # extern crate hyper;
 /// # extern crate mime;
 /// # extern crate serde;
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// #
 /// # use hyper::{Body, Response, StatusCode};
-/// # use gotham::state::{FromState, State};
+/// # use gotham::state::{FromState, State, StateData};
 /// # use gotham::helpers::http::response::create_response;
 /// # use gotham::router::Router;
 /// # use gotham::router::builder::*;
+/// # use gotham::router::response::extender::StaticResponseExtender;
 /// # use gotham::test::TestServer;
+/// # use serde::Deserialize;
 /// #
 /// #[derive(Deserialize, StateData, StaticResponseExtender)]
 /// struct MyQueryParams {

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -15,7 +15,7 @@ use hyper::{Body, Response, StatusCode};
 use log::debug;
 use mime::{self, Mime};
 use mime_guess::from_path;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use tokio::fs::File;
 use tokio::io::{AsyncRead, ReadBuf};
 

--- a/gotham/src/middleware/mod.rs
+++ b/gotham/src/middleware/mod.rs
@@ -15,6 +15,8 @@ pub mod session;
 pub mod state;
 pub mod timer;
 
+pub use gotham_derive::NewMiddleware;
+
 /// `Middleware` has the opportunity to provide additional behaviour to the `Request` / `Response`
 /// interaction. For example:
 ///

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -1046,7 +1046,7 @@ mod tests {
     use cookie::Cookie;
     use hyper::header::{HeaderMap, COOKIE};
     use hyper::{Response, StatusCode};
-    use serde_derive::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
     use std::sync::Mutex;
     use std::time::Duration;
 

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -184,9 +184,6 @@ impl SessionCookieConfig {
 /// ## Examples
 ///
 /// ```rust
-/// # #[macro_use]
-/// # extern crate serde_derive;
-/// #
 /// # use std::sync::Arc;
 /// # use std::time::Duration;
 /// # use futures_util::future::{self, FutureExt};
@@ -198,8 +195,8 @@ impl SessionCookieConfig {
 /// # use gotham::test::TestServer;
 /// # use hyper::{Body, Response, StatusCode};
 /// # use hyper::header::COOKIE;
-/// #
-/// #[derive(Default, Serialize, Deserialize)]
+/// # use serde::{Deserialize, Serialize};
+/// #[derive(Default, Deserialize, Serialize)]
 /// struct MySessionType {
 ///     items: Vec<String>,
 /// }
@@ -441,11 +438,9 @@ where
 ///
 /// ```rust
 /// # extern crate gotham;
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// #
 /// # use gotham::middleware::session::NewSessionMiddleware;
-/// #
+/// # use serde::{Deserialize, Serialize};
 /// #[derive(Default, Serialize, Deserialize)]
 /// struct MySessionType {
 ///     items: Vec<String>,
@@ -558,10 +553,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct MySessionType {
@@ -590,10 +584,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct MySessionType {
@@ -632,10 +625,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct MySessionType {
@@ -663,10 +655,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct MySessionType {
@@ -701,10 +692,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct MySessionType {
@@ -737,10 +727,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct MySessionType {
@@ -766,10 +755,9 @@ where
     ///
     /// ```rust
     /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
     /// #
     /// # use gotham::middleware::session::NewSessionMiddleware;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// #[derive(Default, Serialize, Deserialize)]
     /// struct MySessionType {

--- a/gotham/src/pipeline/single.rs
+++ b/gotham/src/pipeline/single.rs
@@ -25,12 +25,11 @@ pub type SinglePipelineChain<C> = (SinglePipelineHandle<C>, ());
 ///
 /// ```rust
 /// # extern crate gotham;
-/// # #[macro_use]
-/// # extern crate serde_derive;
 /// # use gotham::pipeline::single::single_pipeline;
 /// # use gotham::pipeline::new_pipeline;
 /// # use gotham::router::builder::build_router;
 /// # use gotham::middleware::session::NewSessionMiddleware;
+/// # use serde::{Deserialize, Serialize};
 /// #
 /// # #[derive(Serialize, Deserialize, Default)]
 /// # struct Session;

--- a/gotham/src/router/builder/associated.rs
+++ b/gotham/src/router/builder/associated.rs
@@ -137,18 +137,13 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate gotham_derive;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// # extern crate hyper;
-    /// #
     /// # use hyper::{Body, Response, StatusCode};
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
-    /// # use gotham::state::State;
+    /// # use gotham::router::response::extender::StaticResponseExtender;
+    /// # use gotham::state::{State, StateData};
     /// # use gotham::test::TestServer;
+    /// # use serde::Deserialize;
     /// #
     /// fn handler(state: State) -> (State, Response<Body>) {
     ///     // Implementation elided.
@@ -201,19 +196,13 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate gotham_derive;
-    /// # extern crate hyper;
-    /// # extern crate serde;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// #
     /// # use hyper::{Body, Response, StatusCode};
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
-    /// # use gotham::state::State;
+    /// # use gotham::router::response::extender::StaticResponseExtender;
+    /// # use gotham::state::{State, StateData};
     /// # use gotham::test::TestServer;
+    /// # use serde::Deserialize;
     /// #
     /// fn handler(state: State) -> (State, Response<Body>) {
     ///     // Implementation elided.

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -535,11 +535,6 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate gotham;
-    /// # extern crate hyper;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// #
     /// # use hyper::{Body, Response, StatusCode};
     /// # use gotham::state::State;
     /// # use gotham::middleware::session::{NewSessionMiddleware, SessionData};
@@ -548,6 +543,7 @@ where
     /// # use gotham::pipeline::new_pipeline;
     /// # use gotham::pipeline::set::{finalize_pipeline_set, new_pipeline_set};
     /// # use gotham::test::TestServer;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct Session;
@@ -705,11 +701,6 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate gotham;
-    /// # extern crate hyper;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// #
     /// # use hyper::{Body, Response, StatusCode};
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
@@ -718,6 +709,7 @@ where
     /// # use gotham::state::State;
     /// # use gotham::middleware::session::{NewSessionMiddleware, SessionData};
     /// # use gotham::test::TestServer;
+    /// # use serde::{Deserialize, Serialize};
     /// #
     /// # #[derive(Default, Serialize, Deserialize)]
     /// # struct Session;

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -334,7 +334,7 @@ mod tests {
 
     use hyper::service::Service;
     use hyper::{body, Body, Request, Response, StatusCode};
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
 
     use crate::middleware::cookie::CookieParser;
     use crate::middleware::session::NewSessionMiddleware;

--- a/gotham/src/router/builder/mod.rs
+++ b/gotham/src/router/builder/mod.rs
@@ -39,11 +39,6 @@ pub use self::single::DefineSingleRoute;
 /// `route.get("/foo/bar/baz")`
 ///
 /// ```rust
-/// # extern crate gotham;
-/// # extern crate hyper;
-/// # #[macro_use]
-/// # extern crate serde_derive;
-/// #
 /// # use hyper::{Body, Response, StatusCode};
 /// # use gotham::state::State;
 /// # use gotham::router::Router;
@@ -52,6 +47,7 @@ pub use self::single::DefineSingleRoute;
 /// # use gotham::pipeline::single::*;
 /// # use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 /// # use gotham::test::TestServer;
+/// # use serde::{Deserialize, Serialize};
 /// #
 /// # #[derive(Serialize, Deserialize, Default)]
 /// # struct Session;

--- a/gotham/src/router/builder/single.rs
+++ b/gotham/src/router/builder/single.rs
@@ -420,21 +420,16 @@ pub trait DefineSingleRoute {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate gotham_derive;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// # extern crate hyper;
-    /// #
     /// # use hyper::{Body, Response, StatusCode};
-    /// # use gotham::state::{State, FromState};
+    /// # use gotham::state::{State, StateData, FromState};
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
+    /// # use gotham::router::response::extender::StaticResponseExtender;
     /// # use gotham::pipeline::new_pipeline;
     /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
     /// # use gotham::test::TestServer;
+    /// # use serde::Deserialize;
     /// #
     /// #[derive(Deserialize, StateData, StaticResponseExtender)]
     /// struct MyPathParams {
@@ -489,22 +484,16 @@ pub trait DefineSingleRoute {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate gotham;
-    /// # #[macro_use]
-    /// # extern crate gotham_derive;
-    /// # extern crate hyper;
-    /// # extern crate serde;
-    /// # #[macro_use]
-    /// # extern crate serde_derive;
-    /// #
     /// # use hyper::{Body, Response, StatusCode};
-    /// # use gotham::state::{State, FromState};
+    /// # use gotham::state::{State, StateData, FromState};
     /// # use gotham::router::Router;
     /// # use gotham::router::builder::*;
+    /// # use gotham::router::response::extender::StaticResponseExtender;
     /// # use gotham::pipeline::new_pipeline;
     /// # use gotham::pipeline::set::*;
     /// # use gotham::middleware::session::NewSessionMiddleware;
     /// # use gotham::test::TestServer;
+    /// # use serde::Deserialize;
     /// #
     /// #[derive(StateData, Deserialize, StaticResponseExtender)]
     /// struct MyQueryParams {

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -5,6 +5,8 @@ use hyper::{body::HttpBody, Body, Response};
 use log::trace;
 use std::panic::RefUnwindSafe;
 
+pub use gotham_derive::StaticResponseExtender;
+
 /// Extend the `Response` based on current `State` and `Response` data.
 pub trait StaticResponseExtender: RefUnwindSafe {
     /// The type of the response body. Almost always `hyper::Body`.

--- a/gotham/src/state/data.rs
+++ b/gotham/src/state/data.rs
@@ -7,6 +7,8 @@ use hyper::{Body, HeaderMap, Method, Uri, Version};
 use crate::helpers::http::request::path::RequestPathSegments;
 use crate::state::request_id::RequestId;
 
+pub use gotham_derive::StateData;
+
 /// A marker trait for types that can be stored in `State`.
 ///
 /// This is typically implemented using `#[derive(StateData)]`, which is provided by the

--- a/gotham_derive/Cargo.toml
+++ b/gotham_derive/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Bradley Beddoes <bradleybeddoes@gmail.com>",
           "Isaac Whitfield <iw@whitfin.io>",
           "Judson Lester <nyarly@gmail.com>",
           "Shaun Mangelsdorf <s.mangelsdorf@gmail.com>"]
-description = "Macros 1.1 implementations for Gotham traits"
+description = "Private implementation detail of the gotham framework"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/gotham-rs/gotham"
 categories = ["web-programming::http-server"]

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -13,8 +13,7 @@ keywords = ["http", "async", "web", "gotham", "diesel"]
 
 [dependencies]
 futures-util = "0.3.14"
-gotham = { path = "../../gotham", version = "0.6.0", default-features = false }
-gotham_derive = { path = "../../gotham_derive", version = "0.6.0" }
+gotham = { path = "../../gotham", version = "0.6.0", default-features = false, features = ["derive"] }
 diesel = { version = "1.4.6", features = ["r2d2"] }
 r2d2 = "0.8"
 tokio = { version = "1.0", features = ["full"] }

--- a/middleware/diesel/src/repo.rs
+++ b/middleware/diesel/src/repo.rs
@@ -1,6 +1,6 @@
 use diesel::r2d2::ConnectionManager;
 use diesel::Connection;
-use gotham_derive::StateData;
+use gotham::state::StateData;
 use log::error;
 use r2d2::{CustomizeConnection, Pool, PooledConnection};
 use tokio::task;

--- a/middleware/jwt/Cargo.toml
+++ b/middleware/jwt/Cargo.toml
@@ -16,9 +16,7 @@ edition = "2018"
 
 [dependencies]
 futures-util = "0.3.14"
-gotham = { path = "../../gotham", version = "0.6.0", default-features = false }
-gotham_derive = { path = "../../gotham_derive", version = "0.6.0" }
-serde = "1.0"
-serde_derive = "1.0"
+gotham = { path = "../../gotham", version = "0.6.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 jsonwebtoken = "7.0"
 log = "0.4"

--- a/middleware/jwt/src/lib.rs
+++ b/middleware/jwt/src/lib.rs
@@ -8,14 +8,6 @@
 //! `401: Unauthorized`.
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate gotham_derive;
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
-
 mod middleware;
 mod state_data;
 

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -33,9 +33,6 @@ const DEFAULT_SCHEME: &str = "Bearer";
 ///
 /// Example:
 /// ```rust
-/// #[macro_use]
-/// extern crate serde_derive;
-///
 /// use futures_util::future::{self, FutureExt};
 /// use gotham::hyper::{Response, StatusCode};
 /// use gotham::{
@@ -49,6 +46,7 @@ const DEFAULT_SCHEME: &str = "Bearer";
 ///     state::{FromState, State},
 /// };
 /// use gotham_middleware_jwt::{AuthorizationToken, JwtMiddleware};
+/// use serde::Deserialize;
 /// use std::pin::Pin;
 ///
 /// #[derive(Deserialize, Debug)]

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -12,7 +12,8 @@ use gotham::{
     state::{request_id, FromState, State},
 };
 use jsonwebtoken::{decode, DecodingKey, Validation};
-use serde::de::Deserialize;
+use log::trace;
+use serde::Deserialize;
 use std::pin::Pin;
 use std::{marker::PhantomData, panic::RefUnwindSafe};
 
@@ -195,6 +196,7 @@ mod tests {
         test::TestServer,
     };
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use serde::Serialize;
 
     const SECRET: &str = "some-secret";
 

--- a/middleware/jwt/src/state_data.rs
+++ b/middleware/jwt/src/state_data.rs
@@ -1,3 +1,4 @@
+use gotham::state::StateData;
 pub use jsonwebtoken::TokenData;
 
 /// Struct to contain the JSON Web Token on a per-request basis.

--- a/middleware/template/Cargo.toml
+++ b/middleware/template/Cargo.toml
@@ -15,5 +15,4 @@ futures-util = "0.3.14"
 
 # Middlewares should reference the semantic versions of Gotham that are they compatible with
 # and not use relative references such as shown here.
-gotham = { path = "../../gotham", default-features = false }
-gotham_derive = { path = "../../gotham_derive" }
+gotham = { path = "../../gotham", default-features = false, features = ["derive"] }


### PR DESCRIPTION
also uses the re-exported serde_derive crate through serde

See #71