### PR TITLE
assets: add support for configurable bufsize for FileHandler

### DIFF
--- a/gotham/Cargo.toml
+++ b/gotham/Cargo.toml
@@ -55,8 +55,15 @@ tokio-rustls = { version = "0.23", optional = true }
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
+criterion = { version = "0.5.1", features = ["cargo_bench_support", "plotters", "rayon", "async_futures", "async_tokio"] }
 futures-executor = "0.3.14"
+reqwest = "0.12.2"
+tempfile = "3.10.1"
 tokio = { version = "1.11.0", features = ["macros", "test-util"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "file_handler"
+harness = false

--- a/gotham/benches/file_handler.rs
+++ b/gotham/benches/file_handler.rs
@@ -1,0 +1,117 @@
+use std::{collections::HashMap, fs::File, io::{BufWriter, Write}, net::{SocketAddr, ToSocketAddrs}, sync::atomic::{AtomicU64, Ordering::Relaxed}, time::{Duration, SystemTime}};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures_util::future;
+use gotham::{
+    bind_server, handler::FileOptions, router::{
+        build_simple_router,
+        builder::{DefineSingleRoute, DrawRoutes},
+    }
+};
+use tempfile::TempDir;
+use tokio::{net::TcpListener, runtime::{self, Runtime}};
+
+struct BenchServer {
+    runtime: Runtime,
+    addr: SocketAddr,
+    #[allow(dead_code)]
+    tmp: TempDir,
+    // sizes of test files
+    sizes: Vec<u64>,
+    buf_paths: HashMap<String, Option<usize>>,
+}
+
+impl BenchServer {
+    fn new() -> anyhow::Result<Self> {
+        let tmp = TempDir::new()?;
+        // temporary datafiles
+        let sizes = [10, 17, 24 ].iter().filter_map(|sz| {
+            let size = 1 << sz;
+            mk_tmp(&tmp, size).ok()
+        }).collect();
+        let buf_paths = HashMap::from([
+            ("default".to_string(), None),
+            ("128k".to_string(), Some(1 << 17))
+        ]);
+        
+        let router = build_simple_router(|route| {
+            for (path, sz) in &buf_paths {
+                let mut opts = FileOptions::from(tmp.path().to_owned());
+                if let Some(size) = sz {
+                    opts.with_buffer_size(*size);
+                }
+                route.get(format!("/{path}/*").as_str()).to_dir(opts.to_owned())
+            }
+        });
+        let runtime = runtime::Builder::new_multi_thread()
+            .worker_threads(num_cpus::get())
+            .thread_name("file_handler-bench")
+            .enable_all()
+            .build()
+            .unwrap();
+        // build server manually so that we can capture the actual port instead of 0
+        let addr: std::net::SocketAddr = "127.0.0.1:0".to_socket_addrs().unwrap().next().unwrap();
+        let listener = runtime.block_on(TcpListener::bind(addr)).unwrap();
+        // use any free port
+        let addr = listener.local_addr().unwrap();
+        let _ = runtime.spawn( async move {
+            bind_server(listener, router, future::ok).await;
+        });
+        std::thread::sleep(Duration::from_millis(100));
+        Ok(Self { runtime, addr, tmp, sizes, buf_paths })
+    }
+}
+
+fn mk_tmp(tmp: &TempDir, size: u64) -> anyhow::Result<u64> {
+    let filename = tmp.path().join(format!("{size}"));
+    let file = File::create(filename)?;
+    let mut w = BufWriter::with_capacity(2 << 16, file);
+    // pseudo random data: time stamp as bytes
+    let ts_data = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos().to_le_bytes();
+    for _ in (0..size).step_by(ts_data.len()) {
+        w.write_all(&ts_data)?;
+    }
+    Ok(size)
+}
+
+pub fn filehandler_benchmark(c: &mut Criterion) {
+    let server = BenchServer::new().unwrap();
+
+    let runtime = server.runtime;
+    let client = reqwest::Client::builder().build().unwrap();
+    let counter = AtomicU64::new(0);
+    let failed = AtomicU64::new(0);
+
+    for file_size in server.sizes {
+        let mut group = c.benchmark_group("server_bench");
+        group.throughput(Throughput::Bytes(file_size));
+        for (path, buf_size) in &server.buf_paths {
+            let url = format!("http://{}/{path}/{file_size}", server.addr);
+            let req = client.get(url).build().unwrap();
+            group.bench_with_input(BenchmarkId::new("test_file_handler", 
+                format!("filesize: {file_size}, bufsize: {buf_size:?}")), &req, |b, req| {
+                b.to_async(&runtime).iter(|| async {
+                        let r = client.execute(req.try_clone().unwrap()).await;
+                        counter.fetch_add(1, Relaxed);
+                        match r {
+                            Err(_) => { failed.fetch_add(1, Relaxed); },
+                            Ok(res) => {
+                                // sanity check: did we get what was expected?
+                                assert_eq!(res.content_length().unwrap(), file_size);
+                                let _ = res.bytes().await.unwrap();
+                            }
+                        }
+                });
+            });
+        }
+    }
+    println!("Errors {}/{}", failed.load(Relaxed), counter.load(Relaxed));
+}
+
+criterion_group!{
+    name = file_handler;
+    config = Criterion::default().measurement_time(Duration::from_millis(10_000)).warm_up_time(Duration::from_millis(10));
+    targets = filehandler_benchmark
+}
+
+criterion_main!(file_handler);

--- a/gotham/benches/file_handler.rs
+++ b/gotham/benches/file_handler.rs
@@ -1,15 +1,27 @@
-use std::{collections::HashMap, fs::File, io::{BufWriter, Write}, net::{SocketAddr, ToSocketAddrs}, sync::atomic::{AtomicU64, Ordering::Relaxed}, time::{Duration, SystemTime}};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufWriter, Write},
+    net::{SocketAddr, ToSocketAddrs},
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+    time::{Duration, SystemTime},
+};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures_util::future;
 use gotham::{
-    bind_server, handler::FileOptions, router::{
+    bind_server,
+    handler::FileOptions,
+    router::{
         build_simple_router,
         builder::{DefineSingleRoute, DrawRoutes},
-    }
+    },
 };
 use tempfile::TempDir;
-use tokio::{net::TcpListener, runtime::{self, Runtime}};
+use tokio::{
+    net::TcpListener,
+    runtime::{self, Runtime},
+};
 
 struct BenchServer {
     runtime: Runtime,
@@ -25,22 +37,27 @@ impl BenchServer {
     fn new() -> anyhow::Result<Self> {
         let tmp = TempDir::new()?;
         // temporary datafiles
-        let sizes = [10, 17, 24 ].iter().filter_map(|sz| {
-            let size = 1 << sz;
-            mk_tmp(&tmp, size).ok()
-        }).collect();
+        let sizes = [10, 17, 24]
+            .iter()
+            .filter_map(|sz| {
+                let size = 1 << sz;
+                mk_tmp(&tmp, size).ok()
+            })
+            .collect();
         let buf_paths = HashMap::from([
             ("default".to_string(), None),
-            ("128k".to_string(), Some(1 << 17))
+            ("128k".to_string(), Some(1 << 17)),
         ]);
-        
+
         let router = build_simple_router(|route| {
             for (path, sz) in &buf_paths {
                 let mut opts = FileOptions::from(tmp.path().to_owned());
                 if let Some(size) = sz {
                     opts.with_buffer_size(*size);
                 }
-                route.get(format!("/{path}/*").as_str()).to_dir(opts.to_owned())
+                route
+                    .get(format!("/{path}/*").as_str())
+                    .to_dir(opts.to_owned())
             }
         });
         let runtime = runtime::Builder::new_multi_thread()
@@ -54,11 +71,17 @@ impl BenchServer {
         let listener = runtime.block_on(TcpListener::bind(addr)).unwrap();
         // use any free port
         let addr = listener.local_addr().unwrap();
-        let _ = runtime.spawn( async move {
+        let _ = runtime.spawn(async move {
             bind_server(listener, router, future::ok).await;
         });
         std::thread::sleep(Duration::from_millis(100));
-        Ok(Self { runtime, addr, tmp, sizes, buf_paths })
+        Ok(Self {
+            runtime,
+            addr,
+            tmp,
+            sizes,
+            buf_paths,
+        })
     }
 }
 
@@ -67,7 +90,11 @@ fn mk_tmp(tmp: &TempDir, size: u64) -> anyhow::Result<u64> {
     let file = File::create(filename)?;
     let mut w = BufWriter::with_capacity(2 << 16, file);
     // pseudo random data: time stamp as bytes
-    let ts_data = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos().to_le_bytes();
+    let ts_data = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+        .to_le_bytes();
     for _ in (0..size).step_by(ts_data.len()) {
         w.write_all(&ts_data)?;
     }
@@ -88,27 +115,35 @@ pub fn filehandler_benchmark(c: &mut Criterion) {
         for (path, buf_size) in &server.buf_paths {
             let url = format!("http://{}/{path}/{file_size}", server.addr);
             let req = client.get(url).build().unwrap();
-            group.bench_with_input(BenchmarkId::new("test_file_handler", 
-                format!("filesize: {file_size}, bufsize: {buf_size:?}")), &req, |b, req| {
-                b.to_async(&runtime).iter(|| async {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    "test_file_handler",
+                    format!("filesize: {file_size}, bufsize: {buf_size:?}"),
+                ),
+                &req,
+                |b, req| {
+                    b.to_async(&runtime).iter(|| async {
                         let r = client.execute(req.try_clone().unwrap()).await;
                         counter.fetch_add(1, Relaxed);
                         match r {
-                            Err(_) => { failed.fetch_add(1, Relaxed); },
+                            Err(_) => {
+                                failed.fetch_add(1, Relaxed);
+                            }
                             Ok(res) => {
                                 // sanity check: did we get what was expected?
                                 assert_eq!(res.content_length().unwrap(), file_size);
                                 let _ = res.bytes().await.unwrap();
                             }
                         }
-                });
-            });
+                    });
+                },
+            );
         }
     }
     println!("Errors {}/{}", failed.load(Relaxed), counter.load(Relaxed));
 }
 
-criterion_group!{
+criterion_group! {
     name = file_handler;
     config = Criterion::default().measurement_time(Duration::from_millis(10_000)).warm_up_time(Duration::from_millis(10));
     targets = filehandler_benchmark

--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -224,7 +224,9 @@ fn create_file_response(options: FileOptions, state: State) -> Pin<Box<HandlerFu
                 .body(Body::empty())
                 .unwrap());
         }
-        let buf_size = options.buffer_size.unwrap_or_else(|| optimal_buf_size(&meta));
+        let buf_size = options
+            .buffer_size
+            .unwrap_or_else(|| optimal_buf_size(&meta));
         let (len, range_start) = match resolve_range(meta.len(), &headers) {
             Ok((len, range_start)) => (len, range_start),
             Err(e) => {


### PR DESCRIPTION
The current implementation is using the blocksize as buffer size. In many use cases, the size is too small and limiting throughput. This commit adds an new option, buffer_size in the FileOptions, which, when set, overrides the default value.

Also included is a cargo criterion benchmark, which can be run with

```
cargo bench --bench file_handler
```

The benchmark shows major performance improvements with larger buffers when serving large files. The below results show that on my system (Apple MacBook Pro M2 Max) the throughput improves by an order of magnitude just by increasing the buf_size to 128k when serving a larger file (16MB).

```
server_bench/test_file_handler/filesize: 16777216, bufsize: None
                        time:   [58.284 ms 59.769 ms 61.381 ms]
                        thrpt:  [260.67 MiB/s 267.70 MiB/s 274.52 MiB/s]
                 change:
                        time:   [-3.4531% +0.1903% +3.8002%] (p = 0.92 > 0.05)
                        thrpt:  [-3.6610% -0.1899% +3.5766%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
server_bench/test_file_handler/filesize: 16777216, bufsize: Some(131072)
                        time:   [7.0873 ms 7.2185 ms 7.3694 ms]
                        thrpt:  [2.1202 GiB/s 2.1646 GiB/s 2.2046 GiB/s]
                 change:
                        time:   [-0.8280% +2.2019% +5.3682%] (p = 0.16 > 0.05)
                        thrpt:  [-5.0947% -2.1545% +0.8350%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
 
```