### PR TITLE
assets: add range request support for FileHandler

### DIFF
--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -519,7 +519,7 @@ mod tests {
     use hyper::header::*;
     use hyper::StatusCode;
     use std::fs::File;
-    use std::io::{Read, SeekFrom};
+    use std::io::{Read, Seek, SeekFrom};
     use std::path::PathBuf;
     use std::{fs, str};
     #[test]
@@ -949,7 +949,7 @@ mod tests {
                 assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE);
                 break;
             }
-            std::io::Seek::seek(&mut file, SeekFrom::Start(range_start)).unwrap();
+            file.seek(SeekFrom::Start(range_start)).unwrap();
 
             let expected_content_range = format!(
                 "bytes {}-{}/{}",


### PR DESCRIPTION
This adds range request support for FileHandler. This is a critical feature for handling large files, or any application that will require range request support, e.g. video or audio streaming.

This implementation currentyl only supports ranges that result in a single response, i.e. multiple ranges are not supported.

This implementation will return an error if a range is open from both ends, or if the range beginning is larger than the end.