### PR TITLE
Re-export `cookie`

### DIFF
--- a/examples/cookies/introduction/Cargo.toml
+++ b/examples/cookies/introduction/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-cookie = "0.15"

--- a/examples/cookies/introduction/src/main.rs
+++ b/examples/cookies/introduction/src/main.rs
@@ -1,6 +1,6 @@
 //! An introduction to storing and retrieving cookie data, with the Gotham
 //! web framework.
-use cookie::{Cookie, CookieJar};
+use gotham::cookie::{Cookie, CookieJar};
 use gotham::helpers::http::response::create_response;
 use gotham::hyper::header::SET_COOKIE;
 use gotham::hyper::{Body, Response, StatusCode};
@@ -59,7 +59,7 @@ pub fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cookie::Cookie;
+    use gotham::cookie::Cookie;
     use gotham::hyper::header::COOKIE;
     use gotham::test::TestServer;
 

--- a/examples/sessions/custom_data_type/Cargo.toml
+++ b/examples/sessions/custom_data_type/Cargo.toml
@@ -9,6 +9,5 @@ edition = "2018"
 [dependencies]
 gotham = { path = "../../../gotham" }
 
-cookie = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 time = { version = "0.3.0", features = ["formatting", "local-offset"] }

--- a/examples/sessions/introduction/Cargo.toml
+++ b/examples/sessions/introduction/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2018"
 
 [dependencies]
 gotham = { path = "../../../gotham" }
-cookie = "0.15"

--- a/examples/sessions/introduction/src/main.rs
+++ b/examples/sessions/introduction/src/main.rs
@@ -61,7 +61,7 @@ pub fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cookie::Cookie;
+    use gotham::cookie::Cookie;
     use gotham::hyper::header::{COOKIE, SET_COOKIE};
     use gotham::hyper::StatusCode;
     use gotham::test::TestServer;

--- a/gotham/src/lib.rs
+++ b/gotham/src/lib.rs
@@ -49,6 +49,8 @@ pub mod tls;
 
 /// Re-export anyhow
 pub use anyhow;
+/// Re-export cookie
+pub use cookie;
 /// Re-export hyper
 pub use hyper;
 /// Re-export mime


### PR DESCRIPTION
`cookie` is a public dependency of gotham, so I believe it makes sense to re-export it.