### PR TITLE
Bump minimal versions of anyhow, thiserror and serde

### DIFF
--- a/examples/diesel/Cargo.toml
+++ b/examples/diesel/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 gotham = { path = "../../gotham/"}
 gotham_middleware_diesel = { path = "../../middleware/diesel"}
 
-diesel = { version = "2.0", features = ["r2d2", "sqlite"] }
-diesel_migrations = { version = "2.0", features = ["sqlite"] }
+diesel = { version = "2.1", features = ["r2d2", "sqlite"] }
+diesel_migrations = { version = "2.1", features = ["sqlite"] }
 futures-util = "0.3.14"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/templating/tera/Cargo.toml
+++ b/examples/templating/tera/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-tera = "1.5"
+tera = "1.6"
 lazy_static = "1.0"

--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -29,7 +29,7 @@ testing = ["hyper/client"]
 borrow-bag = { path = "../misc/borrow_bag", version = "1.1" }
 gotham_derive = { path = "../gotham_derive", version = "0.7.1", optional = true }
 
-anyhow = "1.0"
+anyhow = "1.0.5"
 base64 = "0.21"
 bincode = { version = "1.0", optional = true }
 bytes = "1.0"
@@ -47,9 +47,9 @@ pin-project = "1.0.0"
 rand = "0.8"
 rand_chacha = "0.3"
 regex = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
-time = {version = "0.3.4", default-features = false, features = ["std", "formatting", "macros"]}
+serde = { version = "1.0.186", features = ["derive"] }
+thiserror = "1.0.2"
+time = { version = "0.3.4", default-features = false, features = ["std", "formatting", "macros"] }
 tokio = { version = "1.11.0", features = ["net", "rt-multi-thread", "time", "fs", "io-util"] }
 tokio-rustls = { version = "0.23", optional = true }
 uuid = { version = "1.0", features = ["v4"] }

--- a/middleware/diesel/Cargo.toml
+++ b/middleware/diesel/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["http", "async", "web", "gotham", "diesel"]
 [dependencies]
 gotham = { path = "../../gotham", version = "0.7.1", default-features = false, features = ["derive"] }
 
-diesel = { version = "2.0", features = ["r2d2"] }
+diesel = { version = "2.1", features = ["r2d2"] }
 futures-util = "0.3.14"
 log = "0.4"
 tokio = { version = "1.0", features = ["full"] }
@@ -22,4 +22,4 @@ tokio = { version = "1.0", features = ["full"] }
 [dev-dependencies]
 gotham = { path = "../../gotham", version = "0.7.1", default-features = false, features = ["testing"] }
 
-diesel = { version = "2.0.0", features = ["sqlite"] }
+diesel = { version = "2.1", features = ["sqlite"] }


### PR DESCRIPTION
We actually require `anyhow` 1.0.5 and upwards to allow `anyhow::Error` to be used with hyper, and `thiserror` 1.0.2 to use the `#[from]` attribute. I also bumped serde to the oldest version after switching back to from-source compilation.