### PR TITLE
fix: correct typos in comments and documentation

### DIFF
--- a/gotham/src/handler/assets/mod.rs
+++ b/gotham/src/handler/assets/mod.rs
@@ -57,7 +57,7 @@ pub struct FileHandler {
 /// `FileOptions` implements `From` for `String` and `PathBuf` (and related reference types) - so that a
 /// path can be passed to router builder methods if only default options are required.
 ///
-/// For overridding default options, `FileOptions` provides builder methods. The default
+/// For overriding default options, `FileOptions` provides builder methods. The default
 /// values and use of the builder methods are shown in the example below.
 ///
 ///

--- a/gotham/src/helpers/timing.rs
+++ b/gotham/src/helpers/timing.rs
@@ -7,7 +7,7 @@ use time::OffsetDateTime;
 /// Timer struct used to record execution times of requests.
 ///
 /// The `elapsed` function returns the elapsed time in an easy to format way,
-/// suitable for use with requset logging middlewares.
+/// suitable for use with request logging middlewares.
 #[derive(Clone, Copy)]
 pub(crate) struct Timer {
     // We use 2 start fields

--- a/gotham/src/middleware/cookie.rs
+++ b/gotham/src/middleware/cookie.rs
@@ -12,7 +12,7 @@ use crate::state::{FromState, State};
 ///
 /// We implement `NewMiddleware` here for Gotham to allow us to work with the request
 /// lifecycle correctly. This trait requires `Clone`, so that is also included. Cookies
-/// become availabe on the request state as the `CookieJar` type.
+/// become available on the request state as the `CookieJar` type.
 #[derive(Copy, Clone)]
 pub struct CookieParser;
 

--- a/gotham/src/plain/test.rs
+++ b/gotham/src/plain/test.rs
@@ -94,7 +94,7 @@ impl TestServer {
     }
 
     /// Spawns the given future on the `TestServer`'s internal runtime.
-    /// This allows you to spawn more futures ontop of the `TestServer` in your
+    /// This allows you to spawn more futures on top of the `TestServer` in your
     /// tests.
     pub fn spawn<F>(&self, future: F)
     where

--- a/gotham/src/router/non_match.rs
+++ b/gotham/src/router/non_match.rs
@@ -67,7 +67,7 @@ impl RouteNonMatch {
     /// intended for use in cases where two `RouteMatcher` instances with a logical **AND**
     /// connection have both indicated a non-match, and their results need to be aggregated.
     ///
-    /// This is typically for Gotham internal use, but may be useful for implementors of matchers
+    /// This is typically for Gotham internal use, but may be useful for implementers of matchers
     /// which wrap other `RouteMatcher` instances. See the `AndRouteMatcher` implementation (in
     /// `gotham::router::route::matcher::and`) for an example.
     pub fn intersection(self, other: RouteNonMatch) -> RouteNonMatch {
@@ -96,7 +96,7 @@ impl RouteNonMatch {
     /// for use in cases where two `RouteMatcher` instances with a logical **OR** connection have
     /// both indicated a non-match, and their results need to be aggregated.
     ///
-    /// This is typically for Gotham internal use, but may be useful for implementors of matchers
+    /// This is typically for Gotham internal use, but may be useful for implementers of matchers
     /// which wrap other `RouteMatcher` instances. See the `Node::select_route` implementation (in
     /// `gotham::router::tree`) for an example.
     pub fn union(self, other: RouteNonMatch) -> RouteNonMatch {

--- a/gotham/src/tls/test.rs
+++ b/gotham/src/tls/test.rs
@@ -113,7 +113,7 @@ impl TestServer {
     }
 
     /// Spawns the given future on the `TestServer`'s internal runtime.
-    /// This allows you to spawn more futures ontop of the `TestServer` in your
+    /// This allows you to spawn more futures on top of the `TestServer` in your
     /// tests.
     pub fn spawn<F>(&self, future: F)
     where


### PR DESCRIPTION
Fixes several spelling mistakes found by codespell in source file comments.

## Changes

- `overridding` → `overriding` in `gotham/src/handler/assets/mod.rs`
- `availabe` → `available` in `gotham/src/middleware/cookie.rs`
- `requset` → `request` in `gotham/src/helpers/timing.rs`
- `ontop` → `on top` in `gotham/src/plain/test.rs` and `gotham/src/tls/test.rs`
- `implementors` → `implementers` in `gotham/src/router/non_match.rs`

All changes are in doc comments only — no logic or behavior is affected.