### PR TITLE
assets: Fix range request status code

### DIFF
--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -251,7 +251,7 @@ fn create_file_response(options: FileOptions, state: State) -> Pin<Box<HandlerFu
                 (range_start + len).saturating_sub(1),
                 meta.len()
             );
-            response = response.header(
+            response = response.status(StatusCode::PARTIAL_CONTENT).header(
                 CONTENT_RANGE,
                 HeaderValue::from_str(&val).map_err(|e| io::Error::new(ErrorKind::Other, e))?,
             );
@@ -949,6 +949,7 @@ mod tests {
                 assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE);
                 break;
             }
+            assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
             file.seek(SeekFrom::Start(range_start)).unwrap();
 
             let expected_content_range = format!(


### PR DESCRIPTION
Should return partial content (206) rather than (200) RFC 9110, section 14.2: "the server SHOULD send a 206 (Partial Content) response with content containing one or more partial representations"

This commit addresses issue #631 