### PR TITLE
Bump Clippy version to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.58"
+          toolchain: "1.63"
           components: clippy
       
       - name: Get Rust Version

--- a/examples/diesel/src/models.rs
+++ b/examples/diesel/src/models.rs
@@ -1,5 +1,9 @@
 //! Holds the two possible structs that are `Queryable` and
 //! `Insertable` in the DB
+
+// This warning is triggered by diesel's derive macros
+#![allow(clippy::extra_unused_lifetimes)]
+
 use diesel::{Insertable, Queryable};
 use serde::{Deserialize, Serialize};
 

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -1,8 +1,6 @@
 //! An introduction to storing and retrieving session data, in a type safe way, with the Gotham
 //! web framework.
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::get_unwrap))]
-
 use gotham::middleware::session::{NewSessionMiddleware, SessionData};
 use gotham::pipeline::{new_pipeline, single_pipeline};
 use gotham::prelude::*;
@@ -87,7 +85,7 @@ mod tests {
                 .flat_map(|hv| hv.to_str())
                 .collect();
             assert!(set_cookie.len() == 1);
-            set_cookie.get(0).unwrap().to_string().parse().unwrap()
+            set_cookie.first().unwrap().to_string().parse().unwrap()
         };
 
         let body = response.read_body().unwrap();

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -68,7 +68,7 @@ pub struct FileHandler {
 ///
 /// assert_eq!(default_options, from_builder);
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FileOptions {
     path: PathBuf,
     cache_control: String,
@@ -121,7 +121,7 @@ impl FileOptions {
 /// which have a constraint `FileOptions: From<P>` for default options.
 macro_rules! derive_from {
     ($type:ty) => {
-        impl<'a> From<$type> for FileOptions {
+        impl From<$type> for FileOptions {
             fn from(t: $type) -> FileOptions {
                 FileOptions::new(t)
             }
@@ -129,10 +129,10 @@ macro_rules! derive_from {
     };
 }
 
-derive_from!(&'a Path);
+derive_from!(&Path);
 derive_from!(PathBuf);
-derive_from!(&'a str);
-derive_from!(&'a String);
+derive_from!(&str);
+derive_from!(&String);
 derive_from!(String);
 
 impl FileHandler {

--- a/gotham/src/helpers/http/mod.rs
+++ b/gotham/src/helpers/http/mod.rs
@@ -8,7 +8,7 @@ use log::trace;
 use percent_encoding::percent_decode;
 
 /// Represents data that has been successfully percent decoded and is valid UTF-8
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PercentDecoded {
     val: String,
 }
@@ -45,7 +45,7 @@ impl AsRef<str> for PercentDecoded {
 /// Decode form-urlencoded strings (e.g. query string, or request body with Content-Type:
 /// application/x-www-form-urlencoded
 fn form_url_decode(raw: &str) -> Result<String, std::str::Utf8Error> {
-    match percent_decode(raw.replace("+", " ").as_bytes()).decode_utf8() {
+    match percent_decode(raw.replace('+', " ").as_bytes()).decode_utf8() {
         Ok(pd) => {
             trace!(" form_url_decode: {}, src: {}", pd, raw);
             Ok(pd.into_owned())

--- a/gotham/src/helpers/http/request/path.rs
+++ b/gotham/src/helpers/http/request/path.rs
@@ -7,7 +7,7 @@ const EXCLUDED_SEGMENTS: [&str; 1] = [""];
 /// Holder for `Request` URI path segments that have been split into individual segments.
 ///
 /// Used internally by the `Router` when traversing its internal `Tree`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RequestPathSegments {
     segments: Vec<PercentDecoded>,
 }

--- a/gotham/src/middleware/session/backend/memory.rs
+++ b/gotham/src/middleware/session/backend/memory.rs
@@ -278,7 +278,7 @@ mod tests {
         .expect("failed to persist");
 
         {
-            let mut storage = backend.storage.lock().expect("couldn't lock storage");
+            let storage = backend.storage.lock().expect("couldn't lock storage");
             assert_eq!(
                 storage.front().expect("no front element").0,
                 &identifier.value
@@ -295,7 +295,7 @@ mod tests {
 
         {
             // Identifiers have swapped
-            let mut storage = backend.storage.lock().expect("couldn't lock storage");
+            let storage = backend.storage.lock().expect("couldn't lock storage");
             assert_eq!(
                 storage.front().expect("no front element").0,
                 &identifier2.value

--- a/gotham/src/pipeline/chain.rs
+++ b/gotham/src/pipeline/chain.rs
@@ -35,7 +35,7 @@ pub trait PipelineHandleChain<P>: RefUnwindSafe {
 }
 
 /// Part of a `PipelineHandleChain` which references a `Pipeline` and continues with a tail element.
-impl<'a, P, T, N, U> PipelineHandleChain<P> for (Handle<Pipeline<T>, N>, U)
+impl<P, T, N, U> PipelineHandleChain<P> for (Handle<Pipeline<T>, N>, U)
 where
     T: NewMiddlewareChain,
     T::Instance: Send + 'static,

--- a/gotham/src/router/route/mod.rs
+++ b/gotham/src/router/route/mod.rs
@@ -23,7 +23,7 @@ use crate::router::route::matcher::RouteMatcher;
 use crate::router::tree::segment::SegmentMapping;
 use crate::state::{request_id, State};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 /// Indicates whether this `Route` will dispatch the request to an inner `Router` instance. To
 /// support inner `Router` instances which handle a subtree, the `Dispatcher` stores additional
 /// context information.


### PR DESCRIPTION
This PR updates the clippy version used in CI to 1.63 and fixes the newly lints introduced lints. This most notably involves adding a few `#[derive(Eq)]` for types that already derive `PartialEq`.

Bumping the clippy version is necessary as the `time` dependency requires a newer rust version to compile.