### PR TITLE
Fix tarpaulin not compiling our askama example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,8 @@ members = [
     "examples/custom_service/",
 
 ]
+
+[patch.crates-io]
+# bitvec doesn't compile when tarpaulin-specific cfg is set
+# however, bitvec isn't required by nom, so we patch it out
+nom = { git = "https://github.com/djc/nom", rev = "9e999b1e110b26a275ecd8e17f7d091400836599" } # branch = "bitvec-not-default"

--- a/examples/templating/askama/Cargo.toml
+++ b/examples/templating/askama/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2018"
 [dependencies]
 gotham = { path = "../../../gotham" }
 askama = "0.10.3"
+
+# see comment in the workspace root
+nom = "=6.2.0"


### PR DESCRIPTION
This is due to bitvec not compiling when tarpaulin-specific cfg! are set
by simply removing nom's optional-but-cargo-doesn't-know depedency to it