### PR TITLE
Remove TestServer::client_with_address

### DIFF
--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -3,7 +3,7 @@
 //! See the `TestServer` type for example usage.
 
 use std::future::Future;
-use std::net::{self, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -97,15 +97,6 @@ impl TestServer {
         F: Future<Output = ()> + Send + 'static,
     {
         self.data.spawn(future)
-    }
-
-    /// Exactly the same as [`TestServer::client`].
-    #[deprecated(since = "0.3.0", note = "does the same as client")]
-    pub fn client_with_address(
-        &self,
-        _client_addr: net::SocketAddr,
-    ) -> TestClient<Self, TestConnect> {
-        self.client()
     }
 }
 

--- a/gotham/src/state/client_addr.rs
+++ b/gotham/src/state/client_addr.rs
@@ -19,7 +19,6 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// # Examples
 ///
 /// ```rust
-/// # #![allow(deprecated)]
 /// # extern crate gotham;
 /// # extern crate hyper;
 /// # extern crate mime;
@@ -46,7 +45,7 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// # fn main() {
 /// #   let test_server = TestServer::new(|| Ok(my_handler)).unwrap();
 /// #   let response = test_server
-/// #       .client_with_address("127.0.0.1:9816".parse().unwrap())
+/// #       .client()
 /// #       .get("http://localhost/")
 /// #       .perform()
 /// #       .unwrap();
@@ -55,7 +54,7 @@ pub(crate) fn put_client_addr(state: &mut State, addr: SocketAddr) {
 /// #
 /// #   let buf = response.read_body().unwrap();
 /// #   // at the moment, can't actually force the client address
-/// #   assert_eq!(buf[..10], b"127.0.0.1:9816"[0..10]);
+/// #   assert!(buf.starts_with(b"127.0.0.1"));
 /// # }
 pub fn client_addr(state: &State) -> Option<SocketAddr> {
     ClientAddr::try_borrow_from(state).map(|c| c.addr)

--- a/gotham/src/tls/test.rs
+++ b/gotham/src/tls/test.rs
@@ -4,7 +4,7 @@
 
 use std::future::Future;
 use std::io::{self, BufReader};
-use std::net::{self, SocketAddr};
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -120,15 +120,6 @@ impl TestServer {
         F: Future<Output = ()> + Send + 'static,
     {
         self.data.spawn(future)
-    }
-
-    /// Exactly the same as [`TestServer::client`].
-    #[deprecated(note = "does the same as client")]
-    pub fn client_with_address(
-        &self,
-        _client_addr: net::SocketAddr,
-    ) -> TestClient<Self, TestConnect> {
-        self.client()
     }
 }
 


### PR DESCRIPTION
This method wasn't working as expected / documented for a while
now and has been deprecated in #522

Since nobody ever created an issue about this, I assume this method
is completely unused and therefore I believe it should be removed.