### PR TITLE
Fix clippy lints and pin clippy version to Rust 1.54

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,8 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.54"
           components: clippy
       
       - name: Get Rust Version

--- a/examples/path/globs/src/main.rs
+++ b/examples/path/globs/src/main.rs
@@ -36,7 +36,7 @@ fn parts_handler(state: State) -> (State, String) {
 
         for part in path.parts.iter() {
             response_string.push('\n');
-            response_string.push_str(&part);
+            response_string.push_str(part);
         }
 
         response_string
@@ -57,7 +57,7 @@ fn named_parts_handler(state: State) -> (State, String) {
 
         for part in path.parts.iter() {
             response_string.push('\n');
-            response_string.push_str(&part);
+            response_string.push_str(part);
         }
 
         response_string
@@ -78,7 +78,7 @@ fn multi_parts_handler(state: State) -> (State, String) {
 
         for part in path.top.iter() {
             top.push('\n');
-            top.push_str(&part);
+            top.push_str(part);
         }
 
         let mut bottom = format!(
@@ -89,7 +89,7 @@ fn multi_parts_handler(state: State) -> (State, String) {
 
         for part in path.bottom.iter() {
             bottom.push('\n');
-            bottom.push_str(&part);
+            bottom.push_str(part);
         }
 
         vec![top, bottom].join("\n\n")

--- a/gotham/src/extractor/internal.rs
+++ b/gotham/src/extractor/internal.rs
@@ -391,7 +391,7 @@ where
     {
         self.current = self.data_source.next();
         match self.current {
-            Some((ref key, ref _v)) => {
+            Some((key, _)) => {
                 let key = seed.deserialize(DeserializeKey { key })?;
                 Ok(Some(key))
             }

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -267,7 +267,7 @@ fn check_compressed_options(
             accepted_encodings(headers)
                 .iter()
                 .filter_map(|e| {
-                    get_extension(&e.encoding, &options).map(|ext| (e.encoding.to_string(), ext))
+                    get_extension(&e.encoding, options).map(|ext| (e.encoding.to_string(), ext))
                 })
                 .find_map(|(encoding, ext)| {
                     let path = options.path.with_file_name(format!(
@@ -320,7 +320,7 @@ fn normalize_path(path: &Path) -> PathBuf {
 fn not_modified(metadata: &Metadata, headers: &HeaderMap) -> bool {
     // If-None-Match header takes precedence over If-Modified-Since
     match headers.get(IF_NONE_MATCH) {
-        Some(_) => entity_tag(&metadata)
+        Some(_) => entity_tag(metadata)
             .map(|etag| headers.get_all(IF_NONE_MATCH).iter().any(|v| v == &etag))
             .unwrap_or(false),
         _ => headers

--- a/gotham/src/middleware/cookie/mod.rs
+++ b/gotham/src/middleware/cookie/mod.rs
@@ -20,7 +20,7 @@ pub struct CookieParser;
 impl CookieParser {
     /// Parses a `CookieJar` from a `State`.
     pub fn from_state(state: &State) -> CookieJar {
-        HeaderMap::borrow_from(&state)
+        HeaderMap::borrow_from(state)
             .get_all(COOKIE)
             .iter()
             .flat_map(HeaderValue::to_str)

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -292,7 +292,7 @@ where
         state.put(SessionDropData {
             cookie_config: self.cookie_config,
         });
-        self.backend.drop_session(&state, self.identifier)
+        self.backend.drop_session(state, self.identifier)
     }
 
     // Create a new, blank `SessionData<T>`

--- a/gotham/src/router/mod.rs
+++ b/gotham/src/router/mod.rs
@@ -74,7 +74,7 @@ impl Handler for Router {
 
         let future = match state.try_take::<RequestPathSegments>() {
             Some(rps) => {
-                if let Some((node, params, processed)) = self.data.tree.traverse(&rps.segments()) {
+                if let Some((node, params, processed)) = self.data.tree.traverse(rps.segments()) {
                     match node.select_route(&state) {
                         Ok(route) => match route.delegation() {
                             Delegation::External => {

--- a/gotham/src/router/response/extender.rs
+++ b/gotham/src/router/response/extender.rs
@@ -29,7 +29,7 @@ where
     fn extend(&self, state: &mut State, res: &mut Response<B>) {
         trace!(
             "[{}] running closure based response extender",
-            request_id(&state)
+            request_id(state)
         );
         self(state, res);
     }
@@ -46,9 +46,9 @@ impl StaticResponseExtender for NoopResponseExtender {
     fn extend(state: &mut State, _res: &mut Response<Body>) {
         trace!(
             "[{}] NoopResponseExtender invoked, does not make any changes to Response",
-            request_id(&state)
+            request_id(state)
         );
-        trace!("[{}] no response body, no change made", request_id(&state));
+        trace!("[{}] no response body, no change made", request_id(state));
     }
 }
 
@@ -56,8 +56,8 @@ impl ResponseExtender<Body> for NoopResponseExtender {
     fn extend(&self, state: &mut State, _res: &mut Response<Body>) {
         trace!(
             "[{}] NoopResponseExtender invoked on instance, does not make any changes to Response",
-            request_id(&state)
+            request_id(state)
         );
-        trace!("[{}] no response body, no change made", request_id(&state));
+        trace!("[{}] no response body, no change made", request_id(state));
     }
 }

--- a/gotham/src/router/route/matcher/accept.rs
+++ b/gotham/src/router/route/matcher/accept.rs
@@ -120,7 +120,7 @@ impl AcceptHeaderRouteMatcher {
 fn err(state: &State) -> RouteNonMatch {
     trace!(
         "[{}] did not provide an Accept with media types supported by this Route",
-        request_id(&state)
+        request_id(state)
     );
 
     RouteNonMatch::new(StatusCode::NOT_ACCEPTABLE)
@@ -199,23 +199,23 @@ mod test {
     #[test]
     fn no_accept_header() {
         let matcher = AcceptHeaderRouteMatcher::new(vec![mime::TEXT_PLAIN]);
-        with_state(None, |state| assert!(matcher.is_match(&state).is_ok()));
+        with_state(None, |state| assert!(matcher.is_match(state).is_ok()));
     }
 
     #[test]
     fn single_mime_type() {
         let matcher = AcceptHeaderRouteMatcher::new(vec![mime::TEXT_PLAIN, mime::IMAGE_PNG]);
         with_state(Some("text/plain"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("text/html"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
         with_state(Some("image/png"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("image/webp"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
     }
 
@@ -223,7 +223,7 @@ mod test {
     fn star_star() {
         let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
         with_state(Some("*/*"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
     }
 
@@ -231,7 +231,7 @@ mod test {
     fn image_star() {
         let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
         with_state(Some("image/*"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
     }
 
@@ -239,10 +239,10 @@ mod test {
     fn suffix_matched_by_wildcard() {
         let matcher = AcceptHeaderRouteMatcher::new(vec!["application/rss+xml".parse().unwrap()]);
         with_state(Some("*/*"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("application/*"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
     }
 
@@ -250,10 +250,10 @@ mod test {
     fn complex_header() {
         let matcher = AcceptHeaderRouteMatcher::new(vec![mime::IMAGE_PNG]);
         with_state(Some("text/html,image/webp;q=0.8"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
         with_state(Some("text/html,image/webp;q=0.8,*/*;q=0.1"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
     }
 }

--- a/gotham/src/router/route/matcher/access_control_request_method.rs
+++ b/gotham/src/router/route/matcher/access_control_request_method.rs
@@ -85,17 +85,17 @@ mod test {
     #[test]
     fn no_acrm_header() {
         let matcher = AccessControlRequestMethodMatcher::new(Method::PUT);
-        with_state(None, |state| assert!(matcher.is_match(&state).is_err()));
+        with_state(None, |state| assert!(matcher.is_match(state).is_err()));
     }
 
     #[test]
     fn correct_acrm_header() {
         let matcher = AccessControlRequestMethodMatcher::new(Method::PUT);
         with_state(Some("PUT"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("put"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
     }
 
@@ -103,7 +103,7 @@ mod test {
     fn incorrect_acrm_header() {
         let matcher = AccessControlRequestMethodMatcher::new(Method::PUT);
         with_state(Some("DELETE"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
     }
 }

--- a/gotham/src/router/route/matcher/content_type.rs
+++ b/gotham/src/router/route/matcher/content_type.rs
@@ -87,7 +87,7 @@ impl ContentTypeHeaderRouteMatcher {
 fn err(state: &State) -> RouteNonMatch {
     trace!(
         "[{}] did not specify a Content-Type with a media type supported by this Route",
-        request_id(&state)
+        request_id(state)
     );
 
     RouteNonMatch::new(StatusCode::UNSUPPORTED_MEDIA_TYPE)
@@ -167,24 +167,24 @@ mod test {
     #[test]
     fn empty_type_list() {
         let matcher = ContentTypeHeaderRouteMatcher::new(Vec::new());
-        with_state(None, |state| assert!(matcher.is_match(&state).is_err()));
+        with_state(None, |state| assert!(matcher.is_match(state).is_err()));
         with_state(Some("text/plain"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
 
         let matcher = matcher.allow_no_type();
-        with_state(None, |state| assert!(matcher.is_match(&state).is_ok()));
+        with_state(None, |state| assert!(matcher.is_match(state).is_ok()));
     }
 
     #[test]
     fn simple_type() {
         let matcher = ContentTypeHeaderRouteMatcher::new(vec![mime::TEXT_PLAIN]);
-        with_state(None, |state| assert!(matcher.is_match(&state).is_err()));
+        with_state(None, |state| assert!(matcher.is_match(state).is_err()));
         with_state(Some("text/plain"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("text/plain; charset=utf-8"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
     }
 
@@ -194,22 +194,22 @@ mod test {
             .parse()
             .unwrap()]);
         with_state(Some("image/svg"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
         with_state(Some("image/svg+xml"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
         with_state(Some("image/svg+xml; charset=utf-8"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("image/svg+xml; charset=utf-8; eol=lf"), |state| {
-            assert!(matcher.is_match(&state).is_ok())
+            assert!(matcher.is_match(state).is_ok())
         });
         with_state(Some("image/svg+xml; charset=us-ascii"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
         with_state(Some("image/svg+json; charset=utf-8"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
     }
 
@@ -217,7 +217,7 @@ mod test {
     fn type_mismatch() {
         let matcher = ContentTypeHeaderRouteMatcher::new(vec![mime::TEXT_HTML]);
         with_state(Some("text/plain"), |state| {
-            assert!(matcher.is_match(&state).is_err())
+            assert!(matcher.is_match(state).is_err())
         });
     }
 }

--- a/gotham/src/router/route/matcher/mod.rs
+++ b/gotham/src/router/route/matcher/mod.rs
@@ -103,14 +103,14 @@ impl RouteMatcher for MethodOnlyRouteMatcher {
         if self.methods.iter().any(|m| m == method) {
             trace!(
                 "[{}] matched request method {} to permitted method",
-                request_id(&state),
+                request_id(state),
                 method
             );
             Ok(())
         } else {
             trace!(
                 "[{}] did not match request method {}",
-                request_id(&state),
+                request_id(state),
                 method
             );
             Err(RouteNonMatch::new(StatusCode::METHOD_NOT_ALLOWED)

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -178,7 +178,7 @@ where
         match extractor::internal::from_segment_mapping::<PE>(params) {
             Ok(val) => Ok(state.put(val)),
             Err(e) => {
-                debug!("[{}] path extractor failed: {}", request_id(&state), e);
+                debug!("[{}] path extractor failed: {}", request_id(state), e);
                 Err(ExtractorFailed)
             }
         }
@@ -200,7 +200,7 @@ where
             Err(e) => {
                 debug!(
                     "[{}] query string extractor failed: {}",
-                    request_id(&state),
+                    request_id(state),
                     e
                 );
                 Err(ExtractorFailed)

--- a/gotham/src/router/tree/node.rs
+++ b/gotham/src/router/tree/node.rs
@@ -206,7 +206,7 @@ impl Node {
                     params
                         .entry(&child.segment)
                         .or_insert_with(Vec::new)
-                        .push(&segment);
+                        .push(segment);
                 }
 
                 // Static matches based on a raw string match, so we simply
@@ -224,11 +224,11 @@ impl Node {
                 // to make sure to store the value inside the parameters map.
                 SegmentType::Constrained { ref regex } => {
                     // check for regex matching
-                    if !regex.is_match(&segment.as_ref()) {
+                    if !regex.is_match(segment.as_ref()) {
                         continue;
                     }
                     // if there's a match, store the value
-                    params.insert(&child.segment, vec![&segment]);
+                    params.insert(&child.segment, vec![segment]);
                 }
 
                 // Dynamic matches match every value, so we just attach the
@@ -236,7 +236,7 @@ impl Node {
                 // constrained type).
                 SegmentType::Dynamic => {
                     // if there's a match, store the value
-                    params.insert(&child.segment, vec![&segment]);
+                    params.insert(&child.segment, vec![segment]);
                 }
             };
 
@@ -252,7 +252,7 @@ impl Node {
         if let SegmentType::Glob = self.segment_type {
             // push the segment to the parameters of the glob
             if let Some(path) = params.get_mut(self.segment()) {
-                path.push(&segment);
+                path.push(segment);
             }
             // call again, but after shifting the segments to the next
             return self.inner_match_node(remaining, params, processed);
@@ -443,7 +443,7 @@ mod tests {
 
         // GET /seg3/seg4
         let rs = RequestPathSegments::new("/seg3/seg4");
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg4");
                 assert_eq!(processed, 2);
@@ -453,11 +453,11 @@ mod tests {
 
         // GET /seg3/seg4/seg5
         let rs = RequestPathSegments::new("/seg3/seg4/seg5");
-        assert!(root.match_node(&rs.segments()).is_none());
+        assert!(root.match_node(rs.segments()).is_none());
 
         // GET /seg5/seg6
         let rs = RequestPathSegments::new("/seg5/seg6");
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg6");
                 assert_eq!(processed, 2);
@@ -467,7 +467,7 @@ mod tests {
 
         // GET /seg5/someval/seg7
         let rs = RequestPathSegments::new("/seg5/someval/seg7");
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg7");
                 assert_eq!(processed, 3);
@@ -477,7 +477,7 @@ mod tests {
 
         // GET /some/path/seg9/another/path
         let rs = RequestPathSegments::new("/some/path/seg9/another/branch");
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, "seg10");
                 assert_eq!(processed, 5);
@@ -487,7 +487,7 @@ mod tests {
 
         let rs = RequestPathSegments::new("/resource/5001");
         let expected_segment = "id";
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, processed)) => {
                 assert_eq!(node.segment, expected_segment);
                 assert_eq!(processed, 2);
@@ -506,7 +506,7 @@ mod tests {
         set_request_id(&mut state);
 
         let rs = RequestPathSegments::new("/seg2");
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, _processed)) => match node.select_route(&state) {
                 Err(e) => {
                     let (status, mut allow_list) = e.deconstruct();
@@ -520,7 +520,7 @@ mod tests {
         }
 
         let rs = RequestPathSegments::new("/resource/100");
-        match root.match_node(&rs.segments()) {
+        match root.match_node(rs.segments()) {
             Some((node, _params, _processed)) => match node.select_route(&state) {
                 Err(e) => {
                     let (status, mut allow_list) = e.deconstruct();

--- a/gotham/src/state/client_addr.rs
+++ b/gotham/src/state/client_addr.rs
@@ -57,5 +57,5 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #   assert_eq!(buf[..10], b"127.0.0.1:9816"[0..10]);
 /// # }
 pub fn client_addr(state: &State) -> Option<SocketAddr> {
-    ClientAddr::try_borrow_from(&state).map(|c| c.addr)
+    ClientAddr::try_borrow_from(state).map(|c| c.addr)
 }

--- a/middleware/jwt/src/middleware.rs
+++ b/middleware/jwt/src/middleware.rs
@@ -147,7 +147,7 @@ where
         }
 
         let decoding_key = DecodingKey::from_secret(self.secret.as_ref());
-        match decode::<T>(&token.unwrap(), &decoding_key, &self.validation) {
+        match decode::<T>(token.unwrap(), &decoding_key, &self.validation) {
             Ok(token) => {
                 state.put(AuthorizationToken(token));
 


### PR DESCRIPTION
We can (and possibly should) update the rust version in the future. However, I don't like new errors showing up on unrelated changes.