### PR TITLE
CI: Update Rust toolchain for clippy to 1.58

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.54"
+          toolchain: "1.58"
           components: clippy
       
       - name: Get Rust Version

--- a/gotham/src/middleware/session/mod.rs
+++ b/gotham/src/middleware/session/mod.rs
@@ -813,7 +813,7 @@ where
                 self.backend
                     .read_session(&state, id.clone())
                     .then(move |r| self.load_session_into_state(state, id, r))
-                    .and_then(move |state| chain(state))
+                    .and_then(chain)
                     .and_then(persist_session::<T>)
                     .boxed()
             }

--- a/gotham/src/router/builder/draw.rs
+++ b/gotham/src/router/builder/draw.rs
@@ -913,11 +913,7 @@ where
     P: RefUnwindSafe + Send + Sync + 'static,
 {
     fn component_refs(&mut self) -> (&mut Node, &mut C, &PipelineSet<P>) {
-        (
-            &mut self.node_builder,
-            &mut self.pipeline_chain,
-            &self.pipelines,
-        )
+        (self.node_builder, &mut self.pipeline_chain, &self.pipelines)
     }
 }
 
@@ -927,11 +923,7 @@ where
     P: RefUnwindSafe + Send + Sync + 'static,
 {
     fn component_refs(&mut self) -> (&mut Node, &mut C, &PipelineSet<P>) {
-        (
-            &mut self.node_builder,
-            &mut self.pipeline_chain,
-            &self.pipelines,
-        )
+        (self.node_builder, &mut self.pipeline_chain, &self.pipelines)
     }
 }
 


### PR DESCRIPTION
This enables dependencies to use the new Rust 2021 editition